### PR TITLE
Fix Render production bootstrap

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -35,7 +35,7 @@ module.exports = {
   },
 
   cluster: {
-    workers: toOptionalNumber(process.env.WORKER_COUNT),
+    workers: toOptionalNumber(process.env.WORKER_COUNT) ?? 1,
   },
 
   scraper: {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "homepage": "https://github.com/jsugg/alt-text-generator#readme",
   "main": "src/app.js",
   "engines": {
-    "node": ">=18.0.0"
+    "node": "20.x"
   },
   "scripts": {
     "doctor:tls": "node scripts/doctor-tls.js",

--- a/src/app.js
+++ b/src/app.js
@@ -5,7 +5,6 @@ require('dotenv').config({
 });
 
 const cluster = require('cluster');
-const os = require('os');
 const path = require('path');
 const fs = require('fs');
 
@@ -30,16 +29,7 @@ const {
   gracefulShutdown,
 } = require('./server/serverFunctions');
 
-const getAvailableWorkerCount = () => (
-  typeof os.availableParallelism === 'function'
-    ? os.availableParallelism()
-    : os.cpus().length
-);
-
-const resolveWorkerCount = () => (
-  config.cluster.workers
-  ?? (config.env === 'production' ? getAvailableWorkerCount() : 1)
-);
+const resolveWorkerCount = () => config.cluster.workers ?? 1;
 
 // Global error handlers — registered before any async work
 process.on('uncaughtException', (error) => {

--- a/src/createApp.js
+++ b/src/createApp.js
@@ -91,6 +91,7 @@ const createApp = ({
 
   const app = express();
   app.disable('x-powered-by');
+  app.set('trust proxy', 1);
 
   applyMiddlewares(app, requestLogger);
   const { loadRequestFilter } = createRequestFilter(appLogger);

--- a/src/utils/createRouter.js
+++ b/src/utils/createRouter.js
@@ -1,19 +1,42 @@
 const express = require('express');
-const swaggerUi = require('swagger-ui-express');
 
 const createSwaggerRouter = () => {
   const swaggerRouter = express.Router();
+  let swaggerUiServe = null;
   let swaggerUiMiddleware = null;
 
-  swaggerRouter.use('/api-docs', swaggerUi.serve, (req, res, next) => {
+  swaggerRouter.use('/api-docs', (req, res, next) => {
     if (!swaggerUiMiddleware) {
+      // Lazy-load the UI package so regular startup does not pull the docs bundle
+      // into memory unless the docs route is actually requested.
+      // eslint-disable-next-line global-require
+      const swaggerUi = require('swagger-ui-express');
       // Lazy-load the spec so regular startup and test paths do not build it.
       // eslint-disable-next-line global-require
       const swaggerSpec = require('../../config/swagger');
+      swaggerUiServe = Array.isArray(swaggerUi.serve)
+        ? swaggerUi.serve
+        : [swaggerUi.serve];
       swaggerUiMiddleware = swaggerUi.setup(swaggerSpec);
     }
 
-    return swaggerUiMiddleware(req, res, next);
+    let middlewareIndex = 0;
+    const runSwaggerServe = (error) => {
+      if (error) {
+        return next(error);
+      }
+
+      const serveMiddleware = swaggerUiServe[middlewareIndex];
+      middlewareIndex += 1;
+
+      if (!serveMiddleware) {
+        return swaggerUiMiddleware(req, res, next);
+      }
+
+      return serveMiddleware(req, res, runSwaggerServe);
+    };
+
+    return runSwaggerServe();
   });
 
   return swaggerRouter;

--- a/tests/unit/config/index.test.js
+++ b/tests/unit/config/index.test.js
@@ -34,7 +34,7 @@ describe('config', () => {
       ],
     });
 
-    expect(config.cluster.workers).toBeUndefined();
+    expect(config.cluster.workers).toBe(1);
     expect(config.scraper).toEqual({
       requestTimeoutMs: 10000,
       maxRedirects: 5,

--- a/tests/unit/createApp.test.js
+++ b/tests/unit/createApp.test.js
@@ -56,6 +56,7 @@ describe('createApp', () => {
     });
 
     expect(app).toBeDefined();
+    expect(app.get('trust proxy')).toBe(1);
     expect(services.scraperService.httpClient).toBe(httpClient);
     expect(services.scraperService.requestOptions).toEqual({
       timeout: 1500,
@@ -93,6 +94,7 @@ describe('createApp', () => {
       const { app, services } = createApp({ config });
 
       expect(app).toBeDefined();
+      expect(app.get('trust proxy')).toBe(1);
       expect(services.imageDescriberFactory.getAvailableModels()).toEqual(['clip']);
       expect(services.imageDescriberFactory.get('clip').replicate).toBeDefined();
     } finally {

--- a/tests/unit/utils/createRouter.test.js
+++ b/tests/unit/utils/createRouter.test.js
@@ -1,4 +1,7 @@
+let swaggerModuleLoaded = false;
+
 jest.mock('swagger-ui-express', () => {
+  swaggerModuleLoaded = true;
   const setup = jest.fn(() => (req, res) => {
     res.status(200).json({ ok: true });
   });
@@ -15,7 +18,6 @@ jest.mock('../../../config/swagger', () => ({
 
 const express = require('express');
 const request = require('supertest');
-const swaggerUi = require('swagger-ui-express');
 const { createRouter } = require('../../../src/utils/createRouter');
 
 const logger = {
@@ -25,6 +27,7 @@ const logger = {
 describe('createRouter', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    swaggerModuleLoaded = false;
   });
 
   it('loads the swagger spec lazily and caches the UI middleware', async () => {
@@ -36,11 +39,14 @@ describe('createRouter', () => {
 
     const pingResponse = await request(app).get('/ping');
     expect(pingResponse.status).toBe(200);
-    expect(swaggerUi.setup).not.toHaveBeenCalled();
+    expect(swaggerModuleLoaded).toBe(false);
 
     const docsResponse = await request(app).get('/api-docs');
     expect(docsResponse.status).toBe(200);
     expect(docsResponse.body).toEqual({ ok: true });
+    expect(swaggerModuleLoaded).toBe(true);
+    // eslint-disable-next-line global-require
+    const swaggerUi = require('swagger-ui-express');
     expect(swaggerUi.setup).toHaveBeenCalledTimes(1);
 
     const cachedDocsResponse = await request(app).get('/api-docs');


### PR DESCRIPTION
## Summary
- pin Render back to Node 20 LTS instead of allowing Node 25
- default the service to a single worker and set a bounded trust proxy value for Render
- lazy-load Swagger UI so startup no longer pulls the docs bundle into memory

## Validation
- npm run lint
- NODE_ENV=test REPLICATE_API_TOKEN=test-token npm test -- --runInBand
- production-style smoke boot with Node 20 and HTTPS health check
