### PR TITLE
Add tests badge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,47 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+      - housekeeping
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - '20'
+          - '22'
+          - '24'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test -- --ci
+        env:
+          NODE_ENV: test
+          REPLICATE_API_TOKEN: test-token

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![GitHub license](https://img.shields.io/github/license/jsugg/alt-text-generator)](https://github.com/jsugg/alt-text-generator/blob/main/LICENSE)
 [![CI/CD Pipeline](https://github.com/jsugg/alt-text-generator/actions/workflows/ci-cd.yml/badge.svg?branch=main)](https://github.com/jsugg/alt-text-generator/actions/workflows/ci-cd.yml)
-![Node 20.x](https://img.shields.io/badge/node-20.x-339933?logo=node.js&logoColor=white)
+![Node CI 20 | 22 | 24](https://img.shields.io/badge/node%20CI-20%20%7C%2022%20%7C%2024-339933?logo=node.js&logoColor=white)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![GitHub license](https://img.shields.io/github/license/jsugg/alt-text-generator)](https://github.com/jsugg/alt-text-generator/blob/main/LICENSE)
 [![CI/CD Pipeline](https://github.com/jsugg/alt-text-generator/actions/workflows/ci-cd.yml/badge.svg?branch=main)](https://github.com/jsugg/alt-text-generator/actions/workflows/ci-cd.yml)
+[![Tests](https://github.com/jsugg/alt-text-generator/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/jsugg/alt-text-generator/actions/workflows/tests.yml)
 ![Node CI 20 | 22 | 24](https://img.shields.io/badge/node%20CI-20%20%7C%2022%20%7C%2024-339933?logo=node.js&logoColor=white)
 
 ## Overview


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions  workflow so the README can show a real tests badge
- add the new tests badge under the project title in the README

## Validation
- workflow YAML parsed successfully with Ruby/Psych
- README/workflow-only change
