### PR TITLE
Use pre-prod environment for live provider validation

### DIFF
--- a/.github/workflows/live-provider-validation.yml
+++ b/.github/workflows/live-provider-validation.yml
@@ -40,6 +40,7 @@ jobs:
     if: github.event_name != 'schedule' || vars.ENABLE_SCHEDULED_LIVE_PROVIDER_VALIDATION == 'true'
     name: live-provider
     runs-on: ubuntu-latest
+    environment: pre-prod
     timeout-minutes: 20
     steps:
       - name: Checkout


### PR DESCRIPTION
Attach the live-provider validation job to the pre-prod GitHub Environment so the workflow can consume its configured provider secrets without changing the existing validation flow.