### PR TITLE
Fix Swagger example URLs

### DIFF
--- a/src/api/v1/controllers/descriptionController.js
+++ b/src/api/v1/controllers/descriptionController.js
@@ -33,7 +33,7 @@ class DescriptionController {
    *         required: true
    *         schema:
    *           type: string
-   *           example: https%3A%2F%2Fexample.com%2Fphoto.jpg
+   *           example: https%3A%2F%2Fdeveloper.chrome.com%2Fstatic%2Fimages%2Fai-homepage-card.png
    *       - name: model
    *         in: query
    *         description: The AI model to use, for example `clip` or `azure`.
@@ -56,7 +56,7 @@ class DescriptionController {
    *                     example: A man with glasses is playing a violin.
    *                   imageUrl:
    *                     type: string
-   *                     example: https://example.com/photo.jpg
+   *                     example: https://developer.chrome.com/static/images/ai-homepage-card.png
    *       400:
    *         description: Missing or invalid parameters, or unsupported model
    *       500:
@@ -110,7 +110,7 @@ class DescriptionController {
    *         required: true
    *         schema:
    *           type: string
-   *           example: https%3A%2F%2Fexample.com
+   *           example: https%3A%2F%2Fdeveloper.chrome.com%2F
    *       - name: model
    *         in: query
    *         description: The AI model to use, for example `clip` or `azure`.

--- a/src/api/v1/controllers/scraperController.js
+++ b/src/api/v1/controllers/scraperController.js
@@ -29,7 +29,7 @@ class ScraperController {
    *         required: true
    *         schema:
    *           type: string
-   *           example: https%3A%2F%2Fneymarques.com%2F
+   *           example: https%3A%2F%2Fdeveloper.chrome.com%2F
    *     responses:
    *       200:
    *         description: OK

--- a/tests/unit/config/swagger.test.js
+++ b/tests/unit/config/swagger.test.js
@@ -24,6 +24,29 @@ describe('config/swagger', () => {
     return swaggerDefinition;
   };
 
+  const loadParsedSwaggerSpec = ({ env, devServerUrl, prodServerUrl }) => {
+    jest.resetModules();
+
+    jest.doMock('../../../config', () => ({
+      env,
+      swagger: {
+        devServerUrl,
+        prodServerUrl,
+      },
+    }));
+
+    let swaggerSpec;
+
+    jest.isolateModules(() => {
+      // eslint-disable-next-line global-require
+      swaggerSpec = require('../../../config/swagger');
+    });
+
+    jest.dontMock('../../../config');
+
+    return swaggerSpec;
+  };
+
   afterEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
@@ -57,5 +80,39 @@ describe('config/swagger', () => {
         description: 'Production server',
       },
     ]);
+  });
+
+  it('publishes runnable encoded examples for image and page endpoints', () => {
+    const swaggerSpec = loadParsedSwaggerSpec({
+      env: 'production',
+      devServerUrl: 'https://localhost:8443',
+      prodServerUrl: 'https://wcag.qcraft.com.br',
+    });
+
+    const descriptionParameters = swaggerSpec.paths['/api/accessibility/description'].get.parameters;
+    const descriptionImageSource = descriptionParameters.find(
+      (parameter) => parameter.name === 'image_source',
+    );
+    const pageParameters = swaggerSpec.paths['/api/accessibility/descriptions'].get.parameters;
+    const pageUrl = pageParameters.find((parameter) => parameter.name === 'url');
+    const scraperParameters = swaggerSpec.paths['/api/scraper/images'].get.parameters;
+    const scraperUrl = scraperParameters.find((parameter) => parameter.name === 'url');
+    const responseImageExample = swaggerSpec.paths['/api/accessibility/description']
+      .get.responses['200']
+      .content['application/json']
+      .schema.items
+      .properties.imageUrl.example;
+    const serializedSpec = JSON.stringify(swaggerSpec);
+
+    expect(descriptionImageSource.schema.example).toBe(
+      'https%3A%2F%2Fdeveloper.chrome.com%2Fstatic%2Fimages%2Fai-homepage-card.png',
+    );
+    expect(pageUrl.schema.example).toBe('https%3A%2F%2Fdeveloper.chrome.com%2F');
+    expect(scraperUrl.schema.example).toBe('https%3A%2F%2Fdeveloper.chrome.com%2F');
+    expect(responseImageExample).toBe(
+      'https://developer.chrome.com/static/images/ai-homepage-card.png',
+    );
+    expect(serializedSpec).not.toContain('example.com');
+    expect(serializedSpec).not.toContain('neymarques.com');
   });
 });


### PR DESCRIPTION
Replace placeholder Swagger request examples with live, runnable Chrome URLs and add regression coverage so the published examples stay executable.