### PR TITLE
Allow Azure-only startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,9 @@ NODE_ENV=development
 PORT=8080
 TLS_PORT=8443
 
-# Required for real Replicate-backed descriptions.
-REPLICATE_API_TOKEN=replace-me
+# Configure at least one provider before booting the app.
+# Replicate enables the `clip` model.
+# REPLICATE_API_TOKEN=replace-me
 
 # Optional Replicate overrides.
 # REPLICATE_API_ENDPOINT=https://api.replicate.com/v1/
@@ -35,10 +36,10 @@ REPLICATE_API_TOKEN=replace-me
 
 # Optional Swagger URLs.
 # SWAGGER_DEV_URL=https://localhost:8443
-# SWAGGER_PROD_URL=https://wcag.qcraft.dev
+# SWAGGER_PROD_URL=https://wcag.qcraft.com.br
 
 # Optional Azure provider settings. Set ACV_API_ENDPOINT and one credential
-# to register the `azure` model at startup.
+# to register the `azure` model at startup. Azure-only boot is supported.
 # ACV_API_ENDPOINT=
 # ACV_SUBSCRIPTION_KEY=
 # ACV_API_KEY=  # Legacy alias for ACV_SUBSCRIPTION_KEY

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,7 +34,7 @@ Boot locally:
 
 ```bash
 cp .env.example .env
-# edit .env and set REPLICATE_API_TOKEN (required even to boot)
+# edit .env and configure at least one provider
 npm install
 npm run dev
 ```
@@ -85,7 +85,7 @@ The repository uses a small workflow set with separate responsibilities:
 - `Live Provider Validation` in `.github/workflows/live-provider-validation.yml`
   - manual only
   - runs `npm run postman:live`
-  - requires `REPLICATE_API_TOKEN`
+  - requires `REPLICATE_API_TOKEN` only when Replicate validation is enabled
   - includes Azure validation only when Azure secrets are provided and `run_azure` stays enabled
   - also supports a guarded weekly schedule when the repository variable `ENABLE_SCHEDULED_LIVE_PROVIDER_VALIDATION` is set to `true`
 - scheduled Azure live validation additionally requires `ENABLE_SCHEDULED_AZURE_LIVE_VALIDATION=true`
@@ -208,7 +208,7 @@ Notes:
 | Variable | Required | Default | Description |
 | --- | --- | --- | --- |
 | `NODE_ENV` | No | `development` | Valid values: `development`, `production`, `test`. |
-| `REPLICATE_API_TOKEN` | Yes | none | Required for boot (env validation) and for real descriptions. |
+| `REPLICATE_API_TOKEN` | No | none | Required only to register the `clip` provider and for real Replicate-backed descriptions. |
 | `ENV_FILE` | No | `.env` | Selects which dotenv file to load at startup. Not validated by Joi. |
 
 ### Network and Inbound TLS (server)
@@ -270,6 +270,7 @@ Development TLS behavior:
 | `ACV_MAX_CANDIDATES` | No | `4` | Maximum Azure caption candidates. |
 
 `ACV_API_ENDPOINT` and one Azure credential must be set together or startup validation fails.
+At least one provider must be configured at startup: `REPLICATE_API_TOKEN`, or Azure endpoint plus credential.
 
 ### Rate Limiting, Logging, and Swagger
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ The service exposes these primary capabilities:
 - CI validates Node 20, 22, and 24.
 - `engines.node` is currently pinned to `20.x`; use Node 20 locally for the least friction.
 - npm 10+
-- A Replicate API token (required to boot; must be valid for real alt-text generation)
+- At least one provider configuration:
+  - `REPLICATE_API_TOKEN` for the `clip` model
+  - or `ACV_API_ENDPOINT` plus `ACV_SUBSCRIPTION_KEY` or `ACV_API_KEY` for the `azure` model
 
 ## Quick Start
 
@@ -41,7 +43,7 @@ The service exposes these primary capabilities:
 git clone https://github.com/jsugg/alt-text-generator.git
 cd alt-text-generator
 cp .env.example .env
-# edit .env and set REPLICATE_API_TOKEN
+# edit .env and configure at least one provider
 npm install
 npm run dev
 ```
@@ -81,13 +83,15 @@ Notes:
 - `postman:live` is optional and reserved for explicit live-provider validation.
 - Live mode validates Replicate by default and also validates Azure when `ACV_API_ENDPOINT` and either `ACV_SUBSCRIPTION_KEY` or `ACV_API_KEY` are set.
 - Local harness runs accept self-signed development TLS.
-- The deterministic harness uses a local Azure stub and does not require real vendor credentials beyond a dummy Replicate token at app startup.
+- The deterministic harness uses a local Azure stub and can boot with a dummy Replicate token or Azure-only configuration.
 
 ## Runtime Essentials
 
 Required at startup:
 
-- `REPLICATE_API_TOKEN` (required at startup; a dummy value is OK for stubbed-provider validation)
+- At least one provider configuration:
+  - `REPLICATE_API_TOKEN` to register `clip`
+  - or `ACV_API_ENDPOINT` plus `ACV_SUBSCRIPTION_KEY` or `ACV_API_KEY` to register `azure`
 
 Required for live Azure descriptions:
 

--- a/src/createApp.js
+++ b/src/createApp.js
@@ -28,6 +28,10 @@ const buildReplicateClient = (config, fetch) => new Replicate({
   userAgent: config.replicate.userAgent,
 });
 
+const hasReplicateProviderConfig = (replicateConfig = {}) => Boolean(
+  replicateConfig.apiToken,
+);
+
 const hasAzureProviderConfig = (azureConfig = {}) => Boolean(
   azureConfig.apiEndpoint && azureConfig.subscriptionKey,
 );
@@ -40,13 +44,15 @@ const buildImageDescriberFactory = ({
   requestOptions,
 }) => {
   const factory = new ImageDescriberFactory();
-  const replicateDescriber = new ReplicateDescriberService({
-    logger,
-    replicateClient,
-    config,
-  });
+  if (hasReplicateProviderConfig(config.replicate)) {
+    const replicateDescriber = new ReplicateDescriberService({
+      logger,
+      replicateClient,
+      config,
+    });
 
-  factory.register('clip', replicateDescriber);
+    factory.register('clip', replicateDescriber);
+  }
 
   if (hasAzureProviderConfig(config.azure)) {
     const azureDescriber = new AzureDescriberService({
@@ -97,8 +103,9 @@ const createApp = ({
         maxRedirects: scraperConfig.maxRedirects,
         maxContentLength: scraperConfig.maxContentLengthBytes,
       },
-      replicateClient: replicateClient
-        ?? buildReplicateClient(config, resolvedOutboundClients.fetch),
+      replicateClient: hasReplicateProviderConfig(config.replicate)
+        ? (replicateClient ?? buildReplicateClient(config, resolvedOutboundClients.fetch))
+        : undefined,
     });
   const resolvedPageDescriptionService = pageDescriptionService
     ?? new PageDescriptionService({

--- a/src/utils/validateEnvVars.js
+++ b/src/utils/validateEnvVars.js
@@ -28,8 +28,8 @@ const envVarsSchema = Joi.object({
   }),
   OUTBOUND_CA_BUNDLE_FILE: Joi.string().optional(),
 
-  // Replicate is required for core functionality
-  REPLICATE_API_TOKEN: Joi.string().required(),
+  // Replicate is optional and only required when the clip provider is enabled
+  REPLICATE_API_TOKEN: Joi.string().optional(),
   REPLICATE_API_ENDPOINT: Joi.string().uri().optional(),
   REPLICATE_USER_AGENT: Joi.string().optional(),
   REPLICATE_MODEL_OWNER: Joi.string().optional(),
@@ -72,6 +72,16 @@ const validateEnvVars = () => {
   const hasAzureCredential = Boolean(
     process.env.ACV_SUBSCRIPTION_KEY || process.env.ACV_API_KEY,
   );
+  const hasReplicateProvider = Boolean(process.env.REPLICATE_API_TOKEN);
+  const hasAzureProvider = hasAzureEndpoint && hasAzureCredential;
+
+  if (!hasReplicateProvider && !hasAzureProvider) {
+    throw new Error(
+      'Config validation error: at least one provider must be configured. '
+        + 'Set REPLICATE_API_TOKEN to enable clip, or set ACV_API_ENDPOINT and '
+        + 'either ACV_SUBSCRIPTION_KEY or ACV_API_KEY to enable azure',
+    );
+  }
 
   if (hasAzureEndpoint !== hasAzureCredential) {
     throw new Error(

--- a/tests/unit/createApp.test.js
+++ b/tests/unit/createApp.test.js
@@ -112,6 +112,37 @@ describe('createApp', () => {
     }
   });
 
+  it('registers only azure when Replicate is not configured', () => {
+    const config = {
+      replicate: {},
+      azure: {
+        apiEndpoint: 'https://azure.example.com/vision/v3.2/describe',
+        subscriptionKey: 'azure-key',
+        language: 'en',
+        maxCandidates: 4,
+      },
+      scraper: {
+        requestTimeoutMs: 1500,
+        maxRedirects: 4,
+        maxContentLengthBytes: 2048,
+      },
+    };
+    const httpClient = {
+      get: jest.fn(),
+      post: jest.fn(),
+    };
+
+    const { services } = createApp({
+      appLogger: createAppLogger(),
+      requestLogger: createRequestLogger(),
+      httpClient,
+      config,
+    });
+
+    expect(services.imageDescriberFactory.getAvailableModels()).toEqual(['azure']);
+    expect(services.imageDescriberFactory.get('azure').httpClient).toBe(httpClient);
+  });
+
   it('falls back to the default trust proxy setting when config omits proxy', () => {
     const config = {
       replicate: {
@@ -169,5 +200,31 @@ describe('createApp', () => {
     });
 
     expect(services.imageDescriberFactory.getAvailableModels()).toEqual(['clip']);
+  });
+
+  it('does not register clip when the Replicate token is missing', () => {
+    const config = {
+      replicate: {
+        apiEndpoint: 'https://replicate.example.com',
+        userAgent: 'alt-text-generator/test',
+        modelOwner: 'owner',
+        modelName: 'model',
+        modelVersion: 'version',
+      },
+      scraper: {
+        requestTimeoutMs: 1500,
+        maxRedirects: 4,
+        maxContentLengthBytes: 2048,
+      },
+    };
+
+    const { services } = createApp({
+      appLogger: createAppLogger(),
+      requestLogger: createRequestLogger(),
+      httpClient: { get: jest.fn(), post: jest.fn() },
+      config,
+    });
+
+    expect(services.imageDescriberFactory.getAvailableModels()).toEqual([]);
   });
 });

--- a/tests/unit/utils/validateEnvVars.test.js
+++ b/tests/unit/utils/validateEnvVars.test.js
@@ -22,6 +22,37 @@ afterEach(() => {
 });
 
 describe('validateEnvVars', () => {
+  it('accepts a Replicate-only provider configuration', () => {
+    const validateEnvVars = loadValidator({
+      overrides: {
+        REPLICATE_API_TOKEN: 'test-token',
+      },
+      remove: ['ACV_API_ENDPOINT', 'ACV_SUBSCRIPTION_KEY', 'ACV_API_KEY'],
+    });
+
+    expect(() => validateEnvVars()).not.toThrow();
+  });
+
+  it('accepts an Azure-only provider configuration', () => {
+    const validateEnvVars = loadValidator({
+      overrides: {
+        ACV_API_ENDPOINT: 'https://azure.example.com/vision/v3.2/describe',
+        ACV_SUBSCRIPTION_KEY: 'azure-key',
+      },
+      remove: ['REPLICATE_API_TOKEN', 'ACV_API_KEY'],
+    });
+
+    expect(() => validateEnvVars()).not.toThrow();
+  });
+
+  it('rejects startup when no provider is configured', () => {
+    const validateEnvVars = loadValidator({
+      remove: ['REPLICATE_API_TOKEN', 'ACV_API_ENDPOINT', 'ACV_SUBSCRIPTION_KEY', 'ACV_API_KEY'],
+    });
+
+    expect(() => validateEnvVars()).toThrow(/at least one provider must be configured/i);
+  });
+
   it('accepts TLS_* credentials in production', () => {
     const validateEnvVars = loadValidator({
       overrides: {
@@ -111,10 +142,10 @@ describe('validateEnvVars', () => {
   it('accepts Azure provider credentials when endpoint and subscription key are set', () => {
     const validateEnvVars = loadValidator({
       overrides: {
-        REPLICATE_API_TOKEN: 'test-token',
         ACV_API_ENDPOINT: 'https://azure.example.com/vision/v3.2/describe',
         ACV_SUBSCRIPTION_KEY: 'azure-key',
       },
+      remove: ['REPLICATE_API_TOKEN', 'ACV_API_KEY'],
     });
 
     expect(() => validateEnvVars()).not.toThrow();
@@ -123,10 +154,10 @@ describe('validateEnvVars', () => {
   it('accepts the legacy Azure API key alias', () => {
     const validateEnvVars = loadValidator({
       overrides: {
-        REPLICATE_API_TOKEN: 'test-token',
         ACV_API_ENDPOINT: 'https://azure.example.com/vision/v3.2/describe',
         ACV_API_KEY: 'azure-key',
       },
+      remove: ['REPLICATE_API_TOKEN', 'ACV_SUBSCRIPTION_KEY'],
     });
 
     expect(() => validateEnvVars()).not.toThrow();
@@ -135,10 +166,9 @@ describe('validateEnvVars', () => {
   it('rejects an Azure endpoint without credentials', () => {
     const validateEnvVars = loadValidator({
       overrides: {
-        REPLICATE_API_TOKEN: 'test-token',
         ACV_API_ENDPOINT: 'https://azure.example.com/vision/v3.2/describe',
       },
-      remove: ['ACV_API_KEY', 'ACV_SUBSCRIPTION_KEY'],
+      remove: ['REPLICATE_API_TOKEN', 'ACV_API_KEY', 'ACV_SUBSCRIPTION_KEY'],
     });
 
     expect(() => validateEnvVars()).toThrow(/ACV_API_ENDPOINT/);
@@ -147,10 +177,9 @@ describe('validateEnvVars', () => {
   it('rejects Azure credentials without an endpoint', () => {
     const validateEnvVars = loadValidator({
       overrides: {
-        REPLICATE_API_TOKEN: 'test-token',
         ACV_SUBSCRIPTION_KEY: 'azure-key',
       },
-      remove: ['ACV_API_ENDPOINT'],
+      remove: ['REPLICATE_API_TOKEN', 'ACV_API_ENDPOINT'],
     });
 
     expect(() => validateEnvVars()).toThrow(/ACV_API_ENDPOINT/);


### PR DESCRIPTION
Make provider startup conditional so the app boots when at least one provider is configured instead of always requiring Replicate. This keeps `clip` gated behind `REPLICATE_API_TOKEN`, preserves Azure registration rules, updates startup validation and tests, and aligns the docs and env example with the real provider-selection contract.