### PR TITLE
Enable Azure provider and stdout logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,16 +26,16 @@ REPLICATE_API_TOKEN=replace-me
 # RATE_LIMIT_WINDOW_MS=900000
 # RATE_LIMIT_MAX=100
 # LOG_LEVEL=debug
-# LOGS_DIR=./logs
 
 # Optional Swagger URLs.
 # SWAGGER_DEV_URL=https://localhost:8443
 # SWAGGER_PROD_URL=https://wcag.qcraft.dev
 
-# Optional Azure provider settings.
-# ACV_API_KEY=
+# Optional Azure provider settings. Set ACV_API_ENDPOINT and one credential
+# to register the `azure` model at startup.
 # ACV_API_ENDPOINT=
 # ACV_SUBSCRIPTION_KEY=
+# ACV_API_KEY=  # Legacy alias for ACV_SUBSCRIPTION_KEY
 # ACV_LANGUAGE=en
 # ACV_MAX_CANDIDATES=4
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -65,9 +65,8 @@ npm run doctor:tls -- https://example.com --fix --write-env --env-file .env.test
 API routes that generate descriptions require a `model` query parameter. Today the runtime registers:
 
 - `clip` (Replicate-backed)
-
-There is an `AzureDescriberService` implementation in the codebase, but it is not currently registered in
-the model registry exposed by the API, so setting `ACV_*` variables alone does not make an Azure model usable (yet).
+- `azure` (Azure Computer Vision-backed, registered only when `ACV_API_ENDPOINT` and
+  `ACV_SUBSCRIPTION_KEY` or legacy `ACV_API_KEY` are set)
 
 ## Configuration and Profiles
 
@@ -169,15 +168,17 @@ Development TLS behavior:
 | `REPLICATE_MODEL_NAME` | No | `clip_prefix_caption` | Replicate model name. |
 | `REPLICATE_MODEL_VERSION` | No | pinned in `config/index.js` | Replicate model version. |
 
-### Azure Computer Vision (not currently wired into API models)
+### Azure Computer Vision (optional provider)
 
 | Variable | Required | Default | Description |
 | --- | --- | --- | --- |
-| `ACV_API_KEY` | No | unset | Azure Computer Vision API key. |
-| `ACV_API_ENDPOINT` | No | unset | Azure Computer Vision endpoint. |
-| `ACV_SUBSCRIPTION_KEY` | No | unset | Azure subscription key. |
+| `ACV_API_ENDPOINT` | Yes, for Azure | unset | Azure Computer Vision describe endpoint. |
+| `ACV_SUBSCRIPTION_KEY` | Yes, for Azure | unset | Preferred Azure subscription key. |
+| `ACV_API_KEY` | No | unset | Legacy alias for `ACV_SUBSCRIPTION_KEY`. |
 | `ACV_LANGUAGE` | No | `en` | Azure response language. |
 | `ACV_MAX_CANDIDATES` | No | `4` | Maximum Azure caption candidates. |
+
+`ACV_API_ENDPOINT` and one Azure credential must be set together or startup validation fails.
 
 ### Rate Limiting, Logging, and Swagger
 
@@ -185,10 +186,11 @@ Development TLS behavior:
 | --- | --- | --- | --- |
 | `RATE_LIMIT_WINDOW_MS` | No | `900000` | Rate-limit window. |
 | `RATE_LIMIT_MAX` | No | `100` | Max requests per window. |
-| `LOG_LEVEL` | No | `debug` in non-production, `info` in production | Pino log level. |
-| `LOGS_DIR` | No | `./logs` | Directory for production log files. |
+| `LOG_LEVEL` | No | `debug` in non-production, `info` in production | Pino log level for process-stream logs. |
 | `SWAGGER_DEV_URL` | No | `https://localhost:8443` | Swagger server URL for development. |
 | `SWAGGER_PROD_URL` | No | `https://wcag.qcraft.dev` | Swagger server URL for production. |
+
+- Logging stays on stdout so container platforms can collect it without relying on local files.
 
 ## Render Deployment Contract
 
@@ -229,6 +231,7 @@ Do not collapse those into a single smoke test. Treat them as separate checks.
 | Scraper preflight | `npm run doctor:tls -- <target>` | `200` or site-specific expected status | trust store / target policy |
 | Scraper API | `GET /api/scraper/images?...` | `200` with `imageSources` array | scraper logic or target policy |
 | Replicate execution | `GET /api/accessibility/description?...&model=clip` | `200` with non-empty description | vendor account / model execution |
+| Azure execution | `GET /api/accessibility/description?...&model=azure` | `200` with non-empty description | Azure credentials / model execution |
 | Page orchestration | `GET /api/accessibility/descriptions?...&model=clip` | `200` with ordered `descriptions` array | orchestration / provider reuse |
 
 ### Validation sequence (recommended)
@@ -259,7 +262,13 @@ curl -sk 'https://localhost:8443/api/scraper/images?url=https%3A%2F%2Fdeveloper.
 curl -sk 'https://localhost:8443/api/accessibility/description?image_source=https%3A%2F%2Fwww.google.com%2Fimages%2Fbranding%2Fgooglelogo%2F1x%2Fgooglelogo_color_272x92dp.png&model=clip'
 ```
 
-6. Validate the page-level orchestration route:
+6. If Azure is configured, validate the Azure provider through the app:
+
+```bash
+curl -sk 'https://localhost:8443/api/accessibility/description?image_source=https%3A%2F%2Fwww.google.com%2Fimages%2Fbranding%2Fgooglelogo%2F1x%2Fgooglelogo_color_272x92dp.png&model=azure'
+```
+
+7. Validate the page-level orchestration route:
 
 ```bash
 curl -sk 'https://localhost:8443/api/accessibility/descriptions?url=https%3A%2F%2Fdeveloper.chrome.com%2F&model=clip'

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Common local settings:
   - Use `npm run doctor:tls -- https://example.com --fix --write-env --env-file .env.test` when a target works in `curl` but fails in Node/app scraping
 
 Advanced runtime settings such as worker count, scraper timeouts, rate limits, logging, Swagger URLs, and stubbed provider endpoints are documented in [DEVELOPMENT.md](./DEVELOPMENT.md).
+Production logs stay on the process stream so platforms such as Render can collect them directly.
 The Render deployment shape is versioned in [render.yaml](./render.yaml), while the Node runtime pin remains in [`package.json`](./package.json) under `engines.node`.
 
 ## API Endpoints
@@ -110,7 +111,7 @@ GET `/api/accessibility/description` or `/api/v1/accessibility/description`
 - Summary: returns an alt-text description for a given image
 - Query params:
   - `image_source`: URL-encoded address of the image
-  - `model`: AI model identifier, currently `clip`
+  - `model`: AI model identifier, `clip` or `azure` when Azure is configured
 
 Example:
 
@@ -123,7 +124,7 @@ GET `/api/accessibility/descriptions` or `/api/v1/accessibility/descriptions`
 - Summary: scrapes a page and returns descriptions for its images
 - Query params:
   - `url`: URL-encoded address of the target website
-  - `model`: AI model identifier, currently `clip`
+  - `model`: AI model identifier, `clip` or `azure` when Azure is configured
 - Notes:
   - preserves duplicate image entries in page order
   - reuses one prediction per unique normalized image URL per request

--- a/config/index.js
+++ b/config/index.js
@@ -64,11 +64,12 @@ module.exports = {
   },
 
   azure: {
-    apiKey: process.env.ACV_API_KEY,
     apiEndpoint: process.env.ACV_API_ENDPOINT,
-    subscriptionKey: process.env.ACV_SUBSCRIPTION_KEY,
+    subscriptionKey:
+      process.env.ACV_SUBSCRIPTION_KEY
+      || process.env.ACV_API_KEY,
     language: process.env.ACV_LANGUAGE || 'en',
-    maxCandidates: Number(process.env.ACV_MAX_CANDIDATES) || 4,
+    maxCandidates: toNumber(process.env.ACV_MAX_CANDIDATES, 4),
   },
 
   rateLimit: {
@@ -85,6 +86,5 @@ module.exports = {
     level:
       process.env.LOG_LEVEL
       || (process.env.NODE_ENV === 'production' ? 'info' : 'debug'),
-    logsDir: process.env.LOGS_DIR || './logs',
   },
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dev:test-env": "ENV_FILE=.env.test NODE_ENV=development nodemon src/app.js | pino-pretty -i streams,options",
     "lint": "eslint .",
     "test": "jest",
-    "prod": "NODE_ENV=production node src/app.js | pino-pretty -i streams,options",
+    "prod": "NODE_ENV=production node src/app.js",
     "dev": "NODE_ENV=development nodemon src/app.js | pino-pretty -i streams,options"
   },
   "repository": {

--- a/src/api/v1/controllers/descriptionController.js
+++ b/src/api/v1/controllers/descriptionController.js
@@ -36,7 +36,7 @@ class DescriptionController {
    *           example: https%3A%2F%2Fexample.com%2Fphoto.jpg
    *       - name: model
    *         in: query
-   *         description: The AI model to use, for example `clip`.
+   *         description: The AI model to use, for example `clip` or `azure`.
    *         required: true
    *         schema:
    *           type: string
@@ -112,7 +112,7 @@ class DescriptionController {
    *           example: https%3A%2F%2Fexample.com
    *       - name: model
    *         in: query
-   *         description: The AI model to use, for example `clip`.
+   *         description: The AI model to use, for example `clip` or `azure`.
    *         required: true
    *         schema:
    *           type: string

--- a/src/createApp.js
+++ b/src/createApp.js
@@ -10,6 +10,7 @@ const {
 const { createOutboundClients } = require('./infrastructure/outboundTrust');
 const ScraperService = require('./services/ScraperService');
 const ReplicateDescriberService = require('./services/ReplicateDescriberService');
+const AzureDescriberService = require('./services/AzureDescriberService');
 const ImageDescriberFactory = require('./services/ImageDescriberFactory');
 const PageDescriptionService = require('./services/PageDescriptionService');
 const healthController = require('./api/v1/controllers/healthController');
@@ -27,10 +28,15 @@ const buildReplicateClient = (config, fetch) => new Replicate({
   userAgent: config.replicate.userAgent,
 });
 
+const hasAzureProviderConfig = (azureConfig = {}) => Boolean(
+  azureConfig.apiEndpoint && azureConfig.subscriptionKey,
+);
+
 const buildImageDescriberFactory = ({
   config,
   logger,
   replicateClient,
+  httpClient,
 }) => {
   const factory = new ImageDescriberFactory();
   const replicateDescriber = new ReplicateDescriberService({
@@ -39,7 +45,19 @@ const buildImageDescriberFactory = ({
     config,
   });
 
-  return factory.register('clip', replicateDescriber);
+  factory.register('clip', replicateDescriber);
+
+  if (hasAzureProviderConfig(config.azure)) {
+    const azureDescriber = new AzureDescriberService({
+      logger,
+      httpClient,
+      config,
+    });
+
+    factory.register('azure', azureDescriber);
+  }
+
+  return factory;
 };
 
 const createApp = ({
@@ -71,6 +89,7 @@ const createApp = ({
     ?? buildImageDescriberFactory({
       config,
       logger: appLogger,
+      httpClient: resolvedHttpClient,
       replicateClient: replicateClient
         ?? buildReplicateClient(config, resolvedOutboundClients.fetch),
     });

--- a/src/infrastructure/logger.js
+++ b/src/infrastructure/logger.js
@@ -1,35 +1,11 @@
-const os = require('os');
-const path = require('path');
 const crypto = require('crypto');
-const fs = require('fs');
 const pino = require('pino');
 const pinoHttp = require('pino-http');
 const config = require('../../config');
-const packageJSON = require('../../package.json');
-
-const hostname = os.hostname();
-const { username } = os.userInfo();
-const logsDir = path.resolve(config.logging.logsDir);
-
-// Ensure logs directory exists
-if (!fs.existsSync(logsDir)) {
-  fs.mkdirSync(logsDir, { recursive: true });
-}
 
 const createAppLogger = () => pino({
   level: config.logging.level,
   name: 'appLogger',
-  transport: config.env !== 'production'
-    ? undefined
-    : {
-      target: 'pino/file',
-      options: {
-        destination: path.join(
-          logsDir,
-          `${hostname} ${username} ${packageJSON.name} start_date:[${Date.now()}] pid:${process.pid}.log`,
-        ),
-      },
-    },
 });
 
 const createRequestLogger = (appLogger) => pinoHttp({

--- a/src/services/AzureDescriberService.js
+++ b/src/services/AzureDescriberService.js
@@ -18,6 +18,10 @@ class AzureDescriberService {
     this.subscriptionKey = config.azure.subscriptionKey;
     this.language = config.azure.language;
     this.maxCandidates = config.azure.maxCandidates;
+
+    if (!this.endpoint || !this.subscriptionKey) {
+      throw new Error('Azure provider requires both apiEndpoint and subscriptionKey');
+    }
   }
 
   /**
@@ -42,8 +46,20 @@ class AzureDescriberService {
     );
 
     // axios already parses JSON — use response.data, not response.json()
-    const captions = response.data.description.captions.map((c) => c.text);
-    const description = captions.join(', ');
+    const captions = response?.data?.description?.captions;
+
+    if (!Array.isArray(captions) || captions.length === 0) {
+      throw new Error('Azure provider returned no captions');
+    }
+
+    const description = captions
+      .map((caption) => caption.text)
+      .filter(Boolean)
+      .join(', ');
+
+    if (!description) {
+      throw new Error('Azure provider returned empty captions');
+    }
 
     this.logger.debug({ imageUrl }, 'Azure alt text generated');
     return { description, imageUrl };

--- a/src/utils/validateEnvVars.js
+++ b/src/utils/validateEnvVars.js
@@ -40,14 +40,13 @@ const envVarsSchema = Joi.object({
   LOG_LEVEL: Joi.string()
     .valid('trace', 'debug', 'info', 'warn', 'error', 'fatal')
     .optional(),
-  LOGS_DIR: Joi.string().optional(),
 
   // Azure Computer Vision (optional provider)
   ACV_API_KEY: Joi.string().optional(),
   ACV_API_ENDPOINT: Joi.string().uri().optional(),
   ACV_SUBSCRIPTION_KEY: Joi.string().optional(),
   ACV_LANGUAGE: Joi.string().optional(),
-  ACV_MAX_CANDIDATES: Joi.number().optional(),
+  ACV_MAX_CANDIDATES: Joi.number().integer().min(1).optional(),
 
   // Rate limiting
   RATE_LIMIT_WINDOW_MS: Joi.number().optional(),
@@ -62,6 +61,18 @@ const validateEnvVars = () => {
   const { error } = envVarsSchema.validate(process.env);
   if (error) {
     throw new Error(`Config validation error: ${error.message}`);
+  }
+
+  const hasAzureEndpoint = Boolean(process.env.ACV_API_ENDPOINT);
+  const hasAzureCredential = Boolean(
+    process.env.ACV_SUBSCRIPTION_KEY || process.env.ACV_API_KEY,
+  );
+
+  if (hasAzureEndpoint !== hasAzureCredential) {
+    throw new Error(
+      'Config validation error: ACV_API_ENDPOINT and either ACV_SUBSCRIPTION_KEY '
+        + 'or ACV_API_KEY must be set together to enable the Azure provider',
+    );
   }
 };
 

--- a/tests/integration/api.test.js
+++ b/tests/integration/api.test.js
@@ -206,6 +206,80 @@ describe('GET /api/accessibility/description', () => {
       imageUrl: 'https://example.com/img.jpg',
     }]);
   });
+
+  it('serves Azure descriptions through the default runtime composition when configured', async () => {
+    const appLogger = createAppLogger();
+    const requestLogger = createRequestLogger();
+    const httpClient = {
+      get: jest.fn(),
+      post: jest.fn().mockResolvedValue({
+        data: {
+          description: {
+            captions: [
+              { text: 'an azure-generated caption' },
+            ],
+          },
+        },
+      }),
+    };
+    const replicateClient = { run: jest.fn() };
+    const runtimeConfig = {
+      replicate: {
+        apiToken: 'test-token',
+        apiEndpoint: 'https://replicate.example.com',
+        userAgent: 'alt-text-generator/test',
+        modelOwner: 'owner',
+        modelName: 'model',
+        modelVersion: 'version',
+      },
+      azure: {
+        apiEndpoint: 'https://azure.example.com/vision/v3.2/describe',
+        subscriptionKey: 'azure-key',
+        language: 'en',
+        maxCandidates: 4,
+      },
+      scraper: {
+        requestTimeoutMs: 1500,
+        maxRedirects: 4,
+        maxContentLengthBytes: 2048,
+      },
+      proxy: {
+        trustProxyHops: 1,
+      },
+    };
+    const { app, services } = createApp({
+      appLogger,
+      requestLogger,
+      httpClient,
+      replicateClient,
+      config: runtimeConfig,
+    });
+
+    expect(services.imageDescriberFactory.getAvailableModels()).toEqual(['clip', 'azure']);
+
+    const res = await secureGet(
+      app,
+      `/api/accessibility/description?image_source=${
+        encodeURIComponent('https://example.com/azure-image.jpg')
+      }&model=azure`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{
+      description: 'an azure-generated caption',
+      imageUrl: 'https://example.com/azure-image.jpg',
+    }]);
+    expect(httpClient.post).toHaveBeenCalledWith(
+      'https://azure.example.com/vision/v3.2/describe?maxCandidates=4&language=en&model-version=latest',
+      { url: 'https://example.com/azure-image.jpg' },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'Ocp-Apim-Subscription-Key': 'azure-key',
+        },
+      },
+    );
+  });
 });
 
 describe('GET /api/accessibility/descriptions', () => {

--- a/tests/unit/createApp.test.js
+++ b/tests/unit/createApp.test.js
@@ -40,6 +40,12 @@ describe('createApp', () => {
         modelName: 'model',
         modelVersion: 'version',
       },
+      azure: {
+        apiEndpoint: 'https://azure.example.com/vision/v3.2/describe',
+        subscriptionKey: 'azure-key',
+        language: 'en',
+        maxCandidates: 4,
+      },
       scraper: {
         requestTimeoutMs: 1500,
         maxRedirects: 4,
@@ -66,8 +72,9 @@ describe('createApp', () => {
       maxRedirects: 4,
       maxContentLength: 2048,
     });
-    expect(services.imageDescriberFactory.getAvailableModels()).toEqual(['clip']);
+    expect(services.imageDescriberFactory.getAvailableModels()).toEqual(['clip', 'azure']);
     expect(services.imageDescriberFactory.get('clip').replicate).toBe(replicateClient);
+    expect(services.imageDescriberFactory.get('azure').httpClient).toBe(httpClient);
     expect(services.pageDescriptionService.scraperService).toBe(services.scraperService);
     expect(services.pageDescriptionService.imageDescriberFactory)
       .toBe(services.imageDescriberFactory);
@@ -131,5 +138,36 @@ describe('createApp', () => {
     });
 
     expect(app.get('trust proxy')).toBe(1);
+  });
+
+  it('does not register azure when its config is incomplete', () => {
+    const config = {
+      replicate: {
+        apiToken: 'test-token',
+        apiEndpoint: 'https://replicate.example.com',
+        userAgent: 'alt-text-generator/test',
+        modelOwner: 'owner',
+        modelName: 'model',
+        modelVersion: 'version',
+      },
+      azure: {
+        apiEndpoint: 'https://azure.example.com/vision/v3.2/describe',
+      },
+      scraper: {
+        requestTimeoutMs: 1500,
+        maxRedirects: 4,
+        maxContentLengthBytes: 2048,
+      },
+    };
+
+    const { services } = createApp({
+      appLogger: createAppLogger(),
+      requestLogger: createRequestLogger(),
+      httpClient: { get: jest.fn(), post: jest.fn() },
+      replicateClient: { run: jest.fn() },
+      config,
+    });
+
+    expect(services.imageDescriberFactory.getAvailableModels()).toEqual(['clip']);
   });
 });

--- a/tests/unit/infrastructure/logger.test.js
+++ b/tests/unit/infrastructure/logger.test.js
@@ -1,0 +1,193 @@
+const ORIGINAL_ENV = process.env;
+
+const mockStdSerializers = {
+  err: Symbol('err'),
+  req: Symbol('req'),
+  res: Symbol('res'),
+};
+
+const mockPino = jest.fn();
+jest.mock('pino', () => mockPino);
+
+const mockPinoHttp = jest.fn();
+mockPinoHttp.stdSerializers = mockStdSerializers;
+jest.mock('pino-http', () => mockPinoHttp);
+
+const mockRandomUUID = jest.fn();
+jest.mock('crypto', () => ({ randomUUID: mockRandomUUID }));
+
+const mockFs = {
+  existsSync: jest.fn(),
+  mkdirSync: jest.fn(),
+};
+jest.mock('fs', () => mockFs);
+
+const loadLoggerModule = ({
+  env = {},
+  randomUUID = 'generated-request-id',
+} = {}) => {
+  jest.resetModules();
+  process.env = { ...ORIGINAL_ENV };
+  delete process.env.NODE_ENV;
+  delete process.env.LOG_LEVEL;
+
+  Object.entries(env).forEach(([key, value]) => {
+    process.env[key] = value;
+  });
+
+  mockRandomUUID.mockReset().mockReturnValue(randomUUID);
+  mockFs.existsSync.mockReset();
+  mockFs.mkdirSync.mockReset();
+
+  const mockChildLogger = { info: jest.fn() };
+  const mockAppLogger = {
+    child: jest.fn(() => mockChildLogger),
+  };
+  const mockRequestLogger = jest.fn();
+
+  mockPino.mockReset().mockReturnValue(mockAppLogger);
+  mockPinoHttp.mockReset().mockImplementation((options) => {
+    mockRequestLogger.logger = options.logger;
+    mockRequestLogger.options = options;
+    return mockRequestLogger;
+  });
+  mockPinoHttp.stdSerializers = mockStdSerializers;
+
+  // eslint-disable-next-line global-require
+  const loggerModule = require('../../../src/infrastructure/logger');
+
+  return {
+    loggerModule,
+    mockAppLogger,
+    mockChildLogger,
+    mockRequestLogger,
+    requestLoggerOptions: mockRequestLogger.options,
+  };
+};
+
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+  jest.clearAllMocks();
+  jest.resetModules();
+});
+
+describe('infrastructure/logger', () => {
+  it('uses process-stream logging in production without touching the filesystem', () => {
+    const { loggerModule, mockAppLogger } = loadLoggerModule({
+      env: {
+        NODE_ENV: 'production',
+        LOG_LEVEL: 'warn',
+        LOGS_DIR: '/tmp/alt-text-generator-logs',
+      },
+    });
+
+    expect(mockPino).toHaveBeenCalledWith({
+      level: 'warn',
+      name: 'appLogger',
+    });
+    expect(mockFs.existsSync).not.toHaveBeenCalled();
+    expect(mockFs.mkdirSync).not.toHaveBeenCalled();
+    expect(loggerModule.appLogger).toBe(mockAppLogger);
+  });
+
+  it('creates the request logger from the app logger child with standard serializers', () => {
+    const {
+      loggerModule,
+      mockAppLogger,
+      mockChildLogger,
+      mockRequestLogger,
+      requestLoggerOptions,
+    } = loadLoggerModule({
+      env: {
+        NODE_ENV: 'development',
+        LOG_LEVEL: 'debug',
+      },
+    });
+
+    expect(mockAppLogger.child).toHaveBeenCalledWith({ name: 'serverLogger' });
+    expect(mockPinoHttp).toHaveBeenCalledWith(expect.objectContaining({
+      logger: mockChildLogger,
+      serializers: mockStdSerializers,
+      wrapSerializers: true,
+    }));
+    expect(requestLoggerOptions.logger).toBe(mockChildLogger);
+    expect(requestLoggerOptions.serializers).toStrictEqual(mockStdSerializers);
+    expect(loggerModule.requestLogger).toBe(mockRequestLogger);
+    expect(loggerModule.serverLogger).toBe(mockRequestLogger);
+  });
+
+  it('prefers existing request ids before generating a new one', () => {
+    const { requestLoggerOptions } = loadLoggerModule({
+      env: {
+        NODE_ENV: 'production',
+      },
+      randomUUID: 'generated-id',
+    });
+
+    const withReqIdSetHeader = jest.fn();
+    expect(requestLoggerOptions.genReqId({
+      id: 'existing-id',
+      headers: {},
+    }, {
+      setHeader: withReqIdSetHeader,
+    })).toBe('existing-id');
+    expect(withReqIdSetHeader).not.toHaveBeenCalled();
+
+    const withHeaderSetHeader = jest.fn();
+    expect(requestLoggerOptions.genReqId({
+      headers: { 'x-request-id': 'header-id' },
+    }, {
+      setHeader: withHeaderSetHeader,
+    })).toBe('header-id');
+    expect(withHeaderSetHeader).not.toHaveBeenCalled();
+
+    const generatedSetHeader = jest.fn();
+    expect(requestLoggerOptions.genReqId({
+      headers: {},
+    }, {
+      setHeader: generatedSetHeader,
+    })).toBe('generated-id');
+    expect(mockRandomUUID).toHaveBeenCalledTimes(1);
+    expect(generatedSetHeader).toHaveBeenCalledWith(
+      'X-Request-Id',
+      'generated-id',
+    );
+  });
+
+  it('maps request outcomes to the expected log levels and messages', () => {
+    const { requestLoggerOptions } = loadLoggerModule({
+      env: {
+        NODE_ENV: 'production',
+      },
+    });
+
+    expect(requestLoggerOptions.customLogLevel({}, { statusCode: 200 }))
+      .toBe('info');
+    expect(requestLoggerOptions.customLogLevel({}, { statusCode: 404 }))
+      .toBe('warn');
+    expect(requestLoggerOptions.customLogLevel({}, { statusCode: 302 }))
+      .toBe('silent');
+    expect(requestLoggerOptions.customLogLevel({}, { statusCode: 500 }))
+      .toBe('error');
+    expect(requestLoggerOptions.customLogLevel(
+      {},
+      { statusCode: 200 },
+      new Error('boom'),
+    )).toBe('error');
+
+    expect(requestLoggerOptions.customSuccessMessage(
+      { method: 'GET' },
+      { statusCode: 404 },
+    )).toBe('resource not found');
+    expect(requestLoggerOptions.customSuccessMessage(
+      { method: 'POST' },
+      { statusCode: 201 },
+    )).toBe('POST completed');
+    expect(requestLoggerOptions.customReceivedMessage({ method: 'PATCH' }))
+      .toBe('request received: PATCH');
+    expect(requestLoggerOptions.customErrorMessage(
+      {},
+      { statusCode: 503 },
+    )).toBe('request errored with status code: 503');
+  });
+});

--- a/tests/unit/services/AzureDescriberService.test.js
+++ b/tests/unit/services/AzureDescriberService.test.js
@@ -76,4 +76,25 @@ describe('AzureDescriberService.describeImage', () => {
 
     await expect(svc.describeImage('https://example.com/img.jpg')).rejects.toThrow('Azure error');
   });
+
+  it('throws a descriptive error when Azure returns no captions', async () => {
+    const mockHttpClient = {
+      post: jest.fn().mockResolvedValue({
+        data: {
+          description: {
+            captions: [],
+          },
+        },
+      }),
+    };
+    const svc = new AzureDescriberService({
+      logger: mockLogger,
+      httpClient: mockHttpClient,
+      config: mockConfig,
+    });
+
+    await expect(svc.describeImage('https://example.com/img.jpg'))
+      .rejects
+      .toThrow('Azure provider returned no captions');
+  });
 });

--- a/tests/unit/utils/validateEnvVars.test.js
+++ b/tests/unit/utils/validateEnvVars.test.js
@@ -74,4 +74,52 @@ describe('validateEnvVars', () => {
 
     expect(() => validateEnvVars()).toThrow(/TRUST_PROXY_HOPS/);
   });
+
+  it('accepts Azure provider credentials when endpoint and subscription key are set', () => {
+    const validateEnvVars = loadValidator({
+      overrides: {
+        REPLICATE_API_TOKEN: 'test-token',
+        ACV_API_ENDPOINT: 'https://azure.example.com/vision/v3.2/describe',
+        ACV_SUBSCRIPTION_KEY: 'azure-key',
+      },
+    });
+
+    expect(() => validateEnvVars()).not.toThrow();
+  });
+
+  it('accepts the legacy Azure API key alias', () => {
+    const validateEnvVars = loadValidator({
+      overrides: {
+        REPLICATE_API_TOKEN: 'test-token',
+        ACV_API_ENDPOINT: 'https://azure.example.com/vision/v3.2/describe',
+        ACV_API_KEY: 'azure-key',
+      },
+    });
+
+    expect(() => validateEnvVars()).not.toThrow();
+  });
+
+  it('rejects an Azure endpoint without credentials', () => {
+    const validateEnvVars = loadValidator({
+      overrides: {
+        REPLICATE_API_TOKEN: 'test-token',
+        ACV_API_ENDPOINT: 'https://azure.example.com/vision/v3.2/describe',
+      },
+      remove: ['ACV_API_KEY', 'ACV_SUBSCRIPTION_KEY'],
+    });
+
+    expect(() => validateEnvVars()).toThrow(/ACV_API_ENDPOINT/);
+  });
+
+  it('rejects Azure credentials without an endpoint', () => {
+    const validateEnvVars = loadValidator({
+      overrides: {
+        REPLICATE_API_TOKEN: 'test-token',
+        ACV_SUBSCRIPTION_KEY: 'azure-key',
+      },
+      remove: ['ACV_API_ENDPOINT'],
+    });
+
+    expect(() => validateEnvVars()).toThrow(/ACV_API_ENDPOINT/);
+  });
 });


### PR DESCRIPTION
## Intent
This change set does two related runtime cleanups:
- register the optional Azure describer in the default app composition when Azure credentials are configured
- keep production logs on stdout/stderr so container platforms collect them directly instead of relying on local log files

## What changed
- register `azure` in `createApp` when `ACV_API_ENDPOINT` and an Azure credential are configured
- treat `ACV_API_KEY` as a legacy alias for `ACV_SUBSCRIPTION_KEY`
- validate Azure config as an all-or-nothing startup contract
- harden `AzureDescriberService` against empty caption responses
- remove production file transport and `LOGS_DIR`; `npm run prod` now streams logs directly
- update docs and env examples to match the runtime behavior
- add logger, Azure integration, and env-validation coverage

## Validation
- npm run lint
- NODE_ENV=test REPLICATE_API_TOKEN=test-token npm test -- --runInBand
- production smoke: `npm run prod` with local TLS certs plus `/api/health` curl