### PR TITLE
Expand Postman/Newman coverage for Swagger, aliases, and Azure

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,13 +1,23 @@
-name: CI/CD Pipeline
+name: Lint
 
 on:
   push:
     branches:
       - main
+      - production
       - housekeeping
+    paths-ignore:
+      - '**/*.md'
+      - '.github/assets/**'
+      - 'LICENSE'
   pull_request:
     branches:
       - main
+      - production
+    paths-ignore:
+      - '**/*.md'
+      - '.github/assets/**'
+      - 'LICENSE'
 
 permissions:
   contents: read
@@ -22,10 +32,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/live-provider-validation.yml
+++ b/.github/workflows/live-provider-validation.yml
@@ -1,0 +1,54 @@
+name: Live Provider Validation
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: live-provider-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  live-provider:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate live-provider secrets
+        env:
+          REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
+        run: |
+          if [ -z "${REPLICATE_API_TOKEN}" ]; then
+            echo "REPLICATE_API_TOKEN secret is required for live provider validation."
+            exit 1
+          fi
+
+      - name: Run live provider validation
+        run: npm run postman:live
+        env:
+          REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
+          ACV_API_ENDPOINT: ${{ secrets.ACV_API_ENDPOINT }}
+          ACV_SUBSCRIPTION_KEY: ${{ secrets.ACV_SUBSCRIPTION_KEY }}
+          ACV_API_KEY: ${{ secrets.ACV_API_KEY }}
+
+      - name: Upload live validation artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: live-provider-artifacts
+          path: reports/newman/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/postman-newman.yml
+++ b/.github/workflows/postman-newman.yml
@@ -4,10 +4,20 @@ on:
   push:
     branches:
       - main
+      - production
       - housekeeping
+    paths-ignore:
+      - '**/*.md'
+      - '.github/assets/**'
+      - 'LICENSE'
   pull_request:
     branches:
       - main
+      - production
+    paths-ignore:
+      - '**/*.md'
+      - '.github/assets/**'
+      - 'LICENSE'
 
 permissions:
   contents: read
@@ -23,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: npm
@@ -39,7 +49,9 @@ jobs:
 
       - name: Upload Newman artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: newman-artifacts
           path: reports/newman/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,10 +4,20 @@ on:
   push:
     branches:
       - main
+      - production
       - housekeeping
+    paths-ignore:
+      - '**/*.md'
+      - '.github/assets/**'
+      - 'LICENSE'
   pull_request:
     branches:
       - main
+      - production
+    paths-ignore:
+      - '**/*.md'
+      - '.github/assets/**'
+      - 'LICENSE'
 
 permissions:
   contents: read
@@ -29,10 +39,10 @@ jobs:
           - '24'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -45,3 +55,12 @@ jobs:
         env:
           NODE_ENV: test
           REPLICATE_API_TOKEN: test-token
+
+      - name: Upload Jest coverage
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: jest-coverage-node-${{ matrix.node-version }}
+          path: coverage/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Alt-Text 4 All
 
 [![GitHub license](https://img.shields.io/github/license/jsugg/alt-text-generator)](https://github.com/jsugg/alt-text-generator/blob/main/LICENSE)
-[![CI/CD Pipeline](https://github.com/jsugg/alt-text-generator/actions/workflows/ci-cd.yml/badge.svg?branch=main)](https://github.com/jsugg/alt-text-generator/actions/workflows/ci-cd.yml)
+[![Lint](https://github.com/jsugg/alt-text-generator/actions/workflows/ci-cd.yml/badge.svg?branch=main)](https://github.com/jsugg/alt-text-generator/actions/workflows/ci-cd.yml)
 [![Tests](https://github.com/jsugg/alt-text-generator/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/jsugg/alt-text-generator/actions/workflows/tests.yml)
 ![Node CI 20 | 22 | 24](https://img.shields.io/badge/node%20CI-20%20%7C%2022%20%7C%2024-339933?logo=node.js&logoColor=white)
 
@@ -16,7 +16,7 @@ Alt-Text 4 All is an HTTPS-first API that scrapes website images and generates A
 The service exposes these primary capabilities:
 
 - discover image URLs on a target page
-- generate alt text for a specific image with the `clip` model
+- generate alt text for a specific image with the `clip` model or the `azure` model when Azure is configured
 - generate alt text for all images on a page while preserving duplicate entries
 
 ## Features
@@ -31,6 +31,7 @@ The service exposes these primary capabilities:
 ## Requirements
 
 - CI validates Node 20, 22, and 24.
+- `engines.node` is currently pinned to `20.x`; use Node 20 locally for the least friction.
 - npm 10+
 - A Replicate API token (required to boot; must be valid for real alt-text generation)
 
@@ -77,15 +78,22 @@ Notes:
 
 - `postman:smoke` is the fast deterministic gate.
 - `postman:harness` runs the full deterministic suite and writes JSON and JUnit reports under `reports/newman/`.
-- `postman:live` is optional and reserved for explicit Replicate validation.
+- `postman:live` is optional and reserved for explicit live-provider validation.
+- Live mode validates Replicate by default and also validates Azure when `ACV_API_ENDPOINT` and either `ACV_SUBSCRIPTION_KEY` or `ACV_API_KEY` are set.
 - Local harness runs accept self-signed development TLS.
 - The deterministic harness uses a local Azure stub and does not require real vendor credentials beyond a dummy Replicate token at app startup.
 
 ## Runtime Essentials
 
-Required for real descriptions:
+Required at startup:
 
 - `REPLICATE_API_TOKEN` (required at startup; a dummy value is OK for stubbed-provider validation)
+
+Required for live Azure descriptions:
+
+- `ACV_API_ENDPOINT`
+- `ACV_SUBSCRIPTION_KEY` or `ACV_API_KEY`
+- The `azure` model is only registered when the endpoint and one Azure credential are set together.
 
 Common local settings:
 
@@ -166,7 +174,7 @@ Use the development guide for:
 - Postman/Newman harness usage and report interpretation
 - TLS and outbound CA troubleshooting
 - lint, test, and live validation commands
-- real external-integration validation with Replicate
+- real external-integration validation with live providers
 
 See [DEVELOPMENT.md](./DEVELOPMENT.md).
 

--- a/postman/collections/alt-text-generator.postman_collection.json
+++ b/postman/collections/alt-text-generator.postman_collection.json
@@ -12,12 +12,23 @@
         "type": "text/javascript",
         "exec": [
           "const maxResponseTimeMs = Number(",
-          "  pm.environment.get('maxResponseTimeMs') || '1500'",
+          "  pm.request.headers.get('X-Max-Response-Time-Ms') ||",
+          "  pm.environment.get('maxResponseTimeMs') ||",
+          "  '1500'",
           ");",
           "",
-          "pm.test('response is not 5xx', function () {",
-          "  pm.expect(pm.response.code, `unexpected status ${pm.response.code}`).to.be.below(500);",
-          "});",
+          "const expectedStatusClass = pm.request.headers.get('X-Expected-Status-Class') || '';",
+          "",
+          "if (expectedStatusClass === '5xx') {",
+          "  pm.test('response is an expected 5xx', function () {",
+          "    pm.expect(pm.response.code, `unexpected status ${pm.response.code}`).to.be.at.least(500);",
+          "    pm.expect(pm.response.code, `unexpected status ${pm.response.code}`).to.be.below(600);",
+          "  });",
+          "} else {",
+          "  pm.test('response is not 5xx', function () {",
+          "    pm.expect(pm.response.code, `unexpected status ${pm.response.code}`).to.be.below(500);",
+          "  });",
+          "}",
           "",
           "pm.test(`response time is below ${maxResponseTimeMs}ms`, function () {",
           "  pm.expect(pm.response.responseTime).to.be.below(maxResponseTimeMs);",
@@ -174,6 +185,65 @@
               }
             }
           ]
+        },
+        {
+          "name": "Swagger Spec",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/javascript"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api-docs/swagger-ui-init.js",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api-docs",
+                "swagger-ui-init.js"
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('swagger init returns 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const body = pm.response.text();",
+                  "const match = body.match(/\\\"servers\\\":\\s*(\\[[\\s\\S]*?\\])\\s*,\\s*\\\"paths\\\":/);",
+                  "",
+                  "pm.test('swagger init exposes an embedded servers array', function () {",
+                  "  pm.expect(match, 'servers array not found in swagger-ui-init.js').not.to.eql(null);",
+                  "});",
+                  "",
+                  "const servers = match ? JSON.parse(match[1]) : [];",
+                  "const expectedSwaggerServerUrl = pm.environment.get('expectedSwaggerServerUrl');",
+                  "",
+                  "pm.test('swagger spec advertises only the expected local server', function () {",
+                  "  pm.expect(servers).to.eql([",
+                  "    {",
+                  "      url: expectedSwaggerServerUrl,",
+                  "      description: 'Development server'",
+                  "    }",
+                  "  ]);",
+                  "});",
+                  "",
+                  "pm.test('swagger spec does not reference the retired qcraft.dev domain', function () {",
+                  "  pm.expect(body).not.to.include('wcag.qcraft.dev');",
+                  "});"
+                ]
+              }
+            }
+          ]
         }
       ]
     },
@@ -262,6 +332,269 @@
                   "pm.test('redirect location is the https ping endpoint', function () {",
                   "  const location = pm.response.headers.get('Location') || pm.response.headers.get('location') || '';",
                   "  pm.expect(location).to.eql(`${pm.environment.get('baseUrl')}/api/ping`);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "07 Route Aliases",
+      "item": [
+        {
+          "name": "Versioned ping alias",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "text/plain"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/ping",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "ping"
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('versioned ping returns 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('versioned ping returns pong', function () {",
+                  "  pm.expect(pm.response.text()).to.eql('pong');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Versioned health alias",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/health",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "health"
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('versioned health returns 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const body = pm.response.json();",
+                  "",
+                  "pm.test('versioned health payload contains expected fields', function () {",
+                  "  pm.expect(body).to.have.property('message', 'OK');",
+                  "  pm.expect(body).to.have.property('uptime');",
+                  "  pm.expect(body).to.have.property('timestamp');",
+                  "  pm.expect(body.uptime).to.be.a('number');",
+                  "  pm.expect(body.timestamp).to.be.a('number');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Unversioned scraper alias",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/scraper/images",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "scraper",
+                "images"
+              ],
+              "query": [
+                {
+                  "key": "url",
+                  "value": "{{samplePageUrl}}"
+                }
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('unversioned scraper alias returns 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const body = pm.response.json();",
+                  "const expectedA = pm.environment.get('sampleImageAUrl');",
+                  "const expectedB = pm.environment.get('sampleImageBUrl');",
+                  "",
+                  "pm.test('unversioned scraper alias preserves the same image order', function () {",
+                  "  pm.expect(body.imageSources).to.eql([",
+                  "    expectedA,",
+                  "    expectedB,",
+                  "    expectedA",
+                  "  ]);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Unversioned single description alias",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/accessibility/description",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "accessibility",
+                "description"
+              ],
+              "query": [
+                {
+                  "key": "image_source",
+                  "value": "{{sampleImageAUrl}}"
+                },
+                {
+                  "key": "model",
+                  "value": "{{model}}"
+                }
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('unversioned single description alias returns 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const body = pm.response.json();",
+                  "const expectedImageUrl = pm.environment.get('sampleImageAUrl');",
+                  "",
+                  "pm.test('unversioned single description alias matches the stub payload', function () {",
+                  "  pm.expect(body).to.eql([",
+                  "    { description: 'stub caption for asset a', imageUrl: expectedImageUrl }",
+                  "  ]);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Unversioned page descriptions alias",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/accessibility/descriptions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "accessibility",
+                "descriptions"
+              ],
+              "query": [
+                {
+                  "key": "url",
+                  "value": "{{samplePageUrl}}"
+                },
+                {
+                  "key": "model",
+                  "value": "{{model}}"
+                }
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('unversioned page descriptions alias returns 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const body = pm.response.json();",
+                  "const expectedA = pm.environment.get('sampleImageAUrl');",
+                  "const expectedB = pm.environment.get('sampleImageBUrl');",
+                  "",
+                  "pm.test('unversioned page descriptions alias preserves duplicate order', function () {",
+                  "  pm.expect(body.descriptions).to.eql([",
+                  "    { description: 'stub caption for asset a', imageUrl: expectedA },",
+                  "    { description: 'stub caption for asset b', imageUrl: expectedB },",
+                  "    { description: 'stub caption for asset a', imageUrl: expectedA }",
+                  "  ]);",
                   "});"
                 ]
               }
@@ -400,6 +733,126 @@
               }
             }
           ]
+        },
+        {
+          "name": "Missing image returns 500",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Class",
+                "value": "5xx"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/accessibility/description",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "accessibility",
+                "description"
+              ],
+              "query": [
+                {
+                  "key": "image_source",
+                  "value": "{{missingImageUrl}}"
+                },
+                {
+                  "key": "model",
+                  "value": "{{model}}"
+                }
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('single description returns 500 for provider fetch failures', function () {",
+                  "  pm.response.to.have.status(500);",
+                  "});",
+                  "",
+                  "const body = pm.response.json();",
+                  "",
+                  "pm.test('single description 500 matches the public error contract', function () {",
+                  "  pm.expect(body).to.eql({",
+                  "    error: 'Error fetching description for the provided image'",
+                  "  });",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Provider outage returns 500",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Class",
+                "value": "5xx"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/accessibility/description",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "accessibility",
+                "description"
+              ],
+              "query": [
+                {
+                  "key": "image_source",
+                  "value": "{{providerFailureImageUrl}}"
+                },
+                {
+                  "key": "model",
+                  "value": "{{model}}"
+                }
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('single description returns 500 for non-skippable provider failures', function () {",
+                  "  pm.response.to.have.status(500);",
+                  "});",
+                  "",
+                  "const body = pm.response.json();",
+                  "",
+                  "pm.test('single description provider failure matches the public error contract', function () {",
+                  "  pm.expect(body).to.eql({",
+                  "    error: 'Error fetching description for the provided image'",
+                  "  });",
+                  "});"
+                ]
+              }
+            }
+          ]
         }
       ]
     },
@@ -502,6 +955,132 @@
                   "    { description: 'stub caption for asset b', imageUrl: expectedB },",
                   "    { description: 'stub caption for asset a', imageUrl: expectedA }",
                   "  ]);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Skips missing images and preserves successful duplicates",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/accessibility/descriptions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "accessibility",
+                "descriptions"
+              ],
+              "query": [
+                {
+                  "key": "url",
+                  "value": "{{samplePartialPageUrl}}"
+                },
+                {
+                  "key": "model",
+                  "value": "{{model}}"
+                }
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('page descriptions return 200 when bad images are skippable', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const body = pm.response.json();",
+                  "const expectedA = pm.environment.get('sampleImageAUrl');",
+                  "const expectedPageUrl = pm.environment.get('samplePartialPageUrl');",
+                  "",
+                  "pm.test('page metadata counts only successful image descriptions', function () {",
+                  "  pm.expect(body.pageUrl).to.eql(expectedPageUrl);",
+                  "  pm.expect(body.model).to.eql('azure');",
+                  "  pm.expect(body.totalImages).to.eql(2);",
+                  "  pm.expect(body.uniqueImages).to.eql(1);",
+                  "});",
+                  "",
+                  "pm.test('successful duplicate output order is preserved after skips', function () {",
+                  "  pm.expect(body.descriptions).to.eql([",
+                  "    { description: 'stub caption for asset a', imageUrl: expectedA },",
+                  "    { description: 'stub caption for asset a', imageUrl: expectedA }",
+                  "  ]);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Provider outage fails the whole page request",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Class",
+                "value": "5xx"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/accessibility/descriptions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "accessibility",
+                "descriptions"
+              ],
+              "query": [
+                {
+                  "key": "url",
+                  "value": "{{sampleProviderFailurePageUrl}}"
+                },
+                {
+                  "key": "model",
+                  "value": "{{model}}"
+                }
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('page descriptions return 500 for non-skippable provider failures', function () {",
+                  "  pm.response.to.have.status(500);",
+                  "});",
+                  "",
+                  "const body = pm.response.json();",
+                  "",
+                  "pm.test('page description provider failure matches the public error contract', function () {",
+                  "  pm.expect(body).to.eql({",
+                  "    error: 'Error fetching descriptions for the provided page'",
+                  "  });",
                   "});"
                 ]
               }
@@ -999,6 +1578,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Max-Response-Time-Ms",
+                "value": "15000"
               }
             ],
             "url": {
@@ -1059,6 +1642,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Max-Response-Time-Ms",
+                "value": "15000"
               }
             ],
             "url": {
@@ -1115,6 +1702,151 @@
                   "    pm.expect(item).to.have.property('description');",
                   "    pm.expect(item.imageUrl).to.be.a('string');",
                   "    pm.expect(item.description).to.be.a('string');",
+                  "  });",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "91 Live Azure Validation",
+      "item": [
+        {
+          "name": "Live azure single image",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Max-Response-Time-Ms",
+                "value": "15000"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/accessibility/description",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "accessibility",
+                "description"
+              ],
+              "query": [
+                {
+                  "key": "image_source",
+                  "value": "{{liveAzureImageUrl}}"
+                },
+                {
+                  "key": "model",
+                  "value": "azure"
+                }
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('returns 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const body = pm.response.json();",
+                  "",
+                  "pm.test('response is a one-item array', function () {",
+                  "  pm.expect(body).to.be.an('array').with.lengthOf(1);",
+                  "});",
+                  "",
+                  "pm.test('azure description is a non-empty string for the requested image', function () {",
+                  "  pm.expect(body[0].imageUrl).to.eql(pm.environment.get('liveAzureImageUrl'));",
+                  "  pm.expect(body[0].description).to.be.a('string');",
+                  "  pm.expect(body[0].description.length).to.be.above(0);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Live azure page descriptions",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Max-Response-Time-Ms",
+                "value": "15000"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/accessibility/descriptions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "accessibility",
+                "descriptions"
+              ],
+              "query": [
+                {
+                  "key": "url",
+                  "value": "{{liveAzurePageUrl}}"
+                },
+                {
+                  "key": "model",
+                  "value": "azure"
+                }
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('returns 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const body = pm.response.json();",
+                  "",
+                  "pm.test('response includes azure page metadata', function () {",
+                  "  pm.expect(body.pageUrl).to.eql(pm.environment.get('liveAzurePageUrl'));",
+                  "  pm.expect(body.model).to.eql('azure');",
+                  "  pm.expect(body.totalImages).to.be.a('number');",
+                  "  pm.expect(body.uniqueImages).to.be.a('number');",
+                  "  pm.expect(body.descriptions).to.be.an('array');",
+                  "});",
+                  "",
+                  "pm.test('at least one azure description is returned', function () {",
+                  "  pm.expect(body.descriptions.length).to.be.above(0);",
+                  "});",
+                  "",
+                  "pm.test('each azure description has the expected shape', function () {",
+                  "  body.descriptions.forEach((item) => {",
+                  "    pm.expect(item).to.have.property('imageUrl');",
+                  "    pm.expect(item).to.have.property('description');",
+                  "    pm.expect(item.imageUrl).to.be.a('string');",
+                  "    pm.expect(item.description).to.be.a('string');",
+                  "    pm.expect(item.description.length).to.be.above(0);",
                   "  });",
                   "});"
                 ]

--- a/postman/environments/alt-text-generator.local.stub.postman_environment.json
+++ b/postman/environments/alt-text-generator.local.stub.postman_environment.json
@@ -27,6 +27,12 @@
       "enabled": true
     },
     {
+      "key": "samplePartialPageUrl",
+      "value": "http://127.0.0.1:19090/fixtures/page-with-partial-images",
+      "type": "default",
+      "enabled": true
+    },
+    {
       "key": "sampleImageAUrl",
       "value": "http://127.0.0.1:19090/assets/a.png",
       "type": "default",
@@ -35,6 +41,24 @@
     {
       "key": "sampleImageBUrl",
       "value": "http://127.0.0.1:19090/assets/b.png",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "missingImageUrl",
+      "value": "http://127.0.0.1:19090/assets/missing.png",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "providerFailureImageUrl",
+      "value": "http://127.0.0.1:19090/assets/provider-error.png",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "sampleProviderFailurePageUrl",
+      "value": "http://127.0.0.1:19090/fixtures/page-with-provider-failure",
       "type": "default",
       "enabled": true
     },
@@ -51,6 +75,12 @@
       "enabled": true
     },
     {
+      "key": "expectedSwaggerServerUrl",
+      "value": "https://localhost:8443",
+      "type": "default",
+      "enabled": true
+    },
+    {
       "key": "liveImageUrl",
       "value": "https://upload.wikimedia.org/wikipedia/commons/3/3f/Fronalpstock_big.jpg",
       "type": "default",
@@ -58,6 +88,18 @@
     },
     {
       "key": "livePageUrl",
+      "value": "https://developer.chrome.com/",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "liveAzureImageUrl",
+      "value": "https://developer.chrome.com/static/images/ai-homepage-card.png",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "liveAzurePageUrl",
       "value": "https://developer.chrome.com/",
       "type": "default",
       "enabled": true

--- a/scripts/postman-fixture-server.js
+++ b/scripts/postman-fixture-server.js
@@ -29,6 +29,11 @@ const ASSET_B_PNG = Buffer.from(
   'base64',
 );
 
+const ASSET_PROVIDER_FAILURE_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADUlEQVR42mNk+M/wHwAEAQH/cetH5QAAAABJRU5ErkJggg==',
+  'base64',
+);
+
 /**
  * Returns a deterministic caption for a given image URL.
  *
@@ -91,14 +96,83 @@ app.get('/fixtures/page-with-images', (_req, res) => {
 </html>`);
 });
 
+app.get('/fixtures/page-with-partial-images', (_req, res) => {
+  res.type('html').send(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Postman Harness Partial Fixture</title>
+  </head>
+  <body>
+    <h1>Partial Fixture Page</h1>
+
+    <!-- successful image -->
+    <img src="/assets/a.png" alt="" />
+
+    <!-- missing image to exercise page-level best-effort behavior -->
+    <img src="/assets/missing.png" alt="" />
+
+    <!-- duplicate successful image to ensure output order is preserved -->
+    <img src="/assets/a.png" alt="" />
+  </body>
+</html>`);
+});
+
+app.get('/fixtures/page-with-provider-failure', (_req, res) => {
+  res.type('html').send(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Postman Harness Provider Failure Fixture</title>
+  </head>
+  <body>
+    <h1>Provider Failure Fixture Page</h1>
+
+    <!-- successful image -->
+    <img src="/assets/a.png" alt="" />
+
+    <!-- image that forces the Azure stub to return a non-skippable provider error -->
+    <img src="/assets/provider-error.png" alt="" />
+  </body>
+</html>`);
+});
+
 app.get('/assets/:name', (req, res) => {
-  const asset = req.params.name === 'a.png' ? ASSET_A_PNG : ASSET_B_PNG;
+  let asset = null;
+
+  if (req.params.name === 'a.png') {
+    asset = ASSET_A_PNG;
+  } else if (req.params.name === 'b.png') {
+    asset = ASSET_B_PNG;
+  } else if (req.params.name === 'provider-error.png') {
+    asset = ASSET_PROVIDER_FAILURE_PNG;
+  }
+
+  if (!asset) {
+    res.status(404).type('text/plain').send('asset not found');
+    return;
+  }
+
   res.type('image/png').send(asset);
 });
 
 app.post('/vision/v3.2/describe', express.raw({ type: 'application/octet-stream' }), (req, res) => {
   const imageUrl = typeof req.body?.url === 'string' ? req.body.url : '';
   const imageBuffer = Buffer.isBuffer(req.body) ? req.body : Buffer.alloc(0);
+
+  if (
+    imageUrl.endsWith('/assets/provider-error.png')
+    || Buffer.compare(imageBuffer, ASSET_PROVIDER_FAILURE_PNG) === 0
+  ) {
+    res.status(401).json({
+      error: {
+        code: 'PermissionDenied',
+        message: 'stub provider authentication failure',
+      },
+    });
+    return;
+  }
+
   const caption = imageBuffer.length > 0
     ? captionForBuffer(imageBuffer)
     : captionForUrl(imageUrl);

--- a/scripts/run-postman-harness.js
+++ b/scripts/run-postman-harness.js
@@ -159,9 +159,23 @@ function runNewman(label, folders, extraArgs = []) {
     '--env-var',
     `samplePageUrl=http://${HOST}:${FIXTURE_PORT}/fixtures/page-with-images`,
     '--env-var',
+    `samplePartialPageUrl=http://${HOST}:${FIXTURE_PORT}/fixtures/page-with-partial-images`,
+    '--env-var',
+    `sampleProviderFailurePageUrl=http://${HOST}:${FIXTURE_PORT}/fixtures/page-with-provider-failure`,
+    '--env-var',
     `sampleImageAUrl=http://${HOST}:${FIXTURE_PORT}/assets/a.png`,
     '--env-var',
     `sampleImageBUrl=http://${HOST}:${FIXTURE_PORT}/assets/b.png`,
+    '--env-var',
+    `missingImageUrl=http://${HOST}:${FIXTURE_PORT}/assets/missing.png`,
+    '--env-var',
+    `providerFailureImageUrl=http://${HOST}:${FIXTURE_PORT}/assets/provider-error.png`,
+    '--env-var',
+    `expectedSwaggerServerUrl=https://localhost:${APP_HTTPS_PORT}`,
+    '--env-var',
+    'liveAzureImageUrl=https://developer.chrome.com/static/images/ai-homepage-card.png',
+    '--env-var',
+    'liveAzurePageUrl=https://developer.chrome.com/',
     '--env-var',
     'model=azure',
     '--env-var',
@@ -244,6 +258,9 @@ function installSignalCleanup(children) {
  */
 async function main() {
   const mode = process.argv[2] || 'full';
+  const liveModeEnabled = mode === 'live' || process.env.RUN_LIVE_PROVIDER === 'true';
+  const azureSubscriptionKey = process.env.ACV_SUBSCRIPTION_KEY || process.env.ACV_API_KEY || null;
+  const hasLiveAzureConfig = Boolean(process.env.ACV_API_ENDPOINT && azureSubscriptionKey);
   const managedChildren = new Set();
 
   await fs.mkdir(REPORTS_DIR, { recursive: true });
@@ -269,9 +286,14 @@ async function main() {
       TLS_PORT: APP_HTTPS_PORT,
       WORKER_COUNT: '1',
       LOG_LEVEL: 'info',
+      SWAGGER_DEV_URL: `https://localhost:${APP_HTTPS_PORT}`,
       REPLICATE_API_TOKEN: process.env.REPLICATE_API_TOKEN || 'test-token',
-      ACV_API_ENDPOINT: `http://${HOST}:${FIXTURE_PORT}/vision/v3.2/describe`,
-      ACV_SUBSCRIPTION_KEY: 'stub-key',
+      ACV_API_ENDPOINT: liveModeEnabled && hasLiveAzureConfig
+        ? process.env.ACV_API_ENDPOINT
+        : `http://${HOST}:${FIXTURE_PORT}/vision/v3.2/describe`,
+      ACV_SUBSCRIPTION_KEY: liveModeEnabled && hasLiveAzureConfig
+        ? azureSubscriptionKey
+        : 'stub-key',
       ACV_LANGUAGE: 'en',
       ACV_MAX_CANDIDATES: '4',
     },
@@ -291,6 +313,7 @@ async function main() {
         'smoke',
         [
           '00 Core Smoke',
+          '07 Route Aliases',
           '10 Scraper Contract',
           '20 Single Description (Azure Stub)',
         ],
@@ -309,6 +332,7 @@ async function main() {
         'core',
         [
           '00 Core Smoke',
+          '07 Route Aliases',
           '10 Scraper Contract',
           '20 Single Description (Azure Stub)',
           '30 Page Descriptions (Azure Stub)',
@@ -324,10 +348,19 @@ async function main() {
       );
     }
 
-    if (mode === 'live' || process.env.RUN_LIVE_PROVIDER === 'true') {
+    if (liveModeEnabled) {
+      const liveFolders = ['90 Live Provider Validation'];
+
+      if (hasLiveAzureConfig) {
+        liveFolders.push('91 Live Azure Validation');
+      } else {
+        // eslint-disable-next-line no-console
+        console.log('Skipping 91 Live Azure Validation: ACV_API_ENDPOINT/ACV_SUBSCRIPTION_KEY not set');
+      }
+
       await runNewman(
         'live-provider',
-        ['90 Live Provider Validation'],
+        liveFolders,
         ['--insecure'],
       );
     }


### PR DESCRIPTION
Expand the Postman/Newman harness to cover Swagger spec drift, versioned and unversioned route aliases, Azure partial-success behavior, and non-skippable Azure provider failures. This also adds optional live Azure validation when real Azure credentials are present, updates the local fixture server and harness runner to support those scenarios, aligns the README with the current live-provider model, and hardens GitHub Actions by covering production pushes, pinning action SHAs, publishing Jest/Newman artifacts more consistently, and adding a manual live-provider validation workflow.