### PR TITLE
Respect pre-prod defaults in live provider validation

### DIFF
--- a/.github/workflows/live-provider-validation.yml
+++ b/.github/workflows/live-provider-validation.yml
@@ -4,15 +4,23 @@ on:
   workflow_dispatch:
     inputs:
       run_replicate:
-        description: Include Replicate live validation.
+        description: Include Replicate live validation. Use auto to defer to environment defaults.
         required: false
-        default: true
-        type: boolean
+        default: auto
+        type: choice
+        options:
+          - auto
+          - true
+          - false
       run_azure:
-        description: Include Azure live validation when Azure secrets are configured.
+        description: Include Azure live validation when Azure secrets are configured. Use auto to defer to environment defaults.
         required: false
-        default: true
-        type: boolean
+        default: auto
+        type: choice
+        options:
+          - auto
+          - true
+          - false
   schedule:
     - cron: '23 8 * * 1'
 
@@ -52,17 +60,79 @@ jobs:
           node-version: '20'
 
       - name: Resolve validation scope
+        env:
+          INPUT_RUN_REPLICATE: ${{ inputs.run_replicate }}
+          INPUT_RUN_AZURE: ${{ inputs.run_azure }}
+          ENV_RUN_LIVE_REPLICATE: ${{ vars.RUN_LIVE_REPLICATE }}
+          ENV_RUN_REPLICATE: ${{ vars.RUN_REPLICATE }}
+          ENV_RUN_LIVE_AZURE: ${{ vars.RUN_LIVE_AZURE }}
+          ENV_RUN_AZURE: ${{ vars.RUN_AZURE }}
+          ENABLE_SCHEDULED_AZURE_LIVE_VALIDATION: ${{ vars.ENABLE_SCHEDULED_AZURE_LIVE_VALIDATION }}
         run: |
+          normalize_boolean() {
+            case "$1" in
+              true|TRUE|True|1|yes|YES|on|ON)
+                printf 'true\n'
+                ;;
+              false|FALSE|False|0|no|NO|off|OFF)
+                printf 'false\n'
+                ;;
+              '')
+                printf '\n'
+                ;;
+              *)
+                echo "Unsupported boolean value: $1" >&2
+                exit 1
+                ;;
+            esac
+          }
+
+          resolve_manual_toggle() {
+            local input_value="$1"
+            local primary_env_value="$2"
+            local secondary_env_value="$3"
+            local default_value="$4"
+
+            case "$input_value" in
+              true|false)
+                printf '%s\n' "$input_value"
+                return
+                ;;
+              auto|'')
+                ;;
+              *)
+                echo "Unsupported manual toggle value: $input_value" >&2
+                exit 1
+                ;;
+            esac
+
+            local normalized_primary
+            normalized_primary="$(normalize_boolean "$primary_env_value")"
+            if [ -n "$normalized_primary" ]; then
+              printf '%s\n' "$normalized_primary"
+              return
+            fi
+
+            local normalized_secondary
+            normalized_secondary="$(normalize_boolean "$secondary_env_value")"
+            if [ -n "$normalized_secondary" ]; then
+              printf '%s\n' "$normalized_secondary"
+              return
+            fi
+
+            printf '%s\n' "$default_value"
+          }
+
           if [ "${{ github.event_name }}" = "schedule" ]; then
             echo "RUN_REPLICATE=true" >> "$GITHUB_ENV"
-            if [ "${{ vars.ENABLE_SCHEDULED_AZURE_LIVE_VALIDATION }}" = "true" ]; then
+            if [ "${ENABLE_SCHEDULED_AZURE_LIVE_VALIDATION}" = "true" ]; then
               echo "RUN_AZURE=true" >> "$GITHUB_ENV"
             else
               echo "RUN_AZURE=false" >> "$GITHUB_ENV"
             fi
           else
-            echo "RUN_REPLICATE=${{ inputs.run_replicate }}" >> "$GITHUB_ENV"
-            echo "RUN_AZURE=${{ inputs.run_azure }}" >> "$GITHUB_ENV"
+            echo "RUN_REPLICATE=$(resolve_manual_toggle "$INPUT_RUN_REPLICATE" "$ENV_RUN_LIVE_REPLICATE" "$ENV_RUN_REPLICATE" "true")" >> "$GITHUB_ENV"
+            echo "RUN_AZURE=$(resolve_manual_toggle "$INPUT_RUN_AZURE" "$ENV_RUN_LIVE_AZURE" "$ENV_RUN_AZURE" "true")" >> "$GITHUB_ENV"
           fi
 
       - name: Validate live-provider secrets


### PR DESCRIPTION
Make manual live-provider validation use auto/true/false toggles so GitHub Environment defaults can control provider selection, while still allowing explicit overrides when needed.