### PR TITLE
Support legacy TSL env aliases

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -16,6 +16,10 @@ const toOptionalNumber = (value) => {
   return Number.isFinite(parsedValue) ? parsedValue : undefined;
 };
 
+const resolveEnvAlias = (primaryKey, legacyKey) => (
+  process.env[primaryKey] ?? process.env[legacyKey]
+);
+
 module.exports = {
   env: process.env.NODE_ENV || 'development',
 
@@ -24,10 +28,10 @@ module.exports = {
   },
 
   https: {
-    port: Number(process.env.TLS_PORT) || 8443,
-    // TLS_KEY / TLS_CERT can be file paths or inline PEM values.
-    keyPath: process.env.TLS_KEY,
-    certPath: process.env.TLS_CERT,
+    port: Number(resolveEnvAlias('TLS_PORT', 'TSL_PORT')) || 8443,
+    // Accept the legacy TSL_* aliases still configured in Render.
+    keyPath: resolveEnvAlias('TLS_KEY', 'TSL_KEY'),
+    certPath: resolveEnvAlias('TLS_CERT', 'TSL_CERT'),
   },
 
   cluster: {

--- a/src/utils/validateEnvVars.js
+++ b/src/utils/validateEnvVars.js
@@ -1,5 +1,9 @@
 const Joi = require('joi');
 
+const resolveEnvAlias = (primaryKey, legacyKey) => (
+  process.env[primaryKey] ?? process.env[legacyKey]
+);
+
 const envVarsSchema = Joi.object({
   NODE_ENV: Joi.string()
     .valid('development', 'production', 'test')
@@ -58,7 +62,12 @@ const envVarsSchema = Joi.object({
 }).unknown();
 
 const validateEnvVars = () => {
-  const { error } = envVarsSchema.validate(process.env);
+  const { error } = envVarsSchema.validate({
+    ...process.env,
+    TLS_PORT: resolveEnvAlias('TLS_PORT', 'TSL_PORT'),
+    TLS_KEY: resolveEnvAlias('TLS_KEY', 'TSL_KEY'),
+    TLS_CERT: resolveEnvAlias('TLS_CERT', 'TSL_CERT'),
+  });
   if (error) {
     throw new Error(`Config validation error: ${error.message}`);
   }

--- a/tests/unit/config/index.test.js
+++ b/tests/unit/config/index.test.js
@@ -69,4 +69,21 @@ describe('config', () => {
       max: 50,
     });
   });
+
+  it('uses the legacy TSL_* aliases for HTTPS settings when TLS_* is unset', () => {
+    const config = loadConfig({
+      overrides: {
+        TSL_PORT: '9443',
+        TSL_KEY: 'legacy-key',
+        TSL_CERT: 'legacy-cert',
+      },
+      remove: ['TLS_PORT', 'TLS_KEY', 'TLS_CERT'],
+    });
+
+    expect(config.https).toEqual({
+      port: 9443,
+      keyPath: 'legacy-key',
+      certPath: 'legacy-cert',
+    });
+  });
 });

--- a/tests/unit/utils/validateEnvVars.test.js
+++ b/tests/unit/utils/validateEnvVars.test.js
@@ -1,0 +1,50 @@
+const ORIGINAL_ENV = process.env;
+
+const loadValidator = ({ overrides = {}, remove = [] } = {}) => {
+  jest.resetModules();
+  process.env = { ...ORIGINAL_ENV };
+
+  remove.forEach((key) => {
+    delete process.env[key];
+  });
+
+  Object.entries(overrides).forEach(([key, value]) => {
+    process.env[key] = value;
+  });
+
+  // eslint-disable-next-line global-require
+  return require('../../../src/utils/validateEnvVars').validateEnvVars;
+};
+
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+  jest.resetModules();
+});
+
+describe('validateEnvVars', () => {
+  it('accepts the legacy TSL_* aliases in production', () => {
+    const validateEnvVars = loadValidator({
+      overrides: {
+        NODE_ENV: 'production',
+        REPLICATE_API_TOKEN: 'test-token',
+        TSL_KEY: 'legacy-key',
+        TSL_CERT: 'legacy-cert',
+      },
+      remove: ['TLS_KEY', 'TLS_CERT'],
+    });
+
+    expect(() => validateEnvVars()).not.toThrow();
+  });
+
+  it('still requires production TLS credentials when neither TLS_* nor TSL_* is set', () => {
+    const validateEnvVars = loadValidator({
+      overrides: {
+        NODE_ENV: 'production',
+        REPLICATE_API_TOKEN: 'test-token',
+      },
+      remove: ['TLS_KEY', 'TLS_CERT', 'TSL_KEY', 'TSL_CERT'],
+    });
+
+    expect(() => validateEnvVars()).toThrow(/TLS_KEY/);
+  });
+});


### PR DESCRIPTION
## Root cause
- Render deploy logs still failed with `Config validation error: "TLS_KEY" is required` after PR #73 merged.
- The Render service environment is configured with `TSL_KEY`, `TSL_CERT`, and `TSL_PORT` instead of `TLS_*`.
- That typo prevented startup validation from ever seeing the TLS values.

## Fix
- accept `TSL_KEY` / `TSL_CERT` / `TSL_PORT` as backward-compatible aliases for the canonical `TLS_*` variables
- keep canonical `TLS_*` names preferred when both are present
- add regression coverage for config loading and production env validation

## Validation
- npm run lint
- NODE_ENV=test REPLICATE_API_TOKEN=test-token npm test -- --runInBand
- npm ci --dry-run
- runtime smoke: production mode with only `TSL_*` set and base64 TLS values passes validation and loads PEM credentials