### PR TITLE
Strengthen Newman harness governance and CI reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,8 @@ jobs:
     name: newman
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      NEWMAN_MODE: ${{ github.event_name == 'pull_request' && 'smoke' || 'harness' }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -115,13 +117,21 @@ jobs:
           node-version: '20'
 
       - name: Run deterministic Postman/Newman harness
-        run: npm run postman:harness
+        run: npm run "postman:${NEWMAN_MODE}"
+
+      - name: Write Newman summary
+        if: always()
+        run: |
+          node scripts/github/write-newman-summary.js \
+            --reports-dir reports/newman \
+            --collection-path postman/collections/alt-text-generator.postman_collection.json \
+            --summary-file "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Newman artifacts
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: newman-artifacts
+          name: newman-artifacts-${{ env.NEWMAN_MODE }}
           path: reports/newman/
           if-no-files-found: ignore
           retention-days: 7
@@ -145,4 +155,5 @@ jobs:
             echo "- lint: ${{ needs.lint.result }}"
             echo "- test: ${{ needs.test.result }}"
             echo "- newman: ${{ needs.newman.result }}"
+            echo "- newman mode: ${{ github.event_name == 'pull_request' && 'smoke' || 'harness' }}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -28,7 +28,7 @@ If you only need a quick local boot, start with `README.md` and come back here f
 
 Recommended toolchain:
 
-- Node.js 20.x recommended (CI runs on Node 20)
+- Node.js 20.x recommended (compatibility is validated on Node 20, 22, and 24)
 - npm 10+
 
 Boot locally:
@@ -73,6 +73,8 @@ The repository uses a small workflow set with separate responsibilities:
   - runs on pushes to `main` and `production`
   - runs on pull requests targeting `main` and `production`
   - executes `actionlint`, `npm run lint`, the Jest matrix on Node 20/22/24, and the deterministic Newman harness
+  - uses `postman:smoke` on pull requests and `postman:harness` on `main` / `production` pushes
+  - publishes a Newman summary derived from JSON artifacts into the workflow summary
 - `Dependency Review` in `.github/workflows/dependency-review.yml`
   - runs only on pull requests that change `package.json` or `package-lock.json`
   - blocks unsafe dependency changes before merge
@@ -125,6 +127,8 @@ Modes:
   - optional live-provider validation
   - intended for explicit live-provider checks, not default CI
   - supports Replicate-only, Azure-only, or combined validation through workflow env flags
+
+Contribution standards for folder naming, tier placement, and assertion policy are documented in [docs/postman-standards.md](./docs/postman-standards.md).
 
 Deterministic harness characteristics:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The service exposes these primary capabilities:
 ## Requirements
 
 - CI validates Node 20, 22, and 24.
-- `engines.node` is currently pinned to `20.x`; use Node 20 locally for the least friction.
+- `engines.node` allows Node 20 through 24; use Node 20 locally for the least friction.
 - npm 10+
 - At least one provider configuration:
   - `REPLICATE_API_TOKEN` for the `clip` model
@@ -82,9 +82,12 @@ Notes:
 - `postman:smoke` is the fast deterministic gate.
 - `postman:harness` runs the full deterministic suite and writes JSON and JUnit reports under `reports/newman/`.
 - `postman:live` is optional and reserved for explicit live-provider validation.
+- CI runs `postman:smoke` on pull requests and `postman:harness` on `main` / `production` pushes.
 - Live mode validates Replicate by default and also validates Azure when `ACV_API_ENDPOINT` and either `ACV_SUBSCRIPTION_KEY` or `ACV_API_KEY` are set.
 - Local harness runs accept self-signed development TLS.
 - The deterministic harness uses a local Azure stub and can boot with a dummy Replicate token or Azure-only configuration.
+
+Contribution standards for the contract suite live in [docs/postman-standards.md](./docs/postman-standards.md).
 
 ## Runtime Essentials
 

--- a/docs/postman-standards.md
+++ b/docs/postman-standards.md
@@ -1,0 +1,68 @@
+# Postman / Newman Standards
+
+This document defines the contribution standards for the API contract suite.
+
+## Purpose
+
+Use the Postman/Newman layer for external HTTP contract validation, not for re-testing every unit of business logic already covered by Jest.
+
+## Test Tiers
+
+- `smoke`
+  - Fast deterministic checks required on pull requests
+  - Covers core health/docs/routing and one representative provider path
+- `full`
+  - Full deterministic harness for `main` and `production`
+  - Adds broader contract, negative-path, and page-description coverage
+- `live`
+  - Manual or scheduled validation against real providers
+  - Must never be a required PR gate
+- `deploy`
+  - Hosted post-promotion smoke verification against the deployed service
+
+## Naming
+
+- Top-level folders are tiered and ordered numerically: `00`, `05`, `10`, `20`, etc.
+- Request names should describe the user-visible behavior, not the implementation detail.
+- Negative-path request names should state both the scenario and the expected outcome.
+
+## Placement Rules
+
+- Put a scenario in Newman when the main risk is:
+  - request/response contract drift
+  - routing, redirects, docs, or auth behavior
+  - black-box provider integration shape
+- Put a scenario in Jest/Supertest when the main risk is:
+  - service orchestration
+  - internal invariants
+  - algorithmic branching
+  - startup/runtime composition
+
+## Assertions
+
+- Prefer asserting the public contract shape, not internal implementation details.
+- For error responses, assert:
+  - `error`
+  - `code`
+  - `requestId` presence when applicable
+  - `details` only when the endpoint is expected to emit validation details
+- Use exact equality only when the response contract is intentionally minimal and stable.
+
+## Failure Expectations
+
+- Use `X-Expected-Status-Class: 5xx` only for requests that intentionally exercise server/provider failure paths.
+- Do not use the expected-status override to hide flaky behavior.
+
+## Data Policy
+
+- Deterministic tiers must use local fixtures or stubbed providers.
+- Live tiers must use stable public URLs with a history of working in production.
+- Avoid examples that rely on placeholder domains such as `example.com`.
+
+## Review Checklist
+
+- Folder placement matches the intended tier.
+- The request name is user-facing and precise.
+- Assertions validate the contract shape, not just status code.
+- New negative paths do not weaken the deterministic suite.
+- Live validations remain opt-in and credential-gated.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "homepage": "https://github.com/jsugg/alt-text-generator#readme",
   "main": "src/app.js",
   "engines": {
-    "node": "20.x"
+    "node": ">=20 <25"
   },
   "scripts": {
     "doctor:tls": "node scripts/doctor-tls.js",

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,51 @@
+# CI / Newman Improvement Plan
+
+This document captures the next tranche of improvements for the Postman/Newman and CI workflow stack.
+
+## Goal
+
+Strengthen the repo's QA-lead signal by improving contract-suite governance, CI reporting quality, and pipeline economics without broad refactors or behavior drift.
+
+## Scope
+
+1. Add explicit Postman collection folder preflight to the Newman harness.
+2. Generate a leadership-friendly Newman summary from JSON artifacts in CI.
+3. Reconcile the declared Node support contract with the validated CI matrix.
+4. Add a concise Postman/Newman standards document for contributors.
+5. Optimize CI so pull requests run the smoke harness while `main` / `production` pushes run the full deterministic harness.
+
+## Implementation Notes
+
+- Keep the public API behavior unchanged.
+- Prefer reusable scripts over inline workflow shell logic.
+- Keep the harness deterministic and local-first.
+- Preserve existing artifact outputs under `reports/newman/`.
+- Avoid touching unrelated worktree changes.
+
+## Deliverables
+
+- Reusable Postman collection utility module
+- Newman summary script wired into CI
+- Updated `engines.node`
+- `docs/postman-standards.md`
+- CI workflow split between smoke and full deterministic Newman modes
+- Tests for new script/helper behavior
+
+## Validation
+
+- `npm run lint`
+- `npm test -- --runInBand`
+- `npm run postman:smoke`
+- `npm run postman:harness`
+- `actionlint .github/workflows/ci.yml`
+
+## Review Checklist
+
+- Folder preflight fails clearly when configured folders are missing.
+- CI summary includes request/assertion totals, report runtimes, and top failing requests.
+- Docs and package metadata agree on supported Node versions.
+- PRs use the faster smoke gate; branch pushes still run the full deterministic harness.
+
+## Finalization
+
+After you've finished implementing and creating tests, re-check to validate the implementation makes sense and that the adequate professional tests are in place, test, commit, push/pr, merge on green, validate.

--- a/scripts/github/write-newman-summary.js
+++ b/scripts/github/write-newman-summary.js
@@ -1,0 +1,300 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const {
+  buildItemFolderMap,
+  readCollection,
+} = require('../postman/collection-utils');
+
+const DEFAULT_REPORTS_DIR = path.resolve(__dirname, '..', '..', 'reports', 'newman');
+const DEFAULT_COLLECTION_PATH = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'postman',
+  'collections',
+  'alt-text-generator.postman_collection.json',
+);
+
+/**
+ * @param {string[]} argv
+ * @returns {{ collectionPath: string, reportsDir: string, summaryFile: string|null }}
+ */
+function parseArgs(argv) {
+  const args = {
+    collectionPath: DEFAULT_COLLECTION_PATH,
+    reportsDir: DEFAULT_REPORTS_DIR,
+    summaryFile: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${token}`);
+    }
+
+    const key = token.slice(2);
+    const value = argv[index + 1];
+    if (value === undefined) {
+      throw new Error(`Missing value for --${key}`);
+    }
+    index += 1;
+
+    switch (key) {
+      case 'collection-path':
+        args.collectionPath = value;
+        break;
+      case 'reports-dir':
+        args.reportsDir = value;
+        break;
+      case 'summary-file':
+        args.summaryFile = value;
+        break;
+      default:
+        throw new Error(`Unsupported argument: --${key}`);
+    }
+  }
+
+  return args;
+}
+
+/**
+ * @param {string} summaryFile
+ * @param {string[]} lines
+ */
+function appendSummary(summaryFile, lines) {
+  if (!summaryFile) {
+    return;
+  }
+
+  fs.appendFileSync(summaryFile, `${lines.join('\n')}\n`, 'utf8');
+}
+
+/**
+ * @param {string} reportsDir
+ * @returns {string[]}
+ */
+function listReportPaths(reportsDir) {
+  return fs.readdirSync(reportsDir)
+    .filter((name) => name.endsWith('.json'))
+    .sort()
+    .map((name) => path.join(reportsDir, name));
+}
+
+/**
+ * @param {object} report
+ * @returns {number}
+ */
+function getReportDurationMs(report) {
+  const timings = report.run?.timings;
+  if (
+    typeof timings?.started === 'number'
+    && typeof timings?.completed === 'number'
+  ) {
+    return timings.completed - timings.started;
+  }
+
+  return 0;
+}
+
+/**
+ * @param {object} report
+ * @param {Map<string, string>} itemFolderMap
+ * @returns {object}
+ */
+function summarizeReport(report, itemFolderMap) {
+  const label = path.basename(report.reportPath, '.json');
+  const folderBreakdown = new Map();
+  (report.run?.executions ?? []).forEach((execution) => {
+    const folder = itemFolderMap.get(execution.item?.id)
+      ?? itemFolderMap.get(execution.item?.name)
+      ?? 'unknown';
+    const assertionTotal = execution.assertions?.length ?? 0;
+    const assertionFailed = (execution.assertions ?? [])
+      .filter((assertion) => Boolean(assertion.error))
+      .length;
+    const responseTimeMs = Number(execution.response?.responseTime) || 0;
+    const current = folderBreakdown.get(folder) ?? {
+      folder,
+      requestTotal: 0,
+      assertionTotal: 0,
+      assertionFailed: 0,
+      totalResponseTimeMs: 0,
+      maxResponseTimeMs: 0,
+    };
+
+    current.requestTotal += 1;
+    current.assertionTotal += assertionTotal;
+    current.assertionFailed += assertionFailed;
+    current.totalResponseTimeMs += responseTimeMs;
+    current.maxResponseTimeMs = Math.max(current.maxResponseTimeMs, responseTimeMs);
+    folderBreakdown.set(folder, current);
+  });
+  const failures = (report.run?.failures ?? []).map((failure) => ({
+    source: label,
+    folder: itemFolderMap.get(failure.source?.id)
+      ?? itemFolderMap.get(failure.source?.name)
+      ?? 'unknown',
+    requestName: failure.source?.name ?? 'unknown',
+    message: failure.error?.message ?? 'Unknown failure',
+  }));
+
+  return {
+    label,
+    durationMs: getReportDurationMs(report),
+    requestTotal: report.run?.stats?.requests?.total ?? 0,
+    assertionTotal: report.run?.stats?.assertions?.total ?? 0,
+    assertionFailed: report.run?.stats?.assertions?.failed ?? 0,
+    folders: Array.from(folderBreakdown.values()).map((folder) => ({
+      ...folder,
+      avgResponseTimeMs: folder.requestTotal === 0
+        ? 0
+        : Math.round(folder.totalResponseTimeMs / folder.requestTotal),
+    })),
+    failures,
+  };
+}
+
+/**
+ * @param {object[]} reports
+ * @returns {object}
+ */
+function aggregateSummaries(reports) {
+  return reports.reduce((aggregate, report) => ({
+    reportCount: aggregate.reportCount + 1,
+    requestTotal: aggregate.requestTotal + report.requestTotal,
+    assertionTotal: aggregate.assertionTotal + report.assertionTotal,
+    assertionFailed: aggregate.assertionFailed + report.assertionFailed,
+    failures: aggregate.failures.concat(report.failures),
+    folders: report.folders.reduce((folderAggregate, folder) => {
+      const current = folderAggregate.get(folder.folder) ?? {
+        folder: folder.folder,
+        requestTotal: 0,
+        assertionTotal: 0,
+        assertionFailed: 0,
+        totalResponseTimeMs: 0,
+        maxResponseTimeMs: 0,
+      };
+
+      current.requestTotal += folder.requestTotal;
+      current.assertionTotal += folder.assertionTotal;
+      current.assertionFailed += folder.assertionFailed;
+      current.totalResponseTimeMs += folder.totalResponseTimeMs;
+      current.maxResponseTimeMs = Math.max(current.maxResponseTimeMs, folder.maxResponseTimeMs);
+      folderAggregate.set(folder.folder, current);
+      return folderAggregate;
+    }, aggregate.folders),
+    reports: aggregate.reports.concat(report),
+  }), {
+    reportCount: 0,
+    requestTotal: 0,
+    assertionTotal: 0,
+    assertionFailed: 0,
+    failures: [],
+    folders: new Map(),
+    reports: [],
+  });
+}
+
+/**
+ * @param {object} aggregate
+ * @returns {string[]}
+ */
+function formatSummaryLines(aggregate) {
+  const lines = [
+    '## Newman Summary',
+    '',
+    `- Reports parsed: ${aggregate.reportCount}`,
+    `- Requests: ${aggregate.requestTotal}`,
+    `- Assertions: ${aggregate.assertionTotal}`,
+    `- Failed assertions: ${aggregate.assertionFailed}`,
+    '',
+    '### Report Breakdown',
+  ];
+
+  aggregate.reports.forEach((report) => {
+    lines.push(
+      `- ${report.label}: ${report.requestTotal} requests, `
+        + `${report.assertionTotal} assertions, `
+        + `${report.assertionFailed} failed, `
+        + `${report.durationMs}ms`,
+    );
+  });
+
+  lines.push('', '### Folder Breakdown');
+
+  Array.from(aggregate.folders.values())
+    .sort((left, right) => left.folder.localeCompare(right.folder))
+    .forEach((folder) => {
+      const avgResponseTimeMs = folder.requestTotal === 0
+        ? 0
+        : Math.round(folder.totalResponseTimeMs / folder.requestTotal);
+      lines.push(
+        `- ${folder.folder}: ${folder.requestTotal} requests, `
+          + `${folder.assertionTotal} assertions, `
+          + `${folder.assertionFailed} failed, `
+          + `avg ${avgResponseTimeMs}ms, max ${folder.maxResponseTimeMs}ms`,
+      );
+    });
+
+  lines.push('', '### Top Failing Requests');
+
+  if (aggregate.failures.length === 0) {
+    lines.push('- none');
+    return lines;
+  }
+
+  aggregate.failures.slice(0, 10).forEach((failure) => {
+    lines.push(
+      `- [${failure.source}] ${failure.folder} / ${failure.requestName}: ${failure.message}`,
+    );
+  });
+
+  return lines;
+}
+
+/**
+ * @param {{ collectionPath: string, reportsDir: string }} args
+ * @returns {{ lines: string[], aggregate: object }}
+ */
+function buildSummary(args) {
+  const collection = readCollection(args.collectionPath);
+  const itemFolderMap = buildItemFolderMap(collection);
+  const reports = listReportPaths(args.reportsDir).map((reportPath) => {
+    const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+    report.reportPath = reportPath;
+    return summarizeReport(report, itemFolderMap);
+  });
+
+  const aggregate = aggregateSummaries(reports);
+  return {
+    lines: formatSummaryLines(aggregate),
+    aggregate,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const { lines } = buildSummary(args);
+  appendSummary(args.summaryFile, lines);
+  console.log(lines.join('\n'));
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.stack || error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  aggregateSummaries,
+  buildSummary,
+  formatSummaryLines,
+  getReportDurationMs,
+  listReportPaths,
+  parseArgs,
+  summarizeReport,
+};

--- a/scripts/postman/collection-utils.js
+++ b/scripts/postman/collection-utils.js
@@ -1,0 +1,90 @@
+const fs = require('node:fs');
+
+/**
+ * Reads and parses a Postman collection JSON file.
+ *
+ * @param {string} collectionPath
+ * @returns {object}
+ */
+function readCollection(collectionPath) {
+  return JSON.parse(fs.readFileSync(collectionPath, 'utf8'));
+}
+
+/**
+ * Returns the top-level folder names in a Postman collection.
+ *
+ * @param {object} collection
+ * @returns {string[]}
+ */
+function listTopLevelFolderNames(collection) {
+  return (collection.item ?? [])
+    .map((item) => item.name)
+    .filter((name) => typeof name === 'string' && name.length > 0);
+}
+
+/**
+ * Throws when one or more requested folders do not exist in the collection.
+ *
+ * @param {string[]} availableFolders
+ * @param {string[]} requiredFolders
+ * @param {string} context
+ */
+function assertTopLevelFoldersExist(availableFolders, requiredFolders, context) {
+  const missingFolders = requiredFolders.filter((folder) => !availableFolders.includes(folder));
+
+  if (missingFolders.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    `Missing Postman folders for ${context}: ${missingFolders.join(', ')}. `
+      + `Available folders: ${availableFolders.join(', ')}`,
+  );
+}
+
+/**
+ * Builds a map of collection item ids to their top-level folder name.
+ *
+ * @param {object} collection
+ * @returns {Map<string, string>}
+ */
+function buildItemFolderMap(collection) {
+  const itemFolderMap = new Map();
+
+  const visit = (item, topLevelFolderName) => {
+    if (!item || typeof item !== 'object') {
+      return;
+    }
+
+    if (typeof item.id === 'string') {
+      itemFolderMap.set(item.id, topLevelFolderName);
+    }
+
+    if (typeof item.name === 'string' && item.request) {
+      itemFolderMap.set(item.name, topLevelFolderName);
+    }
+
+    if (Array.isArray(item.item)) {
+      item.item.forEach((child) => {
+        visit(child, topLevelFolderName);
+      });
+    }
+  };
+
+  (collection.item ?? []).forEach((folder) => {
+    if (!folder || typeof folder.name !== 'string') {
+      return;
+    }
+
+    visit(folder, folder.name);
+  });
+
+  return itemFolderMap;
+}
+
+module.exports = {
+  assertTopLevelFoldersExist,
+  buildItemFolderMap,
+  listTopLevelFolderNames,
+  readCollection,
+};

--- a/scripts/run-postman-harness.js
+++ b/scripts/run-postman-harness.js
@@ -10,6 +10,11 @@ const path = require('node:path');
 const http = require('node:http');
 const https = require('node:https');
 const { spawn } = require('node:child_process');
+const {
+  assertTopLevelFoldersExist,
+  listTopLevelFolderNames,
+  readCollection,
+} = require('./postman/collection-utils');
 
 const ROOT = path.resolve(__dirname, '..');
 const COLLECTION_PATH = path.join(
@@ -264,6 +269,8 @@ async function main() {
   const azureSubscriptionKey = process.env.ACV_SUBSCRIPTION_KEY || process.env.ACV_API_KEY || null;
   const hasLiveAzureConfig = Boolean(process.env.ACV_API_ENDPOINT && azureSubscriptionKey);
   const managedChildren = new Set();
+  const collection = readCollection(COLLECTION_PATH);
+  const availableFolders = listTopLevelFolderNames(collection);
 
   await fs.mkdir(REPORTS_DIR, { recursive: true });
 
@@ -311,6 +318,16 @@ async function main() {
     });
 
     if (mode === 'smoke') {
+      assertTopLevelFoldersExist(
+        availableFolders,
+        [
+          '00 Core Smoke',
+          '07 Route Aliases',
+          '10 Scraper Contract',
+          '20 Single Description (Azure Stub)',
+        ],
+        'smoke mode',
+      );
       await runNewman(
         'smoke',
         [
@@ -322,6 +339,11 @@ async function main() {
         ['--insecure'],
       );
 
+      assertTopLevelFoldersExist(
+        availableFolders,
+        ['05 Routing & Redirects'],
+        'smoke routing verification',
+      );
       await runNewman(
         'routing',
         ['05 Routing & Redirects'],
@@ -330,6 +352,18 @@ async function main() {
     }
 
     if (mode === 'full') {
+      assertTopLevelFoldersExist(
+        availableFolders,
+        [
+          '00 Core Smoke',
+          '07 Route Aliases',
+          '10 Scraper Contract',
+          '20 Single Description (Azure Stub)',
+          '30 Page Descriptions (Azure Stub)',
+          '40 Negative Paths',
+        ],
+        'full mode',
+      );
       await runNewman(
         'core',
         [
@@ -343,6 +377,11 @@ async function main() {
         ['--insecure'],
       );
 
+      assertTopLevelFoldersExist(
+        availableFolders,
+        ['05 Routing & Redirects'],
+        'full routing verification',
+      );
       await runNewman(
         'routing',
         ['05 Routing & Redirects'],
@@ -374,6 +413,11 @@ async function main() {
         throw new Error('Live mode enabled but no live validation folders were selected');
       }
 
+      assertTopLevelFoldersExist(
+        availableFolders,
+        liveFolders,
+        'live mode',
+      );
       await runNewman(
         'live-provider',
         liveFolders,

--- a/tests/unit/scripts/github/writeNewmanSummary.test.js
+++ b/tests/unit/scripts/github/writeNewmanSummary.test.js
@@ -1,0 +1,275 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  buildSummary,
+  formatSummaryLines,
+  parseArgs,
+} = require('../../../../scripts/github/write-newman-summary');
+
+const createTempDir = () => fs.mkdtempSync(
+  path.join(os.tmpdir(), 'newman-summary-test-'),
+);
+
+describe('scripts/github/write-newman-summary', () => {
+  it('parses supported CLI arguments', () => {
+    expect(parseArgs([
+      '--reports-dir',
+      '/tmp/reports',
+      '--collection-path',
+      '/tmp/collection.json',
+      '--summary-file',
+      '/tmp/summary.md',
+    ])).toEqual({
+      reportsDir: '/tmp/reports',
+      collectionPath: '/tmp/collection.json',
+      summaryFile: '/tmp/summary.md',
+    });
+  });
+
+  it('rejects unsupported CLI arguments', () => {
+    expect(() => parseArgs(['--nope', 'value'])).toThrow('Unsupported argument: --nope');
+  });
+
+  it('builds an aggregate summary from Newman JSON reports', () => {
+    const tempDir = createTempDir();
+    const reportsDir = path.join(tempDir, 'reports');
+    fs.mkdirSync(reportsDir, { recursive: true });
+
+    const collectionPath = path.join(tempDir, 'collection.json');
+    fs.writeFileSync(collectionPath, JSON.stringify({
+      item: [
+        {
+          name: '00 Core Smoke',
+          item: [
+            { id: 'ping-id', name: 'Ping' },
+          ],
+        },
+        {
+          name: '40 Negative Paths',
+          item: [
+            { id: 'missing-url-id', name: 'Scraper missing url' },
+          ],
+        },
+      ],
+    }), 'utf8');
+
+    fs.writeFileSync(path.join(reportsDir, 'smoke.json'), JSON.stringify({
+      run: {
+        stats: {
+          requests: { total: 1 },
+          assertions: { total: 4, failed: 0 },
+        },
+        timings: {
+          started: 100,
+          completed: 220,
+        },
+        executions: [
+          {
+            item: { id: 'ping-id', name: 'Ping' },
+            assertions: [
+              { assertion: 'returns 200' },
+              { assertion: 'returns pong' },
+              { assertion: 'not 5xx' },
+              { assertion: 'fast enough' },
+            ],
+            response: { responseTime: 90 },
+          },
+        ],
+        failures: [],
+      },
+    }), 'utf8');
+
+    fs.writeFileSync(path.join(reportsDir, 'core.json'), JSON.stringify({
+      run: {
+        stats: {
+          requests: { total: 1 },
+          assertions: { total: 3, failed: 1 },
+        },
+        timings: {
+          started: 300,
+          completed: 510,
+        },
+        executions: [
+          {
+            item: { id: 'missing-url-id', name: 'Scraper missing url' },
+            assertions: [
+              { assertion: 'returns 400' },
+              { assertion: 'matches error', error: { message: 'expected 400' } },
+              { assertion: 'has requestId' },
+            ],
+            response: { responseTime: 12 },
+          },
+        ],
+        failures: [
+          {
+            source: {
+              id: 'missing-url-id',
+              name: 'Scraper missing url',
+            },
+            error: {
+              message: 'expected 400',
+            },
+          },
+        ],
+      },
+    }), 'utf8');
+
+    const { aggregate, lines } = buildSummary({
+      reportsDir,
+      collectionPath,
+    });
+
+    expect(aggregate.reportCount).toBe(2);
+    expect(aggregate.requestTotal).toBe(2);
+    expect(aggregate.assertionTotal).toBe(7);
+    expect(aggregate.assertionFailed).toBe(1);
+    expect(aggregate.failures).toEqual([
+      {
+        source: 'core',
+        folder: '40 Negative Paths',
+        requestName: 'Scraper missing url',
+        message: 'expected 400',
+      },
+    ]);
+    expect(Array.from(aggregate.folders.values()).sort((left, right) => (
+      left.folder.localeCompare(right.folder)
+    ))).toEqual([
+      {
+        folder: '00 Core Smoke',
+        requestTotal: 1,
+        assertionTotal: 4,
+        assertionFailed: 0,
+        totalResponseTimeMs: 90,
+        maxResponseTimeMs: 90,
+      },
+      {
+        folder: '40 Negative Paths',
+        requestTotal: 1,
+        assertionTotal: 3,
+        assertionFailed: 1,
+        totalResponseTimeMs: 12,
+        maxResponseTimeMs: 12,
+      },
+    ]);
+    expect(lines).toContain('- Reports parsed: 2');
+    expect(lines).toContain('- smoke: 1 requests, 4 assertions, 0 failed, 120ms');
+    expect(lines).toContain('- 00 Core Smoke: 1 requests, 4 assertions, 0 failed, avg 90ms, max 90ms');
+    expect(lines).toContain('- [core] 40 Negative Paths / Scraper missing url: expected 400');
+  });
+
+  it('falls back to request names when collection ids are unavailable', () => {
+    const tempDir = createTempDir();
+    const reportsDir = path.join(tempDir, 'reports');
+    fs.mkdirSync(reportsDir, { recursive: true });
+
+    const collectionPath = path.join(tempDir, 'collection.json');
+    fs.writeFileSync(collectionPath, JSON.stringify({
+      item: [
+        {
+          name: '90 Live Provider Validation',
+          item: [
+            {
+              name: 'Live clip single image',
+              request: {
+                method: 'GET',
+              },
+            },
+          ],
+        },
+      ],
+    }), 'utf8');
+
+    fs.writeFileSync(path.join(reportsDir, 'live-provider.json'), JSON.stringify({
+      run: {
+        stats: {
+          requests: { total: 1 },
+          assertions: { total: 1, failed: 1 },
+        },
+        timings: {
+          started: 10,
+          completed: 40,
+        },
+        executions: [
+          {
+            item: {
+              id: 'generated-runtime-id',
+              name: 'Live clip single image',
+            },
+            assertions: [
+              { assertion: 'returns 200', error: { message: 'expected 200' } },
+            ],
+            response: { responseTime: 25 },
+          },
+        ],
+        failures: [
+          {
+            source: {
+              id: 'generated-runtime-id',
+              name: 'Live clip single image',
+            },
+            error: {
+              message: 'expected 200',
+            },
+          },
+        ],
+      },
+    }), 'utf8');
+
+    const { aggregate } = buildSummary({
+      reportsDir,
+      collectionPath,
+    });
+
+    expect(Array.from(aggregate.folders.values())).toEqual([
+      {
+        folder: '90 Live Provider Validation',
+        requestTotal: 1,
+        assertionTotal: 1,
+        assertionFailed: 1,
+        totalResponseTimeMs: 25,
+        maxResponseTimeMs: 25,
+      },
+    ]);
+    expect(aggregate.failures).toEqual([
+      {
+        source: 'live-provider',
+        folder: '90 Live Provider Validation',
+        requestName: 'Live clip single image',
+        message: 'expected 200',
+      },
+    ]);
+  });
+
+  it('formats a no-failures summary with an explicit none marker', () => {
+    const lines = formatSummaryLines({
+      reportCount: 1,
+      requestTotal: 2,
+      assertionTotal: 6,
+      assertionFailed: 0,
+      failures: [],
+      folders: new Map([
+        ['00 Core Smoke', {
+          folder: '00 Core Smoke',
+          requestTotal: 2,
+          assertionTotal: 6,
+          assertionFailed: 0,
+          totalResponseTimeMs: 300,
+          maxResponseTimeMs: 180,
+        }],
+      ]),
+      reports: [
+        {
+          label: 'smoke',
+          requestTotal: 2,
+          assertionTotal: 6,
+          assertionFailed: 0,
+          durationMs: 150,
+        },
+      ],
+    });
+
+    expect(lines.slice(-1)[0]).toBe('- none');
+  });
+});

--- a/tests/unit/scripts/postman/collectionUtils.test.js
+++ b/tests/unit/scripts/postman/collectionUtils.test.js
@@ -1,0 +1,69 @@
+const {
+  assertTopLevelFoldersExist,
+  buildItemFolderMap,
+  listTopLevelFolderNames,
+} = require('../../../../scripts/postman/collection-utils');
+
+describe('scripts/postman/collection-utils', () => {
+  const collection = {
+    item: [
+      {
+        name: '00 Core Smoke',
+        item: [
+          {
+            id: 'req-ping',
+            name: 'Ping',
+            request: {
+              method: 'GET',
+            },
+          },
+        ],
+      },
+      {
+        name: '20 Single Description (Azure Stub)',
+        item: [
+          {
+            name: 'Nested Group',
+            item: [
+              {
+                id: 'req-description',
+                name: 'Describe fixture image A',
+                request: {
+                  method: 'GET',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  it('lists the top-level folder names from a collection', () => {
+    expect(listTopLevelFolderNames(collection)).toEqual([
+      '00 Core Smoke',
+      '20 Single Description (Azure Stub)',
+    ]);
+  });
+
+  it('throws a helpful error when requested folders are missing', () => {
+    expect(() => assertTopLevelFoldersExist(
+      listTopLevelFolderNames(collection),
+      ['00 Core Smoke', '90 Live Provider Validation'],
+      'live mode',
+    )).toThrow(
+      'Missing Postman folders for live mode: 90 Live Provider Validation. Available folders: 00 Core Smoke, 20 Single Description (Azure Stub)',
+    );
+  });
+
+  it('maps nested request ids and names back to their top-level folder', () => {
+    const itemFolderMap = buildItemFolderMap(collection);
+
+    expect(itemFolderMap.get('req-ping')).toBe('00 Core Smoke');
+    expect(itemFolderMap.get('Ping')).toBe('00 Core Smoke');
+    expect(itemFolderMap.get('req-description')).toBe('20 Single Description (Azure Stub)');
+    expect(itemFolderMap.get('Describe fixture image A')).toBe(
+      '20 Single Description (Azure Stub)',
+    );
+  });
+});


### PR DESCRIPTION
Add Postman folder preflight to the Newman runner, publish folder-level Newman summaries in CI, align the Node engine declaration with the tested 20/22/24 matrix, document contract-suite standards, and run the smoke harness on pull requests while keeping the full deterministic harness on main and production pushes.