### PR TITLE
Implemented the observability hardening for provider failures

### DIFF
--- a/src/api/v1/controllers/descriptionController.js
+++ b/src/api/v1/controllers/descriptionController.js
@@ -63,6 +63,7 @@ class DescriptionController {
    *         description: Server error
    */
   async describe(req, res) {
+    const requestLogger = req.log ?? this.logger;
     const { image_source: rawImageSource, model } = req.query;
 
     if (!rawImageSource || !model) {
@@ -77,7 +78,7 @@ class DescriptionController {
       return res.status(400).json({ error: 'Invalid image_source URL' });
     }
 
-    this.logger.info({ model, imageSource }, 'Description request');
+    requestLogger.info({ model, imageSource }, 'Description request');
 
     try {
       const describer = this.factory.get(model);
@@ -88,7 +89,7 @@ class DescriptionController {
       if (error.message.startsWith('Unknown model')) {
         return res.status(400).json({ error: error.message });
       }
-      this.logger.error({ error }, 'Error generating description');
+      requestLogger.error({ err: error, model, imageSource }, 'Error generating description');
       return res.status(500).json({
         error: 'Error fetching description for the provided image',
       });
@@ -126,6 +127,7 @@ class DescriptionController {
    *         description: Server error
    */
   async describePage(req, res) {
+    const requestLogger = req.log ?? this.logger;
     const { url: rawPageUrl, model } = req.query;
 
     if (!rawPageUrl || !model) {
@@ -140,7 +142,7 @@ class DescriptionController {
       return res.status(400).json({ error: 'Invalid url parameter' });
     }
 
-    this.logger.info({ model, pageUrl }, 'Page description request');
+    requestLogger.info({ model, pageUrl }, 'Page description request');
 
     try {
       const result = await this.pageDescriptionService.describePage({
@@ -153,7 +155,7 @@ class DescriptionController {
         return res.status(400).json({ error: error.message });
       }
 
-      this.logger.error({ error }, 'Error generating page descriptions');
+      requestLogger.error({ err: error, model, pageUrl }, 'Error generating page descriptions');
       return res.status(500).json({
         error: 'Error fetching descriptions for the provided page',
       });

--- a/src/api/v1/controllers/scraperController.js
+++ b/src/api/v1/controllers/scraperController.js
@@ -48,6 +48,7 @@ class ScraperController {
    *         description: Server error
    */
   async getImages(req, res) {
+    const requestLogger = req.log ?? this.logger;
     const { url } = req.query;
 
     if (!url) {
@@ -64,7 +65,7 @@ class ScraperController {
       const result = await this.scraperService.getImages(decodedUrl);
       return res.json(result);
     } catch (error) {
-      this.logger.error({ error }, 'Error scraping images');
+      requestLogger.error({ err: error, url: decodedUrl }, 'Error scraping images');
       return res.status(500).json({ error: 'Error fetching images from the provided URL' });
     }
   }

--- a/src/services/AzureDescriberService.js
+++ b/src/services/AzureDescriberService.js
@@ -1,3 +1,5 @@
+const { getUpstreamErrorSummary } = require('../utils/getUpstreamErrorSummary');
+
 /**
  * Image description service backed by Azure Computer Vision.
  *
@@ -38,31 +40,42 @@ class AzureDescriberService {
       'Ocp-Apim-Subscription-Key': this.subscriptionKey,
     };
 
-    // Correct axios usage: post(url, data, config)
-    const response = await this.httpClient.post(
-      url,
-      { url: imageUrl },
-      { headers },
-    );
+    try {
+      // Correct axios usage: post(url, data, config)
+      const response = await this.httpClient.post(
+        url,
+        { url: imageUrl },
+        { headers },
+      );
 
-    // axios already parses JSON — use response.data, not response.json()
-    const captions = response?.data?.description?.captions;
+      // axios already parses JSON — use response.data, not response.json()
+      const captions = response?.data?.description?.captions;
 
-    if (!Array.isArray(captions) || captions.length === 0) {
-      throw new Error('Azure provider returned no captions');
+      if (!Array.isArray(captions) || captions.length === 0) {
+        throw new Error('Azure provider returned no captions');
+      }
+
+      const description = captions
+        .map((caption) => caption.text)
+        .filter(Boolean)
+        .join(', ');
+
+      if (!description) {
+        throw new Error('Azure provider returned empty captions');
+      }
+
+      this.logger.debug({ imageUrl }, 'Azure alt text generated');
+      return { description, imageUrl };
+    } catch (error) {
+      this.logger.error({
+        err: error,
+        provider: 'azure',
+        endpoint: this.endpoint,
+        imageUrl,
+        upstream: getUpstreamErrorSummary(error),
+      }, 'Azure description request failed');
+      throw error;
     }
-
-    const description = captions
-      .map((caption) => caption.text)
-      .filter(Boolean)
-      .join(', ');
-
-    if (!description) {
-      throw new Error('Azure provider returned empty captions');
-    }
-
-    this.logger.debug({ imageUrl }, 'Azure alt text generated');
-    return { description, imageUrl };
   }
 }
 

--- a/src/services/ReplicateDescriberService.js
+++ b/src/services/ReplicateDescriberService.js
@@ -1,3 +1,5 @@
+const { getUpstreamErrorSummary } = require('../utils/getUpstreamErrorSummary');
+
 /**
  * Image description service backed by the Replicate AI platform.
  *
@@ -29,12 +31,23 @@ class ReplicateDescriberService {
     const modelRef = `${this.modelOwner}/${this.modelName}:${this.modelVersion}`;
     this.logger.info({ imageUrl, modelRef }, 'Generating alt text');
 
-    const output = await this.replicate.run(modelRef, {
-      input: { image: imageUrl },
-    });
+    try {
+      const output = await this.replicate.run(modelRef, {
+        input: { image: imageUrl },
+      });
 
-    this.logger.debug({ imageUrl }, 'Alt text generated');
-    return { description: output, imageUrl };
+      this.logger.debug({ imageUrl }, 'Alt text generated');
+      return { description: output, imageUrl };
+    } catch (error) {
+      this.logger.error({
+        err: error,
+        provider: 'replicate',
+        imageUrl,
+        modelRef,
+        upstream: getUpstreamErrorSummary(error),
+      }, 'Replicate prediction failed');
+      throw error;
+    }
   }
 }
 

--- a/src/utils/getUpstreamErrorSummary.js
+++ b/src/utils/getUpstreamErrorSummary.js
@@ -1,0 +1,156 @@
+const SAFE_RESPONSE_HEADER_NAMES = [
+  'retry-after',
+  'x-ratelimit-limit',
+  'x-ratelimit-remaining',
+  'x-ratelimit-reset',
+];
+
+const MAX_BODY_PREVIEW_LENGTH = 512;
+
+const truncate = (value) => {
+  if (typeof value !== 'string' || value.length <= MAX_BODY_PREVIEW_LENGTH) {
+    return value;
+  }
+
+  return `${value.slice(0, MAX_BODY_PREVIEW_LENGTH)}...`;
+};
+
+const getHeaderValue = (headers, headerName) => {
+  if (!headers) {
+    return undefined;
+  }
+
+  if (typeof headers.get === 'function') {
+    return headers.get(headerName) ?? undefined;
+  }
+
+  if (typeof headers !== 'object') {
+    return undefined;
+  }
+
+  const matchingKey = Object.keys(headers).find(
+    (key) => key.toLowerCase() === headerName.toLowerCase(),
+  );
+
+  if (!matchingKey) {
+    return undefined;
+  }
+
+  const value = headers[matchingKey];
+
+  if (Array.isArray(value)) {
+    return value.join(', ');
+  }
+
+  return value;
+};
+
+const buildRequestUrl = (config = {}) => {
+  const { baseURL, url } = config;
+
+  if (!url) {
+    return baseURL;
+  }
+
+  if (!baseURL) {
+    return url;
+  }
+
+  try {
+    return new URL(url, baseURL).toString();
+  } catch {
+    return url || baseURL;
+  }
+};
+
+const serializeBodyPreview = (body) => {
+  if (body == null) {
+    return undefined;
+  }
+
+  if (typeof body === 'string') {
+    return truncate(body);
+  }
+
+  try {
+    return truncate(JSON.stringify(body));
+  } catch {
+    return truncate(String(body));
+  }
+};
+
+const summarizeRequest = (error) => {
+  const request = error?.request;
+  const config = error?.config;
+  const method = request?.method ?? config?.method;
+  const url = request?.url ?? buildRequestUrl(config);
+
+  if (!method && !url) {
+    return undefined;
+  }
+
+  return {
+    ...(method ? { method: String(method).toUpperCase() } : {}),
+    ...(url ? { url } : {}),
+  };
+};
+
+const summarizeResponseHeaders = (response) => {
+  const headers = SAFE_RESPONSE_HEADER_NAMES.reduce((accumulator, headerName) => {
+    const value = getHeaderValue(response?.headers, headerName);
+
+    if (value) {
+      accumulator[headerName] = value;
+    }
+
+    return accumulator;
+  }, {});
+
+  return Object.keys(headers).length > 0 ? headers : undefined;
+};
+
+const summarizeResponse = (error) => {
+  const response = error?.response;
+
+  if (!response) {
+    return undefined;
+  }
+
+  const headers = summarizeResponseHeaders(response);
+  const bodyPreview = serializeBodyPreview(response.data);
+
+  return {
+    ...(typeof response.status === 'number' ? { status: response.status } : {}),
+    ...(response.statusText ? { statusText: response.statusText } : {}),
+    ...(headers ? { headers } : {}),
+    ...(bodyPreview ? { bodyPreview } : {}),
+  };
+};
+
+/**
+ * Creates a safe, compact summary of an upstream HTTP/client error.
+ *
+ * @param {unknown} error
+ * @returns {object | undefined}
+ */
+const getUpstreamErrorSummary = (error) => {
+  if (!error || typeof error !== 'object') {
+    return undefined;
+  }
+
+  const request = summarizeRequest(error);
+  const response = summarizeResponse(error);
+  const code = typeof error.code === 'string' ? error.code : undefined;
+
+  if (!request && !response && !code) {
+    return undefined;
+  }
+
+  return {
+    ...(code ? { code } : {}),
+    ...(request ? { request } : {}),
+    ...(response ? { response } : {}),
+  };
+};
+
+module.exports = { getUpstreamErrorSummary };

--- a/tests/unit/controllers/descriptionController.test.js
+++ b/tests/unit/controllers/descriptionController.test.js
@@ -106,8 +106,9 @@ describe('DescriptionController.describe', () => {
   });
 
   it('returns 500 when describer throws a non-model error', async () => {
+    const error = new Error('API timeout');
     const mockDescriber = {
-      describeImage: jest.fn().mockRejectedValue(new Error('API timeout')),
+      describeImage: jest.fn().mockRejectedValue(error),
     };
     const factory = new ImageDescriberFactory().register('clip', mockDescriber);
     const controller = createController(factory);
@@ -125,6 +126,11 @@ describe('DescriptionController.describe', () => {
     expect(res.json).toHaveBeenCalledWith({
       error: 'Error fetching description for the provided image',
     });
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.objectContaining({
+      err: error,
+      model: 'clip',
+      imageSource: 'https://example.com/img.jpg',
+    }), 'Error generating description');
   });
 });
 
@@ -222,9 +228,10 @@ describe('DescriptionController.describePage', () => {
   });
 
   it('returns 500 when the page orchestration fails', async () => {
+    const error = new Error('network error');
     const controller = createController(
       new ImageDescriberFactory(),
-      { describePage: jest.fn().mockRejectedValue(new Error('network error')) },
+      { describePage: jest.fn().mockRejectedValue(error) },
     );
     const req = {
       query: {
@@ -240,5 +247,10 @@ describe('DescriptionController.describePage', () => {
     expect(res.json).toHaveBeenCalledWith({
       error: 'Error fetching descriptions for the provided page',
     });
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.objectContaining({
+      err: error,
+      model: 'clip',
+      pageUrl: 'https://example.com/page',
+    }), 'Error generating page descriptions');
   });
 });

--- a/tests/unit/services/AzureDescriberService.test.js
+++ b/tests/unit/services/AzureDescriberService.test.js
@@ -65,8 +65,14 @@ describe('AzureDescriberService.describeImage', () => {
   });
 
   it('propagates errors from the HTTP client', async () => {
+    const error = new Error('Azure error');
+    error.code = 'ENOTFOUND';
+    error.config = {
+      method: 'post',
+      url: mockConfig.azure.apiEndpoint,
+    };
     const mockHttpClient = {
-      post: jest.fn().mockRejectedValue(new Error('Azure error')),
+      post: jest.fn().mockRejectedValue(error),
     };
     const svc = new AzureDescriberService({
       logger: mockLogger,
@@ -75,6 +81,19 @@ describe('AzureDescriberService.describeImage', () => {
     });
 
     await expect(svc.describeImage('https://example.com/img.jpg')).rejects.toThrow('Azure error');
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.objectContaining({
+      err: error,
+      provider: 'azure',
+      endpoint: mockConfig.azure.apiEndpoint,
+      imageUrl: 'https://example.com/img.jpg',
+      upstream: {
+        code: 'ENOTFOUND',
+        request: {
+          method: 'POST',
+          url: mockConfig.azure.apiEndpoint,
+        },
+      },
+    }), 'Azure description request failed');
   });
 
   it('throws a descriptive error when Azure returns no captions', async () => {

--- a/tests/unit/services/ReplicateDescriberService.test.js
+++ b/tests/unit/services/ReplicateDescriberService.test.js
@@ -38,8 +38,23 @@ describe('ReplicateDescriberService.describeImage', () => {
   });
 
   it('propagates errors from the Replicate client', async () => {
+    const error = new Error('API error');
+    error.request = {
+      method: 'POST',
+      url: 'https://api.replicate.com/v1/predictions',
+    };
+    error.response = {
+      status: 429,
+      statusText: 'Too Many Requests',
+      headers: {
+        get: (name) => {
+          const values = { 'retry-after': '30' };
+          return values[name] ?? null;
+        },
+      },
+    };
     const mockReplicate = {
-      run: jest.fn().mockRejectedValue(new Error('API error')),
+      run: jest.fn().mockRejectedValue(error),
     };
     const svc = new ReplicateDescriberService({
       logger: mockLogger,
@@ -48,5 +63,24 @@ describe('ReplicateDescriberService.describeImage', () => {
     });
 
     await expect(svc.describeImage('https://example.com/cat.jpg')).rejects.toThrow('API error');
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.objectContaining({
+      err: error,
+      provider: 'replicate',
+      imageUrl: 'https://example.com/cat.jpg',
+      modelRef: 'testowner/testmodel:abc123',
+      upstream: {
+        request: {
+          method: 'POST',
+          url: 'https://api.replicate.com/v1/predictions',
+        },
+        response: {
+          status: 429,
+          statusText: 'Too Many Requests',
+          headers: {
+            'retry-after': '30',
+          },
+        },
+      },
+    }), 'Replicate prediction failed');
   });
 });

--- a/tests/unit/utils/getUpstreamErrorSummary.test.js
+++ b/tests/unit/utils/getUpstreamErrorSummary.test.js
@@ -1,0 +1,80 @@
+const { getUpstreamErrorSummary } = require('../../../src/utils/getUpstreamErrorSummary');
+
+describe('getUpstreamErrorSummary', () => {
+  it('extracts request and response details from fetch-style errors', () => {
+    const error = new Error('Request failed');
+    error.request = {
+      method: 'POST',
+      url: 'https://api.replicate.com/v1/predictions',
+    };
+    error.response = {
+      status: 429,
+      statusText: 'Too Many Requests',
+      headers: {
+        get: (name) => {
+          const values = {
+            'retry-after': '30',
+            'x-ratelimit-remaining': '0',
+          };
+
+          return values[name] ?? null;
+        },
+      },
+    };
+
+    expect(getUpstreamErrorSummary(error)).toEqual({
+      request: {
+        method: 'POST',
+        url: 'https://api.replicate.com/v1/predictions',
+      },
+      response: {
+        status: 429,
+        statusText: 'Too Many Requests',
+        headers: {
+          'retry-after': '30',
+          'x-ratelimit-remaining': '0',
+        },
+      },
+    });
+  });
+
+  it('extracts axios-style config, code, headers, and body preview', () => {
+    const error = new Error('Network Error');
+    error.code = 'ENOTFOUND';
+    error.config = {
+      method: 'post',
+      baseURL: 'https://azure.example.com',
+      url: '/vision/v3.2/describe',
+    };
+    error.response = {
+      status: 503,
+      statusText: 'Service Unavailable',
+      headers: {
+        'Retry-After': '120',
+      },
+      data: {
+        detail: 'Temporary upstream outage',
+      },
+    };
+
+    expect(getUpstreamErrorSummary(error)).toEqual({
+      code: 'ENOTFOUND',
+      request: {
+        method: 'POST',
+        url: 'https://azure.example.com/vision/v3.2/describe',
+      },
+      response: {
+        status: 503,
+        statusText: 'Service Unavailable',
+        headers: {
+          'retry-after': '120',
+        },
+        bodyPreview: JSON.stringify({ detail: 'Temporary upstream outage' }),
+      },
+    });
+  });
+
+  it('returns undefined when no upstream details are available', () => {
+    expect(getUpstreamErrorSummary(new Error('boom'))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
This change hardens provider-failure observability by logging structured, safe upstream diagnostics for Replicate and Azure, aligning controller error logging with the configured Pino serializer, and adding regression coverage so production provider failures preserve actionable request, status, and retry context without exposing secrets.