### PR TITLE
Add optional API auth and structured errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,11 @@ TLS_PORT=8443
 # RATE_LIMIT_MAX=100
 # LOG_LEVEL=debug
 
+# Optional API access control. When set, scraper and description endpoints
+# require either `Authorization: Bearer <token>` or `X-API-Key: <token>`.
+# Health, ping, and Swagger docs remain public.
+# API_AUTH_TOKENS=replace-me,rotate-me
+
 # Optional Swagger URLs.
 # SWAGGER_DEV_URL=https://localhost:8443
 # SWAGGER_PROD_URL=https://wcag.qcraft.com.br

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -7,6 +7,7 @@ If you only need a quick local boot, start with `README.md` and come back here f
 - full configuration reference (env vars and defaults)
 - production-like external integration validation
 - TLS and outbound trust troubleshooting (scraper and providers)
+- auth and public error-contract behavior
 
 ## Table of Contents
 
@@ -209,6 +210,7 @@ Notes:
 | --- | --- | --- | --- |
 | `NODE_ENV` | No | `development` | Valid values: `development`, `production`, `test`. |
 | `REPLICATE_API_TOKEN` | No | none | Required only to register the `clip` provider and for real Replicate-backed descriptions. |
+| `API_AUTH_TOKENS` | No | unset | Optional comma-separated API tokens. When set, scraper and description endpoints require either `Authorization: Bearer <token>` or `X-API-Key: <token>`. |
 | `ENV_FILE` | No | `.env` | Selects which dotenv file to load at startup. Not validated by Joi. |
 
 ### Network and Inbound TLS (server)
@@ -283,6 +285,8 @@ At least one provider must be configured at startup: `REPLICATE_API_TOKEN`, or A
 | `SWAGGER_PROD_URL` | No | `https://wcag.qcraft.com.br` | Swagger server URL for production docs. |
 
 - Logging stays on stdout so container platforms can collect it without relying on local files.
+- Public endpoints remain `ping`, `health`, and `api-docs` even when `API_AUTH_TOKENS` is set.
+- Auth-protected API failures use a structured JSON contract with `error`, `code`, `requestId`, and optional `details`.
 
 ## Render Deployment Contract
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The service exposes these primary capabilities:
 - Swagger UI for interactive API exploration
 - Lint and test automation in CI
 - Deterministic Postman/Newman API contract harness with local stubs
+- Optional token-based API access control for cost-bearing endpoints
 
 ## Requirements
 
@@ -102,6 +103,10 @@ Required for live Azure descriptions:
 Common local settings:
 
 - `PORT` and `TLS_PORT`
+- `API_AUTH_TOKENS`
+  - Optional comma-separated tokens
+  - When set, scraper and description endpoints require `Authorization: Bearer <token>` or `X-API-Key: <token>`
+  - `ping`, `health`, and `api-docs` stay public
 - `TRUST_PROXY_HOPS`
   - Defaults to `1`
   - Controls how many proxy hops Express trusts for forwarded headers
@@ -119,11 +124,22 @@ Clustered mode applies bounded restart backoff and a crash budget so persistent 
 Production logs stay on the process stream so platforms such as Render can collect them directly.
 The Render deployment shape is versioned in [render.yaml](./render.yaml), while the Node runtime pin remains in [`package.json`](./package.json) under `engines.node`.
 
+## Error Contract
+
+Error responses keep the existing top-level `error` message and add stable metadata:
+
+- `error`: human-readable message
+- `code`: machine-readable error code
+- `requestId`: request correlation id when available
+- `details`: optional validation details for field-level failures
+
 ## API Endpoints
 
 ### Swagger Documentation
 
 Interactive documentation: `/api-docs`
+
+When `API_AUTH_TOKENS` is configured, use Swagger UI's `Authorize` flow with either a Bearer token or `X-API-Key`.
 
 ### Images
 

--- a/config/index.js
+++ b/config/index.js
@@ -16,6 +16,17 @@ const toOptionalNumber = (value) => {
   return Number.isFinite(parsedValue) ? parsedValue : undefined;
 };
 
+const toList = (value) => {
+  if (typeof value !== 'string') {
+    return [];
+  }
+
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+};
+
 module.exports = {
   env: process.env.NODE_ENV || 'development',
 
@@ -86,6 +97,10 @@ module.exports = {
   rateLimit: {
     windowMs: toNumber(process.env.RATE_LIMIT_WINDOW_MS, 15 * 60 * 1000),
     max: toNumber(process.env.RATE_LIMIT_MAX, 100),
+  },
+
+  auth: {
+    tokens: toList(process.env.API_AUTH_TOKENS),
   },
 
   swagger: {

--- a/config/swagger.js
+++ b/config/swagger.js
@@ -28,6 +28,57 @@ const swaggerDefinition = {
       'This API provides descriptions to images, to contribute to the world-wide accessibility efforts.',
   },
   servers: buildServers(),
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'API token',
+      },
+      apiKeyAuth: {
+        type: 'apiKey',
+        in: 'header',
+        name: 'X-API-Key',
+      },
+    },
+    schemas: {
+      ApiErrorResponse: {
+        type: 'object',
+        required: ['error', 'code'],
+        properties: {
+          error: {
+            type: 'string',
+            example: 'Invalid image_source URL',
+          },
+          code: {
+            type: 'string',
+            example: 'INVALID_IMAGE_SOURCE_URL',
+          },
+          requestId: {
+            type: 'string',
+            example: 'd5c9fca2-bef2-4ff6-92ff-0227d219d67e',
+          },
+          details: {
+            type: 'array',
+            items: {
+              type: 'object',
+              required: ['field', 'issue'],
+              properties: {
+                field: {
+                  type: 'string',
+                  example: 'image_source',
+                },
+                issue: {
+                  type: 'string',
+                  example: 'invalid_url',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
 };
 
 const options = {

--- a/postman/collections/alt-text-generator.postman_collection.json
+++ b/postman/collections/alt-text-generator.postman_collection.json
@@ -219,7 +219,7 @@
                   "});",
                   "",
                   "const body = pm.response.text();",
-                  "const match = body.match(/\\\"servers\\\":\\s*(\\[[\\s\\S]*?\\])\\s*,\\s*\\\"paths\\\":/);",
+                  "const match = body.match(/\\\"servers\\\":\\s*(\\[[\\s\\S]*?\\])/);",
                   "",
                   "pm.test('swagger init exposes an embedded servers array', function () {",
                   "  pm.expect(match, 'servers array not found in swagger-ui-init.js').not.to.eql(null);",
@@ -785,9 +785,9 @@
                   "const body = pm.response.json();",
                   "",
                   "pm.test('single description 500 matches the public error contract', function () {",
-                  "  pm.expect(body).to.eql({",
-                  "    error: 'Error fetching description for the provided image'",
-                  "  });",
+                  "  pm.expect(body.error).to.eql('Error fetching description for the provided image');",
+                  "  pm.expect(body.code).to.eql('DESCRIPTION_FETCH_FAILED');",
+                  "  pm.expect(body.requestId).to.be.a('string').and.not.empty;",
                   "});"
                 ]
               }
@@ -845,9 +845,9 @@
                   "const body = pm.response.json();",
                   "",
                   "pm.test('single description provider failure matches the public error contract', function () {",
-                  "  pm.expect(body).to.eql({",
-                  "    error: 'Error fetching description for the provided image'",
-                  "  });",
+                  "  pm.expect(body.error).to.eql('Error fetching description for the provided image');",
+                  "  pm.expect(body.code).to.eql('DESCRIPTION_FETCH_FAILED');",
+                  "  pm.expect(body.requestId).to.be.a('string').and.not.empty;",
                   "});"
                 ]
               }
@@ -1078,9 +1078,9 @@
                   "const body = pm.response.json();",
                   "",
                   "pm.test('page description provider failure matches the public error contract', function () {",
-                  "  pm.expect(body).to.eql({",
-                  "    error: 'Error fetching descriptions for the provided page'",
-                  "  });",
+                  "  pm.expect(body.error).to.eql('Error fetching descriptions for the provided page');",
+                  "  pm.expect(body.code).to.eql('PAGE_DESCRIPTION_FETCH_FAILED');",
+                  "  pm.expect(body.requestId).to.be.a('string').and.not.empty;",
                   "});"
                 ]
               }
@@ -1129,9 +1129,10 @@
                   "const body = pm.response.json();",
                   "",
                   "pm.test('error matches contract', function () {",
-                  "  pm.expect(body).to.eql({",
-                  "    error: 'Missing required query parameter: url'",
-                  "  });",
+                  "  pm.expect(body.error).to.eql('Missing required query parameter: url');",
+                  "  pm.expect(body.code).to.eql('QUERY_VALIDATION_ERROR');",
+                  "  pm.expect(body.requestId).to.be.a('string').and.not.empty;",
+                  "  pm.expect(body.details).to.eql([{ field: 'url', issue: 'required' }]);",
                   "});"
                 ]
               }
@@ -1181,9 +1182,10 @@
                   "const body = pm.response.json();",
                   "",
                   "pm.test('error matches contract', function () {",
-                  "  pm.expect(body).to.eql({",
-                  "    error: 'Invalid URL format'",
-                  "  });",
+                  "  pm.expect(body.error).to.eql('Invalid URL format');",
+                  "  pm.expect(body.code).to.eql('INVALID_PAGE_URL');",
+                  "  pm.expect(body.requestId).to.be.a('string').and.not.empty;",
+                  "  pm.expect(body.details).to.eql([{ field: 'url', issue: 'invalid_url' }]);",
                   "});"
                 ]
               }
@@ -1233,9 +1235,10 @@
                   "const body = pm.response.json();",
                   "",
                   "pm.test('error matches contract', function () {",
-                  "  pm.expect(body).to.eql({",
-                  "    error: 'Missing required query parameters: image_source and model'",
-                  "  });",
+                  "  pm.expect(body.error).to.eql('Missing required query parameters: image_source and model');",
+                  "  pm.expect(body.code).to.eql('QUERY_VALIDATION_ERROR');",
+                  "  pm.expect(body.requestId).to.be.a('string').and.not.empty;",
+                  "  pm.expect(body.details).to.eql([{ field: 'image_source', issue: 'required' }]);",
                   "});"
                 ]
               }
@@ -1289,9 +1292,10 @@
                   "const body = pm.response.json();",
                   "",
                   "pm.test('error matches contract', function () {",
-                  "  pm.expect(body).to.eql({",
-                  "    error: 'Invalid image_source URL'",
-                  "  });",
+                  "  pm.expect(body.error).to.eql('Invalid image_source URL');",
+                  "  pm.expect(body.code).to.eql('INVALID_IMAGE_SOURCE_URL');",
+                  "  pm.expect(body.requestId).to.be.a('string').and.not.empty;",
+                  "  pm.expect(body.details).to.eql([{ field: 'image_source', issue: 'invalid_url' }]);",
                   "});"
                 ]
               }
@@ -1398,9 +1402,10 @@
                   "const body = pm.response.json();",
                   "",
                   "pm.test('error matches contract', function () {",
-                  "  pm.expect(body).to.eql({",
-                  "    error: 'Missing required query parameters: url and model'",
-                  "  });",
+                  "  pm.expect(body.error).to.eql('Missing required query parameters: url and model');",
+                  "  pm.expect(body.code).to.eql('QUERY_VALIDATION_ERROR');",
+                  "  pm.expect(body.requestId).to.be.a('string').and.not.empty;",
+                  "  pm.expect(body.details).to.eql([{ field: 'url', issue: 'required' }]);",
                   "});"
                 ]
               }
@@ -1454,9 +1459,10 @@
                   "const body = pm.response.json();",
                   "",
                   "pm.test('error matches contract', function () {",
-                  "  pm.expect(body).to.eql({",
-                  "    error: 'Invalid url parameter'",
-                  "  });",
+                  "  pm.expect(body.error).to.eql('Invalid url parameter');",
+                  "  pm.expect(body.code).to.eql('INVALID_PAGE_URL');",
+                  "  pm.expect(body.requestId).to.be.a('string').and.not.empty;",
+                  "  pm.expect(body.details).to.eql([{ field: 'url', issue: 'invalid_url' }]);",
                   "});"
                 ]
               }
@@ -1556,9 +1562,9 @@
                   "const body = pm.response.json();",
                   "",
                   "pm.test('404 fallback matches contract', function () {",
-                  "  pm.expect(body).to.eql({",
-                  "    error: 'Endpoint not found'",
-                  "  });",
+                  "  pm.expect(body.error).to.eql('Endpoint not found');",
+                  "  pm.expect(body.code).to.eql('ENDPOINT_NOT_FOUND');",
+                  "  pm.expect(body.requestId).to.be.a('string').and.not.empty;",
                   "});"
                 ]
               }

--- a/src/api/v1/controllers/descriptionController.js
+++ b/src/api/v1/controllers/descriptionController.js
@@ -1,5 +1,11 @@
 const { isValidUrl } = require('../../../utils/urlValidator');
 const { normalizeImageSource } = require('../../../utils/imageSource');
+const { ApiError } = require('../../../errors/ApiError');
+
+const buildRequiredQueryDetails = (fields) => fields.map((field) => ({
+  field,
+  issue: 'required',
+}));
 
 /**
  * Handles requests to generate alt-text descriptions for images.
@@ -26,6 +32,9 @@ class DescriptionController {
    *     summary: Returns a description for a given image
    *     description: Takes an image URL and sends it to the selected AI model
    *       to generate an alt-text description.
+   *     security:
+   *       - bearerAuth: []
+   *       - apiKeyAuth: []
    *     parameters:
    *       - name: image_source
    *         in: query
@@ -59,23 +68,44 @@ class DescriptionController {
    *                     example: https://developer.chrome.com/static/images/ai-homepage-card.png
    *       400:
    *         description: Missing or invalid parameters, or unsupported model
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ApiErrorResponse'
+   *       401:
+   *         description: Missing or invalid API authentication credentials
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ApiErrorResponse'
    *       500:
    *         description: Server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ApiErrorResponse'
    */
-  async describe(req, res) {
+  async describe(req, res, next) {
     const requestLogger = req.log ?? this.logger;
     const { image_source: rawImageSource, model } = req.query;
+    const missingFields = ['image_source', 'model'].filter((field) => !req.query[field]);
 
-    if (!rawImageSource || !model) {
-      return res.status(400).json({
-        error: 'Missing required query parameters: image_source and model',
-      });
+    if (missingFields.length > 0) {
+      return next(ApiError.badRequest({
+        message: 'Missing required query parameters: image_source and model',
+        code: 'QUERY_VALIDATION_ERROR',
+        details: buildRequiredQueryDetails(missingFields),
+      }));
     }
 
     const imageSource = normalizeImageSource(rawImageSource);
 
     if (!isValidUrl(imageSource)) {
-      return res.status(400).json({ error: 'Invalid image_source URL' });
+      return next(ApiError.badRequest({
+        message: 'Invalid image_source URL',
+        code: 'INVALID_IMAGE_SOURCE_URL',
+        details: [{ field: 'image_source', issue: 'invalid_url' }],
+      }));
     }
 
     requestLogger.info({ model, imageSource }, 'Description request');
@@ -87,12 +117,18 @@ class DescriptionController {
     } catch (error) {
       // factory.get() throws a user-facing error for unknown models
       if (error.message.startsWith('Unknown model')) {
-        return res.status(400).json({ error: error.message });
+        return next(ApiError.badRequest({
+          message: error.message,
+          code: 'UNKNOWN_MODEL',
+          details: [{ field: 'model', issue: 'unsupported_value' }],
+        }));
       }
-      requestLogger.error({ err: error, model, imageSource }, 'Error generating description');
-      return res.status(500).json({
-        error: 'Error fetching description for the provided image',
-      });
+
+      return next(ApiError.internal({
+        message: 'Error fetching description for the provided image',
+        code: 'DESCRIPTION_FETCH_FAILED',
+        cause: error,
+      }));
     }
   }
 
@@ -103,6 +139,9 @@ class DescriptionController {
    *     summary: Returns descriptions for images found on a page
    *     description: Scrapes a website, preserves duplicate image entries in page
    *       order, and reuses a single prediction per unique image URL.
+   *     security:
+   *       - bearerAuth: []
+   *       - apiKeyAuth: []
    *     parameters:
    *       - name: url
    *         in: query
@@ -123,23 +162,44 @@ class DescriptionController {
    *         description: OK
    *       400:
    *         description: Missing or invalid parameters, or unsupported model
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ApiErrorResponse'
+   *       401:
+   *         description: Missing or invalid API authentication credentials
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ApiErrorResponse'
    *       500:
    *         description: Server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ApiErrorResponse'
    */
-  async describePage(req, res) {
+  async describePage(req, res, next) {
     const requestLogger = req.log ?? this.logger;
     const { url: rawPageUrl, model } = req.query;
+    const missingFields = ['url', 'model'].filter((field) => !req.query[field]);
 
-    if (!rawPageUrl || !model) {
-      return res.status(400).json({
-        error: 'Missing required query parameters: url and model',
-      });
+    if (missingFields.length > 0) {
+      return next(ApiError.badRequest({
+        message: 'Missing required query parameters: url and model',
+        code: 'QUERY_VALIDATION_ERROR',
+        details: buildRequiredQueryDetails(missingFields),
+      }));
     }
 
     const pageUrl = decodeURIComponent(rawPageUrl);
 
     if (!isValidUrl(pageUrl)) {
-      return res.status(400).json({ error: 'Invalid url parameter' });
+      return next(ApiError.badRequest({
+        message: 'Invalid url parameter',
+        code: 'INVALID_PAGE_URL',
+        details: [{ field: 'url', issue: 'invalid_url' }],
+      }));
     }
 
     requestLogger.info({ model, pageUrl }, 'Page description request');
@@ -152,13 +212,18 @@ class DescriptionController {
       return res.json(result);
     } catch (error) {
       if (error.message.startsWith('Unknown model')) {
-        return res.status(400).json({ error: error.message });
+        return next(ApiError.badRequest({
+          message: error.message,
+          code: 'UNKNOWN_MODEL',
+          details: [{ field: 'model', issue: 'unsupported_value' }],
+        }));
       }
 
-      requestLogger.error({ err: error, model, pageUrl }, 'Error generating page descriptions');
-      return res.status(500).json({
-        error: 'Error fetching descriptions for the provided page',
-      });
+      return next(ApiError.internal({
+        message: 'Error fetching descriptions for the provided page',
+        code: 'PAGE_DESCRIPTION_FETCH_FAILED',
+        cause: error,
+      }));
     }
   }
 }

--- a/src/api/v1/controllers/scraperController.js
+++ b/src/api/v1/controllers/scraperController.js
@@ -1,4 +1,5 @@
 const { isValidUrl } = require('../../../utils/urlValidator');
+const { ApiError } = require('../../../errors/ApiError');
 
 /**
  * Handles requests to scrape images from a website.
@@ -22,6 +23,9 @@ class ScraperController {
    *   get:
    *     summary: Returns the list of images found in a website
    *     description: Visits the website, selects img elements, and returns their src URLs as JSON.
+   *     security:
+   *       - bearerAuth: []
+   *       - apiKeyAuth: []
    *     parameters:
    *       - name: url
    *         in: query
@@ -44,29 +48,53 @@ class ScraperController {
    *                     type: string
    *       400:
    *         description: Missing or invalid url parameter
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ApiErrorResponse'
+   *       401:
+   *         description: Missing or invalid API authentication credentials
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ApiErrorResponse'
    *       500:
    *         description: Server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ApiErrorResponse'
    */
-  async getImages(req, res) {
-    const requestLogger = req.log ?? this.logger;
+  async getImages(req, res, next) {
     const { url } = req.query;
 
     if (!url) {
-      return res.status(400).json({ error: 'Missing required query parameter: url' });
+      return next(ApiError.badRequest({
+        message: 'Missing required query parameter: url',
+        code: 'QUERY_VALIDATION_ERROR',
+        details: [{ field: 'url', issue: 'required' }],
+      }));
     }
 
     const decodedUrl = decodeURIComponent(url);
 
     if (!isValidUrl(decodedUrl)) {
-      return res.status(400).json({ error: 'Invalid URL format' });
+      return next(ApiError.badRequest({
+        message: 'Invalid URL format',
+        code: 'INVALID_PAGE_URL',
+        details: [{ field: 'url', issue: 'invalid_url' }],
+      }));
     }
 
     try {
       const result = await this.scraperService.getImages(decodedUrl);
       return res.json(result);
     } catch (error) {
-      requestLogger.error({ err: error, url: decodedUrl }, 'Error scraping images');
-      return res.status(500).json({ error: 'Error fetching images from the provided URL' });
+      return next(ApiError.internal({
+        message: 'Error fetching images from the provided URL',
+        code: 'SCRAPE_FETCH_FAILED',
+        cause: error,
+      }));
     }
   }
 }

--- a/src/api/v1/middleware/access-control.js
+++ b/src/api/v1/middleware/access-control.js
@@ -1,0 +1,70 @@
+const { ApiError } = require('../../../errors/ApiError');
+
+const PUBLIC_PATHS = new Set([
+  '/api',
+  '/api/',
+  '/api/v1',
+  '/api/ping',
+  '/api/v1/ping',
+  '/api/health',
+  '/api/v1/health',
+]);
+
+const isApiPath = (path = '') => path === '/api' || path.startsWith('/api/');
+
+const extractBearerToken = (authorizationHeader) => {
+  if (typeof authorizationHeader !== 'string') {
+    return null;
+  }
+
+  const [scheme, token, ...rest] = authorizationHeader.trim().split(/\s+/);
+  if (!scheme || !token || rest.length > 0 || !/^Bearer$/i.test(scheme)) {
+    return null;
+  }
+
+  return token;
+};
+
+const extractApiAuthToken = (req) => {
+  const apiKey = req.get('x-api-key');
+  if (typeof apiKey === 'string' && apiKey.trim()) {
+    return apiKey.trim();
+  }
+
+  return extractBearerToken(req.get('authorization'));
+};
+
+const isPublicPath = (path = '') => path.startsWith('/api-docs')
+  || PUBLIC_PATHS.has(path);
+
+/**
+ * @param {object} authConfig
+ * @param {string[]} [authConfig.tokens]
+ * @returns {Function}
+ */
+const createAccessControlMiddleware = (authConfig = {}) => {
+  const allowedTokens = new Set(authConfig.tokens ?? []);
+
+  return (req, res, next) => {
+    if (allowedTokens.size === 0 || !isApiPath(req.path) || isPublicPath(req.path)) {
+      return next();
+    }
+
+    const token = extractApiAuthToken(req);
+    if (token && allowedTokens.has(token)) {
+      return next();
+    }
+
+    return next(ApiError.unauthorized({
+      message: 'Missing or invalid API authentication credentials',
+      code: 'API_AUTHENTICATION_FAILED',
+    }));
+  };
+};
+
+module.exports = {
+  createAccessControlMiddleware,
+  extractApiAuthToken,
+  isApiPath,
+  isPublicPath,
+};

--- a/src/api/v1/middleware/error-handler.js
+++ b/src/api/v1/middleware/error-handler.js
@@ -1,0 +1,49 @@
+const { ApiError, buildErrorResponse } = require('../../../errors/ApiError');
+
+/**
+ * Wraps an async route handler so rejected promises reach Express error handling.
+ *
+ * @param {Function} handler
+ * @returns {Function}
+ */
+const asyncHandler = (handler) => (req, res, next) => Promise
+  .resolve(handler(req, res, next))
+  .catch(next);
+
+/**
+ * @param {object} req
+ * @param {object} res
+ * @param {Function} next
+ * @returns {void}
+ */
+const notFoundHandler = (req, res, next) => {
+  next(ApiError.notFound({
+    message: 'Endpoint not found',
+    code: 'ENDPOINT_NOT_FOUND',
+  }));
+};
+
+/**
+ * @param {Error} error
+ * @param {object} req
+ * @param {object} res
+ * @param {Function} next
+ * @returns {object|void}
+ */
+const errorHandler = (error, req, res, next) => {
+  if (res.headersSent) {
+    return next(error);
+  }
+
+  const apiError = ApiError.from(error);
+
+  return res
+    .status(apiError.statusCode)
+    .json(buildErrorResponse(apiError, req.id));
+};
+
+module.exports = {
+  asyncHandler,
+  errorHandler,
+  notFoundHandler,
+};

--- a/src/api/v1/routes/api.js
+++ b/src/api/v1/routes/api.js
@@ -1,4 +1,8 @@
 const express = require('express');
+const {
+  asyncHandler,
+  notFoundHandler,
+} = require('../middleware/error-handler');
 
 /**
  * Registers all API routes onto an Express router.
@@ -21,23 +25,21 @@ module.exports = ({ health, scraper, description }, logger) => {
 
   apiRouter.get(
     ['/api/scraper/images', '/api/v1/scraper/images'],
-    scraper.getImages,
+    asyncHandler(scraper.getImages),
   );
 
   apiRouter.get(
     ['/api/accessibility/description', '/api/v1/accessibility/description'],
-    description.describe,
+    asyncHandler(description.describe),
   );
 
   apiRouter.get(
     ['/api/accessibility/descriptions', '/api/v1/accessibility/descriptions'],
-    description.describePage,
+    asyncHandler(description.describePage),
   );
 
   // 404 fallback
-  apiRouter.use((req, res) => {
-    res.status(404).json({ error: 'Endpoint not found' });
-  });
+  apiRouter.use(notFoundHandler);
 
   logger.info('API routes loaded');
 

--- a/src/createApp.js
+++ b/src/createApp.js
@@ -17,6 +17,10 @@ const healthController = require('./api/v1/controllers/healthController');
 const ScraperController = require('./api/v1/controllers/scraperController');
 const DescriptionController = require('./api/v1/controllers/descriptionController');
 const { applyMiddlewares } = require('./utils/applyBaseMiddleware');
+const {
+  createAccessControlMiddleware,
+} = require('./api/v1/middleware/access-control');
+const { errorHandler } = require('./api/v1/middleware/error-handler');
 const createRequestFilter = require('./api/v1/middleware/request-filter');
 const { createRouter } = require('./utils/createRouter');
 const buildApiRouter = require('./api/v1/routes/api');
@@ -130,6 +134,7 @@ const createApp = ({
   applyMiddlewares(app, requestLogger);
   const { loadRequestFilter } = createRequestFilter(appLogger);
   loadRequestFilter(app);
+  app.use(createAccessControlMiddleware(config.auth));
 
   const apiRouter = buildApiRouter({
     health,
@@ -138,6 +143,7 @@ const createApp = ({
   }, appLogger);
   const mainRouter = createRouter(appLogger, apiRouter);
   app.use(mainRouter);
+  app.use(errorHandler);
 
   return {
     app,

--- a/src/errors/ApiError.js
+++ b/src/errors/ApiError.js
@@ -1,0 +1,133 @@
+class ApiError extends Error {
+  /**
+   * @param {object} params
+   * @param {number} params.statusCode
+   * @param {string} params.code
+   * @param {string} params.message
+   * @param {Array<object>} [params.details]
+   * @param {object} [params.cause]
+   */
+  constructor({
+    statusCode,
+    code,
+    message,
+    details,
+    cause,
+  }) {
+    super(message, cause ? { cause } : undefined);
+    this.name = 'ApiError';
+    this.statusCode = statusCode;
+    this.code = code;
+
+    if (details !== undefined) {
+      this.details = details;
+    }
+  }
+
+  /**
+   * @param {object} params
+   * @param {string} params.message
+   * @param {string} params.code
+   * @param {Array<object>} [params.details]
+   * @returns {ApiError}
+   */
+  static badRequest({ message, code, details }) {
+    return new ApiError({
+      statusCode: 400,
+      code,
+      message,
+      details,
+    });
+  }
+
+  /**
+   * @param {object} params
+   * @param {string} params.message
+   * @param {string} params.code
+   * @returns {ApiError}
+   */
+  static unauthorized({ message, code }) {
+    return new ApiError({
+      statusCode: 401,
+      code,
+      message,
+    });
+  }
+
+  /**
+   * @param {object} params
+   * @param {string} params.message
+   * @param {string} params.code
+   * @returns {ApiError}
+   */
+  static notFound({ message, code }) {
+    return new ApiError({
+      statusCode: 404,
+      code,
+      message,
+    });
+  }
+
+  /**
+   * @param {object} params
+   * @param {string} params.message
+   * @param {string} params.code
+   * @returns {ApiError}
+   */
+  static tooManyRequests({ message, code }) {
+    return new ApiError({
+      statusCode: 429,
+      code,
+      message,
+    });
+  }
+
+  /**
+   * @param {object} params
+   * @param {string} params.message
+   * @param {string} params.code
+   * @param {object} [params.cause]
+   * @returns {ApiError}
+   */
+  static internal({ message, code, cause }) {
+    return new ApiError({
+      statusCode: 500,
+      code,
+      message,
+      cause,
+    });
+  }
+
+  /**
+   * @param {Error|ApiError} error
+   * @returns {ApiError}
+   */
+  static from(error) {
+    if (error instanceof ApiError) {
+      return error;
+    }
+
+    return ApiError.internal({
+      message: 'Internal server error',
+      code: 'INTERNAL_SERVER_ERROR',
+      cause: error,
+    });
+  }
+}
+
+/**
+ * @param {ApiError} error
+ * @param {string|undefined} requestId
+ * @returns {object}
+ */
+const buildErrorResponse = (error, requestId) => ({
+  error: error.message,
+  code: error.code,
+  ...(requestId ? { requestId } : {}),
+  ...(error.details ? { details: error.details } : {}),
+});
+
+module.exports = {
+  ApiError,
+  buildErrorResponse,
+};

--- a/src/utils/validateEnvVars.js
+++ b/src/utils/validateEnvVars.js
@@ -1,5 +1,16 @@
 const Joi = require('joi');
 
+const parseAuthTokens = (value) => {
+  if (typeof value !== 'string') {
+    return [];
+  }
+
+  return value
+    .split(',')
+    .map((token) => token.trim())
+    .filter(Boolean);
+};
+
 const envVarsSchema = Joi.object({
   NODE_ENV: Joi.string()
     .valid('development', 'production', 'test')
@@ -57,6 +68,9 @@ const envVarsSchema = Joi.object({
   RATE_LIMIT_WINDOW_MS: Joi.number().optional(),
   RATE_LIMIT_MAX: Joi.number().optional(),
 
+  // Optional API access control
+  API_AUTH_TOKENS: Joi.string().optional(),
+
   // Swagger
   SWAGGER_DEV_URL: Joi.string().uri().optional(),
   SWAGGER_PROD_URL: Joi.string().uri().optional(),
@@ -87,6 +101,16 @@ const validateEnvVars = () => {
     throw new Error(
       'Config validation error: ACV_API_ENDPOINT and either ACV_SUBSCRIPTION_KEY '
         + 'or ACV_API_KEY must be set together to enable the Azure provider',
+    );
+  }
+
+  if (
+    process.env.API_AUTH_TOKENS !== undefined
+    && parseAuthTokens(process.env.API_AUTH_TOKENS).length === 0
+  ) {
+    throw new Error(
+      'Config validation error: API_AUTH_TOKENS must contain at least one '
+        + 'non-empty token when set',
     );
   }
 

--- a/tests/integration/api.test.js
+++ b/tests/integration/api.test.js
@@ -4,6 +4,8 @@ const { createApp } = require('../../src/createApp');
 const ImageDescriberFactory = require('../../src/services/ImageDescriberFactory');
 const config = require('../../config');
 
+const TEST_REQUEST_ID = 'test-request-id';
+
 const createAppLogger = () => ({
   info: jest.fn(),
   debug: jest.fn(),
@@ -14,7 +16,9 @@ const createAppLogger = () => ({
 
 const createRequestLogger = () => {
   const requestLogger = jest.fn((req, res, next) => {
+    req.id = TEST_REQUEST_ID;
     req.log = requestLogger.logger;
+    res.setHeader('X-Request-Id', TEST_REQUEST_ID);
     next();
   });
 
@@ -35,6 +39,7 @@ const secureGet = (app, path) => request(app)
 const buildTestApp = ({
   scraperService = {},
   imageDescriberFactory = new ImageDescriberFactory(),
+  config: appConfig,
 } = {}) => {
   const appLogger = createAppLogger();
   const requestLogger = createRequestLogger();
@@ -43,6 +48,7 @@ const buildTestApp = ({
     requestLogger,
     scraperService,
     imageDescriberFactory,
+    config: appConfig,
   });
 
   return { app, appLogger, requestLogger };
@@ -120,6 +126,12 @@ describe('GET /api/scraper/images', () => {
     const res = await secureGet(app, '/api/scraper/images');
 
     expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      error: 'Missing required query parameter: url',
+      code: 'QUERY_VALIDATION_ERROR',
+      requestId: TEST_REQUEST_ID,
+      details: [{ field: 'url', issue: 'required' }],
+    });
   });
 
   it('returns image list on success', async () => {
@@ -151,6 +163,11 @@ describe('GET /api/scraper/images', () => {
     );
 
     expect(res.status).toBe(500);
+    expect(res.body).toMatchObject({
+      error: 'Error fetching images from the provided URL',
+      code: 'SCRAPE_FETCH_FAILED',
+      requestId: TEST_REQUEST_ID,
+    });
   });
 });
 
@@ -164,6 +181,12 @@ describe('GET /api/accessibility/description', () => {
     );
 
     expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      error: 'Missing required query parameters: image_source and model',
+      code: 'QUERY_VALIDATION_ERROR',
+      requestId: TEST_REQUEST_ID,
+      details: [{ field: 'image_source', issue: 'required' }],
+    });
   });
 
   it('returns 400 for an unknown model', async () => {
@@ -181,6 +204,8 @@ describe('GET /api/accessibility/description', () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/Unknown model/);
+    expect(res.body.code).toBe('UNKNOWN_MODEL');
+    expect(res.body.requestId).toBe(TEST_REQUEST_ID);
   });
 
   it('returns description array on success', async () => {
@@ -304,6 +329,12 @@ describe('GET /api/accessibility/descriptions', () => {
     );
 
     expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({
+      error: 'Missing required query parameters: url and model',
+      code: 'QUERY_VALIDATION_ERROR',
+      requestId: TEST_REQUEST_ID,
+      details: [{ field: 'url', issue: 'required' }],
+    });
   });
 
   it('preserves duplicate entries while reusing one prediction per unique URL', async () => {
@@ -426,5 +457,96 @@ describe('unknown routes', () => {
 
     expect(res.status).toBe(404);
     expect(res.body.error).toBe('Endpoint not found');
+    expect(res.body.code).toBe('ENDPOINT_NOT_FOUND');
+    expect(res.body.requestId).toBe(TEST_REQUEST_ID);
+  });
+});
+
+describe('API access control', () => {
+  const authConfig = {
+    auth: {
+      tokens: ['test-api-token'],
+    },
+    replicate: {},
+    azure: {},
+    scraper: {
+      requestTimeoutMs: 1500,
+      maxRedirects: 4,
+      maxContentLengthBytes: 2048,
+    },
+  };
+
+  it('allows public health endpoints without authentication', async () => {
+    const { app } = buildTestApp({ config: authConfig });
+
+    const res = await secureGet(app, '/api/health');
+
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects protected endpoints without authentication', async () => {
+    const { app } = buildTestApp({ config: authConfig });
+
+    const res = await secureGet(
+      app,
+      `/api/accessibility/description?image_source=${
+        encodeURIComponent('https://example.com/img.jpg')
+      }&model=clip`,
+    );
+
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({
+      error: 'Missing or invalid API authentication credentials',
+      code: 'API_AUTHENTICATION_FAILED',
+      requestId: TEST_REQUEST_ID,
+    });
+  });
+
+  it('accepts X-API-Key authentication on protected endpoints', async () => {
+    const factory = new ImageDescriberFactory().register('clip', {
+      describeImage: jest.fn().mockResolvedValue({
+        description: 'authenticated description',
+        imageUrl: 'https://example.com/img.jpg',
+      }),
+    });
+    const { app } = buildTestApp({
+      config: authConfig,
+      imageDescriberFactory: factory,
+    });
+
+    const res = await secureGet(
+      app,
+      `/api/accessibility/description?image_source=${
+        encodeURIComponent('https://example.com/img.jpg')
+      }&model=clip`,
+    ).set('X-API-Key', 'test-api-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{
+      description: 'authenticated description',
+      imageUrl: 'https://example.com/img.jpg',
+    }]);
+  });
+
+  it('accepts Bearer authentication on protected endpoints', async () => {
+    const scraperService = {
+      getImages: jest.fn().mockResolvedValue({
+        imageSources: ['https://example.com/a.jpg'],
+      }),
+    };
+    const { app } = buildTestApp({
+      config: authConfig,
+      scraperService,
+    });
+
+    const res = await secureGet(
+      app,
+      `/api/scraper/images?url=${encodeURIComponent('https://example.com')}`,
+    ).set('Authorization', 'Bearer test-api-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      imageSources: ['https://example.com/a.jpg'],
+    });
   });
 });

--- a/tests/unit/config/index.test.js
+++ b/tests/unit/config/index.test.js
@@ -37,6 +37,7 @@ describe('config', () => {
         'SCRAPER_MAX_CONTENT_LENGTH_BYTES',
         'RATE_LIMIT_WINDOW_MS',
         'RATE_LIMIT_MAX',
+        'API_AUTH_TOKENS',
       ],
     });
 
@@ -57,6 +58,9 @@ describe('config', () => {
     expect(config.rateLimit).toEqual({
       windowMs: 15 * 60 * 1000,
       max: 100,
+    });
+    expect(config.auth).toEqual({
+      tokens: [],
     });
     expect(config.swagger).toEqual({
       devServerUrl: 'https://localhost:8443',
@@ -79,6 +83,7 @@ describe('config', () => {
         SCRAPER_MAX_CONTENT_LENGTH_BYTES: '4096',
         RATE_LIMIT_WINDOW_MS: '30000',
         RATE_LIMIT_MAX: '50',
+        API_AUTH_TOKENS: ' token-a,token-b , token-c ',
       },
     });
 
@@ -99,6 +104,9 @@ describe('config', () => {
     expect(config.rateLimit).toEqual({
       windowMs: 30000,
       max: 50,
+    });
+    expect(config.auth).toEqual({
+      tokens: ['token-a', 'token-b', 'token-c'],
     });
   });
 

--- a/tests/unit/config/swagger.test.js
+++ b/tests/unit/config/swagger.test.js
@@ -115,4 +115,34 @@ describe('config/swagger', () => {
     expect(serializedSpec).not.toContain('example.com');
     expect(serializedSpec).not.toContain('neymarques.com');
   });
+
+  it('publishes reusable auth schemes and protects non-health endpoints', () => {
+    const swaggerSpec = loadParsedSwaggerSpec({
+      env: 'production',
+      devServerUrl: 'https://localhost:8443',
+      prodServerUrl: 'https://wcag.qcraft.com.br',
+    });
+
+    expect(swaggerSpec.components.securitySchemes).toEqual({
+      bearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'API token',
+      },
+      apiKeyAuth: {
+        type: 'apiKey',
+        in: 'header',
+        name: 'X-API-Key',
+      },
+    });
+    expect(swaggerSpec.paths['/api/health'].get.security).toBeUndefined();
+    expect(swaggerSpec.paths['/api/scraper/images'].get.security).toEqual([
+      { bearerAuth: [] },
+      { apiKeyAuth: [] },
+    ]);
+    expect(swaggerSpec.paths['/api/accessibility/description'].get.responses['401']
+      .content['application/json'].schema).toEqual({
+      $ref: '#/components/schemas/ApiErrorResponse',
+    });
+  });
 });

--- a/tests/unit/controllers/descriptionController.test.js
+++ b/tests/unit/controllers/descriptionController.test.js
@@ -1,4 +1,5 @@
 const DescriptionController = require('../../../src/api/v1/controllers/descriptionController');
+const { ApiError } = require('../../../src/errors/ApiError');
 const ImageDescriberFactory = require('../../../src/services/ImageDescriberFactory');
 
 const mockLogger = {
@@ -15,57 +16,71 @@ const createController = (imageDescriberFactory, pageDescriptionService = {
   logger: mockLogger,
 });
 
-const makeResMock = () => {
-  const res = {};
-  res.status = jest.fn().mockReturnValue(res);
-  res.json = jest.fn().mockReturnValue(res);
-  return res;
-};
+const makeResMock = () => ({
+  json: jest.fn(),
+});
 
 describe('DescriptionController.describe', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('returns 400 when image_source is missing', async () => {
-    const factory = new ImageDescriberFactory();
-    const controller = createController(factory);
+  it('forwards a validation error when image_source is missing', async () => {
+    const controller = createController(new ImageDescriberFactory());
     const req = { query: { model: 'clip' } };
     const res = makeResMock();
+    const next = jest.fn();
 
-    await controller.describe(req, res);
+    await controller.describe(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+    expect(next.mock.calls[0][0]).toMatchObject({
+      statusCode: 400,
+      code: 'QUERY_VALIDATION_ERROR',
+      message: 'Missing required query parameters: image_source and model',
+      details: [{ field: 'image_source', issue: 'required' }],
+    });
   });
 
-  it('returns 400 when model is missing', async () => {
-    const factory = new ImageDescriberFactory();
-    const controller = createController(factory);
-    const req = { query: { image_source: encodeURIComponent('https://example.com/img.jpg') } };
+  it('forwards a validation error when model is missing', async () => {
+    const controller = createController(new ImageDescriberFactory());
+    const req = {
+      query: { image_source: encodeURIComponent('https://example.com/img.jpg') },
+    };
     const res = makeResMock();
+    const next = jest.fn();
 
-    await controller.describe(req, res);
+    await controller.describe(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+    expect(next.mock.calls[0][0]).toMatchObject({
+      statusCode: 400,
+      code: 'QUERY_VALIDATION_ERROR',
+      details: [{ field: 'model', issue: 'required' }],
+    });
   });
 
-  it('returns 400 for an invalid image_source URL', async () => {
-    const factory = new ImageDescriberFactory();
-    const controller = createController(factory);
+  it('forwards a validation error for an invalid image_source URL', async () => {
+    const controller = createController(new ImageDescriberFactory());
     const req = { query: { image_source: 'not-a-url', model: 'clip' } };
     const res = makeResMock();
+    const next = jest.fn();
 
-    await controller.describe(req, res);
+    await controller.describe(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid image_source URL' });
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+    expect(next.mock.calls[0][0]).toMatchObject({
+      statusCode: 400,
+      code: 'INVALID_IMAGE_SOURCE_URL',
+      message: 'Invalid image_source URL',
+      details: [{ field: 'image_source', issue: 'invalid_url' }],
+    });
   });
 
-  it('returns 400 for an unknown model', async () => {
-    const factory = new ImageDescriberFactory().register('clip', {
+  it('forwards a validation error for an unknown model', async () => {
+    const controller = createController(new ImageDescriberFactory().register('clip', {
       describeImage: jest.fn(),
-    });
-    const controller = createController(factory);
+    }));
     const req = {
       query: {
         image_source: encodeURIComponent('https://example.com/img.jpg'),
@@ -73,64 +88,75 @@ describe('DescriptionController.describe', () => {
       },
     };
     const res = makeResMock();
+    const next = jest.fn();
 
-    await controller.describe(req, res);
+    await controller.describe(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json.mock.calls[0][0].error).toMatch(/Unknown model/);
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+    expect(next.mock.calls[0][0]).toMatchObject({
+      statusCode: 400,
+      code: 'UNKNOWN_MODEL',
+      details: [{ field: 'model', issue: 'unsupported_value' }],
+    });
+    expect(next.mock.calls[0][0].message).toMatch(/Unknown model/);
   });
 
-  it('returns description array on success', async () => {
+  it('returns the description array on success', async () => {
     const mockDescriber = {
       describeImage: jest.fn().mockResolvedValue({
         description: 'a sunset over the mountains',
         imageUrl: 'https://example.com/img.jpg',
       }),
     };
-    const factory = new ImageDescriberFactory().register('clip', mockDescriber);
-    const controller = createController(factory);
+    const controller = createController(
+      new ImageDescriberFactory().register('clip', mockDescriber),
+    );
     const req = {
       query: {
         image_source: encodeURIComponent('https://example.com/img.jpg'),
         model: 'clip',
       },
+      log: mockLogger,
     };
     const res = makeResMock();
+    const next = jest.fn();
 
-    await controller.describe(req, res);
+    await controller.describe(req, res, next);
 
     expect(res.json).toHaveBeenCalledWith([{
       description: 'a sunset over the mountains',
       imageUrl: 'https://example.com/img.jpg',
     }]);
+    expect(next).not.toHaveBeenCalled();
   });
 
-  it('returns 500 when describer throws a non-model error', async () => {
+  it('forwards an internal error when the describer fails', async () => {
     const error = new Error('API timeout');
     const mockDescriber = {
       describeImage: jest.fn().mockRejectedValue(error),
     };
-    const factory = new ImageDescriberFactory().register('clip', mockDescriber);
-    const controller = createController(factory);
+    const controller = createController(
+      new ImageDescriberFactory().register('clip', mockDescriber),
+    );
     const req = {
       query: {
         image_source: encodeURIComponent('https://example.com/img.jpg'),
         model: 'clip',
       },
+      log: mockLogger,
     };
     const res = makeResMock();
+    const next = jest.fn();
 
-    await controller.describe(req, res);
+    await controller.describe(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({
-      error: 'Error fetching description for the provided image',
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+    expect(next.mock.calls[0][0]).toMatchObject({
+      statusCode: 500,
+      code: 'DESCRIPTION_FETCH_FAILED',
+      message: 'Error fetching description for the provided image',
+      cause: error,
     });
-    expect(mockLogger.error).toHaveBeenCalledWith(expect.objectContaining({
-      err: error,
-      model: 'clip',
-      imageSource: 'https://example.com/img.jpg',
-    }), 'Error generating description');
   });
 });
 
@@ -139,31 +165,41 @@ describe('DescriptionController.describePage', () => {
     jest.clearAllMocks();
   });
 
-  it('returns 400 when url is missing', async () => {
+  it('forwards a validation error when url is missing', async () => {
     const controller = createController(new ImageDescriberFactory());
     const req = { query: { model: 'clip' } };
     const res = makeResMock();
+    const next = jest.fn();
 
-    await controller.describePage(req, res);
+    await controller.describePage(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({
-      error: 'Missing required query parameters: url and model',
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+    expect(next.mock.calls[0][0]).toMatchObject({
+      statusCode: 400,
+      code: 'QUERY_VALIDATION_ERROR',
+      message: 'Missing required query parameters: url and model',
+      details: [{ field: 'url', issue: 'required' }],
     });
   });
 
-  it('returns 400 when url is invalid', async () => {
+  it('forwards a validation error when url is invalid', async () => {
     const controller = createController(new ImageDescriberFactory());
     const req = { query: { url: 'not-a-url', model: 'clip' } };
     const res = makeResMock();
+    const next = jest.fn();
 
-    await controller.describePage(req, res);
+    await controller.describePage(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid url parameter' });
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+    expect(next.mock.calls[0][0]).toMatchObject({
+      statusCode: 400,
+      code: 'INVALID_PAGE_URL',
+      message: 'Invalid url parameter',
+      details: [{ field: 'url', issue: 'invalid_url' }],
+    });
   });
 
-  it('returns 400 for an unknown model', async () => {
+  it('forwards a validation error for an unknown model', async () => {
     const controller = createController(
       new ImageDescriberFactory(),
       { describePage: jest.fn().mockRejectedValue(new Error('Unknown model: clip')) },
@@ -175,11 +211,16 @@ describe('DescriptionController.describePage', () => {
       },
     };
     const res = makeResMock();
+    const next = jest.fn();
 
-    await controller.describePage(req, res);
+    await controller.describePage(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Unknown model: clip' });
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+    expect(next.mock.calls[0][0]).toMatchObject({
+      statusCode: 400,
+      code: 'UNKNOWN_MODEL',
+      message: 'Unknown model: clip',
+    });
   });
 
   it('returns ordered descriptions on success', async () => {
@@ -215,19 +256,22 @@ describe('DescriptionController.describePage', () => {
         url: encodeURIComponent('https://example.com/page'),
         model: 'clip',
       },
+      log: mockLogger,
     };
     const res = makeResMock();
+    const next = jest.fn();
 
-    await controller.describePage(req, res);
+    await controller.describePage(req, res, next);
 
     expect(pageDescriptionService.describePage).toHaveBeenCalledWith({
       pageUrl: 'https://example.com/page',
       model: 'clip',
     });
     expect(res.json).toHaveBeenCalledWith(expected);
+    expect(next).not.toHaveBeenCalled();
   });
 
-  it('returns 500 when the page orchestration fails', async () => {
+  it('forwards an internal error when page orchestration fails', async () => {
     const error = new Error('network error');
     const controller = createController(
       new ImageDescriberFactory(),
@@ -238,19 +282,19 @@ describe('DescriptionController.describePage', () => {
         url: encodeURIComponent('https://example.com/page'),
         model: 'clip',
       },
+      log: mockLogger,
     };
     const res = makeResMock();
+    const next = jest.fn();
 
-    await controller.describePage(req, res);
+    await controller.describePage(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({
-      error: 'Error fetching descriptions for the provided page',
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+    expect(next.mock.calls[0][0]).toMatchObject({
+      statusCode: 500,
+      code: 'PAGE_DESCRIPTION_FETCH_FAILED',
+      message: 'Error fetching descriptions for the provided page',
+      cause: error,
     });
-    expect(mockLogger.error).toHaveBeenCalledWith(expect.objectContaining({
-      err: error,
-      model: 'clip',
-      pageUrl: 'https://example.com/page',
-    }), 'Error generating page descriptions');
   });
 });

--- a/tests/unit/controllers/scraperController.test.js
+++ b/tests/unit/controllers/scraperController.test.js
@@ -1,4 +1,5 @@
 const ScraperController = require('../../../src/api/v1/controllers/scraperController');
+const { ApiError } = require('../../../src/errors/ApiError');
 
 const mockLogger = {
   info: jest.fn(),
@@ -6,40 +7,47 @@ const mockLogger = {
   error: jest.fn(),
 };
 
-const makeResMock = () => {
-  const res = {};
-  res.status = jest.fn().mockReturnValue(res);
-  res.json = jest.fn().mockReturnValue(res);
-  return res;
-};
+const makeResMock = () => ({
+  json: jest.fn(),
+});
 
 describe('ScraperController.getImages', () => {
-  it('returns 400 when url param is missing', async () => {
+  it('forwards a validation error when url is missing', async () => {
     const controller = new ScraperController({
       scraperService: {},
       logger: mockLogger,
     });
     const req = { query: {} };
     const res = makeResMock();
+    const next = jest.fn();
 
-    await controller.getImages(req, res);
+    await controller.getImages(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Missing required query parameter: url' });
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+    expect(next.mock.calls[0][0]).toMatchObject({
+      statusCode: 400,
+      code: 'QUERY_VALIDATION_ERROR',
+      details: [{ field: 'url', issue: 'required' }],
+    });
   });
 
-  it('returns 400 for an invalid URL', async () => {
+  it('forwards a validation error for an invalid URL', async () => {
     const controller = new ScraperController({
       scraperService: {},
       logger: mockLogger,
     });
     const req = { query: { url: 'not-a-url' } };
     const res = makeResMock();
+    const next = jest.fn();
 
-    await controller.getImages(req, res);
+    await controller.getImages(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid URL format' });
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+    expect(next.mock.calls[0][0]).toMatchObject({
+      statusCode: 400,
+      code: 'INVALID_PAGE_URL',
+      message: 'Invalid URL format',
+    });
   });
 
   it('returns scraped images on success', async () => {
@@ -52,13 +60,15 @@ describe('ScraperController.getImages', () => {
     });
     const req = { query: { url: encodeURIComponent('https://example.com') } };
     const res = makeResMock();
+    const next = jest.fn();
 
-    await controller.getImages(req, res);
+    await controller.getImages(req, res, next);
 
     expect(res.json).toHaveBeenCalledWith({ imageSources: ['https://example.com/a.jpg'] });
+    expect(next).not.toHaveBeenCalled();
   });
 
-  it('returns 500 when scraper service throws', async () => {
+  it('forwards an internal error when the scraper service fails', async () => {
     const mockScraperService = {
       getImages: jest.fn().mockRejectedValue(new Error('fetch failed')),
     };
@@ -68,12 +78,15 @@ describe('ScraperController.getImages', () => {
     });
     const req = { query: { url: encodeURIComponent('https://example.com') } };
     const res = makeResMock();
+    const next = jest.fn();
 
-    await controller.getImages(req, res);
+    await controller.getImages(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({
-      error: 'Error fetching images from the provided URL',
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+    expect(next.mock.calls[0][0]).toMatchObject({
+      statusCode: 500,
+      code: 'SCRAPE_FETCH_FAILED',
+      message: 'Error fetching images from the provided URL',
     });
   });
 });

--- a/tests/unit/middleware/accessControl.test.js
+++ b/tests/unit/middleware/accessControl.test.js
@@ -1,0 +1,97 @@
+const {
+  createAccessControlMiddleware,
+  extractApiAuthToken,
+  isApiPath,
+  isPublicPath,
+} = require('../../../src/api/v1/middleware/access-control');
+const { ApiError } = require('../../../src/errors/ApiError');
+
+const makeRequest = ({
+  path = '/api/accessibility/description',
+  headers = {},
+} = {}) => ({
+  path,
+  get: (name) => headers[name.toLowerCase()] ?? null,
+});
+
+describe('access-control middleware', () => {
+  it('treats docs and health endpoints as public', () => {
+    expect(isApiPath('/')).toBe(false);
+    expect(isApiPath('/api/v1/accessibility/description')).toBe(true);
+    expect(isPublicPath('/api-docs')).toBe(true);
+    expect(isPublicPath('/api-docs/swagger-ui-init.js')).toBe(true);
+    expect(isPublicPath('/api/health')).toBe(true);
+    expect(isPublicPath('/api/v1/ping')).toBe(true);
+    expect(isPublicPath('/api/accessibility/description')).toBe(false);
+  });
+
+  it('extracts tokens from X-API-Key first', () => {
+    const req = makeRequest({
+      headers: {
+        'x-api-key': 'token-a',
+        authorization: 'Bearer token-b',
+      },
+    });
+
+    expect(extractApiAuthToken(req)).toBe('token-a');
+  });
+
+  it('extracts tokens from Bearer authorization', () => {
+    const req = makeRequest({
+      headers: {
+        authorization: 'Bearer token-a',
+      },
+    });
+
+    expect(extractApiAuthToken(req)).toBe('token-a');
+  });
+
+  it('allows requests through when auth is not configured', () => {
+    const middleware = createAccessControlMiddleware();
+    const req = makeRequest();
+    const next = jest.fn();
+
+    middleware(req, {}, next);
+
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('allows public requests through when auth is configured', () => {
+    const middleware = createAccessControlMiddleware({ tokens: ['token-a'] });
+    const req = makeRequest({ path: '/api/health' });
+    const next = jest.fn();
+
+    middleware(req, {}, next);
+
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('rejects protected requests without a valid token', () => {
+    const middleware = createAccessControlMiddleware({ tokens: ['token-a'] });
+    const req = makeRequest();
+    const next = jest.fn();
+
+    middleware(req, {}, next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+    expect(next.mock.calls[0][0]).toMatchObject({
+      statusCode: 401,
+      code: 'API_AUTHENTICATION_FAILED',
+      message: 'Missing or invalid API authentication credentials',
+    });
+  });
+
+  it('allows protected requests with a matching token', () => {
+    const middleware = createAccessControlMiddleware({ tokens: ['token-a'] });
+    const req = makeRequest({
+      headers: {
+        authorization: 'Bearer token-a',
+      },
+    });
+    const next = jest.fn();
+
+    middleware(req, {}, next);
+
+    expect(next).toHaveBeenCalledWith();
+  });
+});

--- a/tests/unit/middleware/errorHandler.test.js
+++ b/tests/unit/middleware/errorHandler.test.js
@@ -1,0 +1,77 @@
+const {
+  asyncHandler,
+  errorHandler,
+  notFoundHandler,
+} = require('../../../src/api/v1/middleware/error-handler');
+const { ApiError } = require('../../../src/errors/ApiError');
+
+describe('error-handler middleware', () => {
+  it('wraps async handlers and forwards rejected promises', async () => {
+    const error = new Error('boom');
+    const handler = asyncHandler(async () => {
+      throw error;
+    });
+    const next = jest.fn();
+
+    await handler({}, {}, next);
+
+    expect(next).toHaveBeenCalledWith(error);
+  });
+
+  it('converts the 404 fallback into a not-found ApiError', () => {
+    const next = jest.fn();
+
+    notFoundHandler({}, {}, next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+    expect(next.mock.calls[0][0]).toMatchObject({
+      statusCode: 404,
+      code: 'ENDPOINT_NOT_FOUND',
+      message: 'Endpoint not found',
+    });
+  });
+
+  it('serializes ApiError instances with request metadata', () => {
+    const req = { id: 'request-123' };
+    const res = {
+      headersSent: false,
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+    const error = ApiError.badRequest({
+      message: 'Invalid image_source URL',
+      code: 'INVALID_IMAGE_SOURCE_URL',
+      details: [{ field: 'image_source', issue: 'invalid_url' }],
+    });
+
+    errorHandler(error, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Invalid image_source URL',
+      code: 'INVALID_IMAGE_SOURCE_URL',
+      requestId: 'request-123',
+      details: [{ field: 'image_source', issue: 'invalid_url' }],
+    });
+  });
+
+  it('normalizes unexpected errors into a generic internal response', () => {
+    const req = { id: 'request-123' };
+    const res = {
+      headersSent: false,
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+
+    errorHandler(new Error('unexpected'), req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Internal server error',
+      code: 'INTERNAL_SERVER_ERROR',
+      requestId: 'request-123',
+    });
+  });
+});

--- a/tests/unit/utils/validateEnvVars.test.js
+++ b/tests/unit/utils/validateEnvVars.test.js
@@ -184,4 +184,26 @@ describe('validateEnvVars', () => {
 
     expect(() => validateEnvVars()).toThrow(/ACV_API_ENDPOINT/);
   });
+
+  it('accepts non-empty API auth tokens when provided', () => {
+    const validateEnvVars = loadValidator({
+      overrides: {
+        REPLICATE_API_TOKEN: 'test-token',
+        API_AUTH_TOKENS: 'token-a, token-b',
+      },
+    });
+
+    expect(() => validateEnvVars()).not.toThrow();
+  });
+
+  it('rejects API auth tokens when the configured list is empty after trimming', () => {
+    const validateEnvVars = loadValidator({
+      overrides: {
+        REPLICATE_API_TOKEN: 'test-token',
+        API_AUTH_TOKENS: ' ,  , ',
+      },
+    });
+
+    expect(() => validateEnvVars()).toThrow(/API_AUTH_TOKENS/);
+  });
 });


### PR DESCRIPTION
Add optional token-based access control for scraper and description endpoints while keeping health, ping, and Swagger docs public. This also centralizes API error handling behind a single contract that preserves the existing top-level error message and adds stable code, requestId, and validation details fields, with updated Swagger docs plus unit, integration, and Newman coverage.