### PR TITLE
Add Newman auth and deploy verification tiers

### DIFF
--- a/.github/workflows/deploy-verification.yml
+++ b/.github/workflows/deploy-verification.yml
@@ -30,14 +30,34 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - name: Setup project
+        uses: ./.github/actions/setup-node-project
         with:
           node-version: '20'
 
-      - name: Run deploy verification
+      - name: Run deploy Newman verification
+        run: npm run postman:deploy -- --base-url "${BASE_URL}"
+
+      - name: Write deploy summary
+        if: always()
         run: |
-          node scripts/github/verify-deploy.js \
-            --base-url "${BASE_URL}" \
-            --event "${{ github.event_name }}" \
-            --summary-file "${GITHUB_STEP_SUMMARY}"
+          {
+            echo "## Deploy Verification"
+            echo
+            echo "- Event: ${{ github.event_name }}"
+            echo "- Base URL: ${BASE_URL}"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+          node scripts/github/write-newman-summary.js \
+            --reports-dir reports/newman \
+            --collection-path postman/collections/alt-text-generator.postman_collection.json \
+            --summary-file "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Newman artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: deploy-verification-artifacts
+          path: reports/newman/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -59,6 +59,7 @@ npm run lint
 NODE_ENV=test REPLICATE_API_TOKEN=test-token npm test -- --runInBand
 npm run postman:smoke
 npm run postman:harness
+npm run postman:deploy -- --base-url https://wcag.qcraft.com.br
 
 # outbound TLS diagnostics
 npm run doctor:tls -- https://example.com
@@ -95,7 +96,8 @@ The repository uses a small workflow set with separate responsibilities:
 - scheduled Azure live validation additionally requires `ENABLE_SCHEDULED_AZURE_LIVE_VALIDATION=true`
 - `Deploy Verification` in `.github/workflows/deploy-verification.yml`
   - runs automatically on `production` pushes
-  - verifies the deployed service health, Swagger server URL, scraper behavior, and one Azure-backed description endpoint
+  - runs `npm run postman:deploy -- --base-url <host>`
+  - reuses the Postman deploy folder to verify hosted health, Swagger server URL, scraper behavior, and one Azure-backed description endpoint
 - `Promote to Production` in `.github/workflows/promote-to-production.yml`
   - manual only
   - verifies that `main` has the required CI checks green
@@ -119,21 +121,25 @@ Modes:
 
 - `npm run postman:smoke`
   - fast deterministic gate
-  - covers core smoke, scraper contract, one Azure-stubbed description, and routing checks
+  - covers core smoke, route aliases, protected-endpoint auth, scraper contract, one Azure-stubbed description, and routing checks
 - `npm run postman:harness`
   - full deterministic suite
-  - includes page descriptions and negative-path coverage
+  - includes protected-endpoint auth, page descriptions, and negative-path coverage
   - writes JSON and JUnit reports to `reports/newman/`
 - `npm run postman:live`
   - optional live-provider validation
   - intended for explicit live-provider checks, not default CI
   - supports Replicate-only, Azure-only, or combined validation through workflow env flags
+- `npm run postman:deploy -- --base-url https://wcag.qcraft.com.br`
+  - hosted deploy smoke verification
+  - runs only the deploy folder from the shared Postman collection and writes `deploy.json` / `deploy.xml`
 
 Contribution standards for folder naming, tier placement, and assertion policy are documented in [docs/postman-standards.md](./docs/postman-standards.md).
 
 Deterministic harness characteristics:
 
 - starts the local app on `https://127.0.0.1:8443` and `http://127.0.0.1:8080`
+- starts an auth-enabled local app on `https://127.0.0.1:18443` for protected-endpoint contract checks
 - starts a local fixture server on `http://127.0.0.1:19090`
 - configures Azure to point at the fixture server stub endpoint
 - uses a dummy `REPLICATE_API_TOKEN` if one is not already set
@@ -149,6 +155,8 @@ Generated artifacts:
 - `reports/newman/routing.xml`
 - `reports/newman/live-provider.json`
 - `reports/newman/live-provider.xml`
+- `reports/newman/deploy.json`
+- `reports/newman/deploy.xml`
 
 Use the deterministic modes for routine validation and CI. Use the live mode only when you deliberately want to validate vendor connectivity and account readiness.
 

--- a/README.md
+++ b/README.md
@@ -75,14 +75,17 @@ Commands:
 npm run postman:smoke
 npm run postman:harness
 npm run postman:live
+npm run postman:deploy -- --base-url https://wcag.qcraft.com.br
 ```
 
 Notes:
 
 - `postman:smoke` is the fast deterministic gate.
-- `postman:harness` runs the full deterministic suite and writes JSON and JUnit reports under `reports/newman/`.
+- `postman:harness` runs the full deterministic suite, including protected-endpoint auth coverage, and writes JSON and JUnit reports under `reports/newman/`.
 - `postman:live` is optional and reserved for explicit live-provider validation.
+- `postman:deploy` runs the hosted deploy-smoke folder from the same Postman collection against a supplied base URL.
 - CI runs `postman:smoke` on pull requests and `postman:harness` on `main` / `production` pushes.
+- Deploy verification runs `postman:deploy` on `production` pushes so hosted smoke checks stay inside the Newman contract layer.
 - Live mode validates Replicate by default and also validates Azure when `ACV_API_ENDPOINT` and either `ACV_SUBSCRIPTION_KEY` or `ACV_API_KEY` are set.
 - Local harness runs accept self-signed development TLS.
 - The deterministic harness uses a local Azure stub and can boot with a dummy Replicate token or Azure-only configuration.

--- a/docs/postman-standards.md
+++ b/docs/postman-standards.md
@@ -10,7 +10,7 @@ Use the Postman/Newman layer for external HTTP contract validation, not for re-t
 
 - `smoke`
   - Fast deterministic checks required on pull requests
-  - Covers core health/docs/routing and one representative provider path
+  - Covers core health/docs/routing, protected-endpoint auth, and one representative provider path
 - `full`
   - Full deterministic harness for `main` and `production`
   - Adds broader contract, negative-path, and page-description coverage

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "postman:smoke": "node scripts/run-postman-harness.js smoke",
     "postman:harness": "node scripts/run-postman-harness.js full",
     "postman:live": "node scripts/run-postman-harness.js live",
+    "postman:deploy": "node scripts/run-postman-deploy.js",
     "test": "jest",
     "prod": "NODE_ENV=production node src/app.js",
     "dev": "NODE_ENV=development nodemon src/app.js | pino-pretty -i streams,options"

--- a/postman/collections/alt-text-generator.postman_collection.json
+++ b/postman/collections/alt-text-generator.postman_collection.json
@@ -604,6 +604,188 @@
       ]
     },
     {
+      "name": "08 API Auth Contract",
+      "item": [
+        {
+          "name": "Protected description rejects missing auth",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{authBaseUrl}}/api/v1/accessibility/description",
+              "host": [
+                "{{authBaseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "accessibility",
+                "description"
+              ],
+              "query": [
+                {
+                  "key": "image_source",
+                  "value": "{{sampleImageAUrl}}"
+                },
+                {
+                  "key": "model",
+                  "value": "{{model}}"
+                }
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('returns 401', function () {",
+                  "  pm.response.to.have.status(401);",
+                  "});",
+                  "",
+                  "const body = pm.response.json();",
+                  "",
+                  "pm.test('auth failure matches the public error contract', function () {",
+                  "  pm.expect(body.error).to.eql('Missing or invalid API authentication credentials');",
+                  "  pm.expect(body.code).to.eql('API_AUTHENTICATION_FAILED');",
+                  "  pm.expect(body.requestId).to.be.a('string').and.not.empty;",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Protected description accepts X-API-Key",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "X-API-Key",
+                "value": "{{apiAuthToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{authBaseUrl}}/api/v1/accessibility/description",
+              "host": [
+                "{{authBaseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "accessibility",
+                "description"
+              ],
+              "query": [
+                {
+                  "key": "image_source",
+                  "value": "{{sampleImageAUrl}}"
+                },
+                {
+                  "key": "model",
+                  "value": "{{model}}"
+                }
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('returns 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const body = pm.response.json();",
+                  "const expectedImageUrl = pm.environment.get('sampleImageAUrl');",
+                  "",
+                  "pm.test('x-api-key auth returns the expected stub payload', function () {",
+                  "  pm.expect(body).to.eql([",
+                  "    { description: 'stub caption for asset a', imageUrl: expectedImageUrl }",
+                  "  ]);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Protected scraper accepts Bearer token",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{apiAuthToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{authBaseUrl}}/api/v1/scraper/images",
+              "host": [
+                "{{authBaseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "scraper",
+                "images"
+              ],
+              "query": [
+                {
+                  "key": "url",
+                  "value": "{{samplePageUrl}}"
+                }
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('returns 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const body = pm.response.json();",
+                  "const expectedA = pm.environment.get('sampleImageAUrl');",
+                  "const expectedB = pm.environment.get('sampleImageBUrl');",
+                  "",
+                  "pm.test('bearer auth returns the expected scraper payload', function () {",
+                  "  pm.expect(body.imageSources).to.eql([",
+                  "    expectedA,",
+                  "    expectedB,",
+                  "    expectedA",
+                  "  ]);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "10 Scraper Contract",
       "item": [
         {
@@ -1854,6 +2036,234 @@
                   "    pm.expect(item.description).to.be.a('string');",
                   "    pm.expect(item.description.length).to.be.above(0);",
                   "  });",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "95 Deploy Verification",
+      "item": [
+        {
+          "name": "Hosted health",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Max-Response-Time-Ms",
+                "value": "45000"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/health",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "health"
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('deploy health returns 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const body = pm.response.json();",
+                  "",
+                  "pm.test('deploy health payload contains expected fields', function () {",
+                  "  pm.expect(body).to.have.property('message', 'OK');",
+                  "  pm.expect(body).to.have.property('uptime');",
+                  "  pm.expect(body).to.have.property('timestamp');",
+                  "  pm.expect(body.uptime).to.be.a('number');",
+                  "  pm.expect(body.timestamp).to.be.a('number');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Hosted swagger spec",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/javascript"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api-docs/swagger-ui-init.js",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api-docs",
+                "swagger-ui-init.js"
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('deploy swagger init returns 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const body = pm.response.text();",
+                  "const match = body.match(/\\\"servers\\\":\\s*(\\[[\\s\\S]*?\\])/);",
+                  "",
+                  "pm.test('deploy swagger init exposes an embedded servers array', function () {",
+                  "  pm.expect(match, 'servers array not found in swagger-ui-init.js').not.to.eql(null);",
+                  "});",
+                  "",
+                  "const servers = match ? JSON.parse(match[1]) : [];",
+                  "const expectedSwaggerServerUrl = pm.environment.get('expectedSwaggerServerUrl');",
+                  "",
+                  "pm.test('deploy swagger spec includes the expected hosted server', function () {",
+                  "  pm.expect(servers.some((server) => server.url === expectedSwaggerServerUrl)).to.eql(true);",
+                  "});",
+                  "",
+                  "pm.test('deploy swagger spec does not reference the retired qcraft.dev domain', function () {",
+                  "  pm.expect(body).not.to.include('wcag.qcraft.dev');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Hosted scraper contract",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/scraper/images",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "scraper",
+                "images"
+              ],
+              "query": [
+                {
+                  "key": "url",
+                  "value": "{{deployScrapePageUrl}}"
+                }
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('deploy scraper returns 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const body = pm.response.json();",
+                  "",
+                  "pm.test('deploy scraper response has an imageSources array', function () {",
+                  "  pm.expect(body).to.have.property('imageSources');",
+                  "  pm.expect(body.imageSources).to.be.an('array');",
+                  "});",
+                  "",
+                  "pm.test('deploy scraper image sources are strings when present', function () {",
+                  "  body.imageSources.forEach((imageUrl) => {",
+                  "    pm.expect(imageUrl).to.be.a('string');",
+                  "  });",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Hosted azure single description",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Max-Response-Time-Ms",
+                "value": "20000"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/accessibility/description",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "accessibility",
+                "description"
+              ],
+              "query": [
+                {
+                  "key": "image_source",
+                  "value": "{{deployAzureImageUrl}}"
+                },
+                {
+                  "key": "model",
+                  "value": "azure"
+                }
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('deploy azure description returns 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const body = pm.response.json();",
+                  "",
+                  "pm.test('deploy azure description response is a one-item array', function () {",
+                  "  pm.expect(body).to.be.an('array').with.lengthOf(1);",
+                  "});",
+                  "",
+                  "pm.test('deploy azure description is non-empty for the requested image', function () {",
+                  "  pm.expect(body[0].imageUrl).to.eql(pm.environment.get('deployAzureImageUrl'));",
+                  "  pm.expect(body[0].description).to.be.a('string');",
+                  "  pm.expect(body[0].description.length).to.be.above(0);",
                   "});"
                 ]
               }

--- a/postman/environments/alt-text-generator.deploy.postman_environment.json
+++ b/postman/environments/alt-text-generator.deploy.postman_environment.json
@@ -1,0 +1,39 @@
+{
+  "id": "a97ef5e3-a830-48d4-82cf-bd6f963af2af",
+  "name": "alt-text-generator deploy",
+  "values": [
+    {
+      "key": "baseUrl",
+      "value": "https://wcag.qcraft.com.br",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "expectedSwaggerServerUrl",
+      "value": "https://wcag.qcraft.com.br",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "deployScrapePageUrl",
+      "value": "https://developer.mozilla.org/en-US/",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "deployAzureImageUrl",
+      "value": "https://developer.chrome.com/static/images/ai-homepage-card.png",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "maxResponseTimeMs",
+      "value": "15000",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2026-03-10T00:00:00.000Z",
+  "_postman_exported_using": "OpenAI GPT-5.4 Pro"
+}

--- a/postman/environments/alt-text-generator.local.stub.postman_environment.json
+++ b/postman/environments/alt-text-generator.local.stub.postman_environment.json
@@ -15,6 +15,12 @@
       "enabled": true
     },
     {
+      "key": "authBaseUrl",
+      "value": "https://127.0.0.1:18443",
+      "type": "default",
+      "enabled": true
+    },
+    {
       "key": "fixtureBaseUrl",
       "value": "http://127.0.0.1:19090",
       "type": "default",
@@ -77,6 +83,12 @@
     {
       "key": "expectedSwaggerServerUrl",
       "value": "https://localhost:8443",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "apiAuthToken",
+      "value": "postman-api-token",
       "type": "default",
       "enabled": true
     },

--- a/scripts/run-postman-deploy.js
+++ b/scripts/run-postman-deploy.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+/**
+ * Executes the hosted deploy verification folder from the Postman collection.
+ */
+
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const {
+  assertTopLevelFoldersExist,
+  listTopLevelFolderNames,
+  readCollection,
+} = require('./postman/collection-utils');
+
+const ROOT = path.resolve(__dirname, '..');
+const COLLECTION_PATH = path.join(
+  ROOT,
+  'postman',
+  'collections',
+  'alt-text-generator.postman_collection.json',
+);
+const ENV_PATH = path.join(
+  ROOT,
+  'postman',
+  'environments',
+  'alt-text-generator.deploy.postman_environment.json',
+);
+const REPORTS_DIR = path.join(ROOT, 'reports', 'newman');
+const DEPLOY_FOLDER = '95 Deploy Verification';
+const DEFAULT_BASE_URL = 'https://wcag.qcraft.com.br';
+const NPX = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+
+/**
+ * Normalizes a base URL for env-var reuse.
+ *
+ * @param {string} baseUrl
+ * @returns {string}
+ */
+function normalizeBaseUrl(baseUrl) {
+  return baseUrl.replace(/\/+$/, '');
+}
+
+/**
+ * Parses CLI arguments.
+ *
+ * @param {string[]} argv
+ * @returns {{ baseUrl: string }}
+ */
+function parseArgs(argv) {
+  const args = {
+    baseUrl: DEFAULT_BASE_URL,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${token}`);
+    }
+
+    const separatorIndex = token.indexOf('=');
+    const key = separatorIndex >= 0 ? token.slice(2, separatorIndex) : token.slice(2);
+    const rawValue = separatorIndex >= 0 ? token.slice(separatorIndex + 1) : argv[index + 1];
+
+    if (separatorIndex < 0) {
+      index += 1;
+    }
+
+    if (rawValue === undefined) {
+      throw new Error(`Missing value for --${key}`);
+    }
+
+    switch (key) {
+      case 'base-url':
+        args.baseUrl = rawValue;
+        break;
+      default:
+        throw new Error(`Unsupported argument: --${key}`);
+    }
+  }
+
+  return args;
+}
+
+/**
+ * Runs the deploy Newman folder.
+ *
+ * @param {string} baseUrl
+ * @returns {Promise<void>}
+ */
+function runNewman(baseUrl) {
+  const args = [
+    '--no-install',
+    'newman',
+    'run',
+    COLLECTION_PATH,
+    '-e',
+    ENV_PATH,
+    '--env-var',
+    `baseUrl=${baseUrl}`,
+    '--env-var',
+    `expectedSwaggerServerUrl=${baseUrl}`,
+    '--timeout-request',
+    '45000',
+    '--timeout-script',
+    '10000',
+    '-r',
+    'cli,json,junit',
+    '--reporter-json-export',
+    path.join(REPORTS_DIR, 'deploy.json'),
+    '--reporter-junit-export',
+    path.join(REPORTS_DIR, 'deploy.xml'),
+    '--folder',
+    DEPLOY_FOLDER,
+  ];
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(NPX, args, {
+      cwd: ROOT,
+      env: process.env,
+      stdio: 'inherit',
+    });
+
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      reject(new Error(`Deploy Newman run failed with exit code ${code}`));
+    });
+
+    child.on('error', reject);
+  });
+}
+
+/**
+ * Entry point.
+ *
+ * @returns {Promise<void>}
+ */
+async function main() {
+  const { baseUrl } = parseArgs(process.argv.slice(2));
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  const collection = readCollection(COLLECTION_PATH);
+  const availableFolders = listTopLevelFolderNames(collection);
+
+  assertTopLevelFoldersExist(
+    availableFolders,
+    [DEPLOY_FOLDER],
+    'deploy mode',
+  );
+
+  await fs.mkdir(REPORTS_DIR, { recursive: true });
+  await runNewman(normalizedBaseUrl);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  normalizeBaseUrl,
+  parseArgs,
+};

--- a/scripts/run-postman-harness.js
+++ b/scripts/run-postman-harness.js
@@ -34,7 +34,10 @@ const REPORTS_DIR = path.join(ROOT, 'reports', 'newman');
 const HOST = '127.0.0.1';
 const APP_HTTP_PORT = '8080';
 const APP_HTTPS_PORT = '8443';
+const AUTH_APP_HTTP_PORT = String(process.env.POSTMAN_AUTH_HTTP_PORT || 18080);
+const AUTH_APP_HTTPS_PORT = String(process.env.POSTMAN_AUTH_HTTPS_PORT || 18443);
 const FIXTURE_PORT = String(process.env.POSTMAN_FIXTURE_PORT || 19090);
+const API_AUTH_TOKEN = process.env.POSTMAN_API_AUTH_TOKEN || 'postman-api-token';
 
 const NODE = process.execPath;
 const NPX = process.platform === 'win32' ? 'npx.cmd' : 'npx';
@@ -138,14 +141,68 @@ function spawnLogged(label, command, args, env = {}) {
 }
 
 /**
+ * Builds the environment for a local app instance.
+ *
+ * @param {{
+ *   httpPort: string,
+ *   httpsPort: string,
+ *   liveModeEnabled: boolean,
+ *   hasLiveAzureConfig: boolean,
+ *   azureSubscriptionKey: string | null,
+ *   apiAuthTokens?: string | null,
+ * }} options
+ * @returns {Record<string, string>}
+ */
+function buildAppServerEnv({
+  httpPort,
+  httpsPort,
+  liveModeEnabled,
+  hasLiveAzureConfig,
+  azureSubscriptionKey,
+  apiAuthTokens = null,
+}) {
+  const env = {
+    NODE_ENV: 'development',
+    PORT: httpPort,
+    TLS_PORT: httpsPort,
+    WORKER_COUNT: '1',
+    LOG_LEVEL: 'info',
+    SWAGGER_DEV_URL: `https://localhost:${httpsPort}`,
+    REPLICATE_API_TOKEN: process.env.REPLICATE_API_TOKEN || 'test-token',
+    ACV_API_ENDPOINT: liveModeEnabled && hasLiveAzureConfig
+      ? process.env.ACV_API_ENDPOINT
+      : `http://${HOST}:${FIXTURE_PORT}/vision/v3.2/describe`,
+    ACV_SUBSCRIPTION_KEY: liveModeEnabled && hasLiveAzureConfig
+      ? azureSubscriptionKey
+      : 'stub-key',
+    ACV_LANGUAGE: 'en',
+    ACV_MAX_CANDIDATES: '4',
+  };
+
+  if (apiAuthTokens) {
+    env.API_AUTH_TOKENS = apiAuthTokens;
+  }
+
+  return env;
+}
+
+/**
  * Runs Newman for the given folder list.
  *
  * @param {string} label
  * @param {string[]} folders
- * @param {string[]} extraArgs
+ * @param {{ envPath?: string, envVars?: string[], extraArgs?: string[] }} options
  * @returns {Promise<void>}
  */
-function runNewman(label, folders, extraArgs = []) {
+function runNewman(
+  label,
+  folders,
+  {
+    envPath = ENV_PATH,
+    envVars = [],
+    extraArgs = [],
+  } = {},
+) {
   const folderArgs = folders.flatMap((folder) => ['--folder', folder]);
 
   const args = [
@@ -154,7 +211,7 @@ function runNewman(label, folders, extraArgs = []) {
     'run',
     COLLECTION_PATH,
     '-e',
-    ENV_PATH,
+    envPath,
     '--env-var',
     `baseUrl=https://${HOST}:${APP_HTTPS_PORT}`,
     '--env-var',
@@ -185,6 +242,7 @@ function runNewman(label, folders, extraArgs = []) {
     'model=azure',
     '--env-var',
     'maxResponseTimeMs=1500',
+    ...envVars.flatMap((envVar) => ['--env-var', envVar]),
     '--timeout-request',
     '10000',
     '--timeout-script',
@@ -264,6 +322,7 @@ function installSignalCleanup(children) {
 async function main() {
   const mode = process.argv[2] || 'full';
   const liveModeEnabled = mode === 'live' || process.env.RUN_LIVE_PROVIDER === 'true';
+  const requiresAuthHarness = mode === 'smoke' || mode === 'full';
   const runLiveReplicate = process.env.RUN_LIVE_REPLICATE !== 'false';
   const runLiveAzure = process.env.RUN_LIVE_AZURE !== 'false';
   const azureSubscriptionKey = process.env.ACV_SUBSCRIPTION_KEY || process.env.ACV_API_KEY || null;
@@ -271,6 +330,10 @@ async function main() {
   const managedChildren = new Set();
   const collection = readCollection(COLLECTION_PATH);
   const availableFolders = listTopLevelFolderNames(collection);
+  const localNewmanEnvVars = [
+    `authBaseUrl=https://${HOST}:${AUTH_APP_HTTPS_PORT}`,
+    `apiAuthToken=${API_AUTH_TOKEN}`,
+  ];
 
   await fs.mkdir(REPORTS_DIR, { recursive: true });
 
@@ -289,26 +352,35 @@ async function main() {
     'app',
     NODE,
     [path.join(ROOT, 'src', 'app.js')],
-    {
-      NODE_ENV: 'development',
-      PORT: APP_HTTP_PORT,
-      TLS_PORT: APP_HTTPS_PORT,
-      WORKER_COUNT: '1',
-      LOG_LEVEL: 'info',
-      SWAGGER_DEV_URL: `https://localhost:${APP_HTTPS_PORT}`,
-      REPLICATE_API_TOKEN: process.env.REPLICATE_API_TOKEN || 'test-token',
-      ACV_API_ENDPOINT: liveModeEnabled && hasLiveAzureConfig
-        ? process.env.ACV_API_ENDPOINT
-        : `http://${HOST}:${FIXTURE_PORT}/vision/v3.2/describe`,
-      ACV_SUBSCRIPTION_KEY: liveModeEnabled && hasLiveAzureConfig
-        ? azureSubscriptionKey
-        : 'stub-key',
-      ACV_LANGUAGE: 'en',
-      ACV_MAX_CANDIDATES: '4',
-    },
+    buildAppServerEnv({
+      httpPort: APP_HTTP_PORT,
+      httpsPort: APP_HTTPS_PORT,
+      liveModeEnabled,
+      hasLiveAzureConfig,
+      azureSubscriptionKey,
+    }),
   );
   managedChildren.add(appServer);
   appServer.once('exit', () => managedChildren.delete(appServer));
+
+  let authAppServer;
+  if (requiresAuthHarness) {
+    authAppServer = spawnLogged(
+      'app-auth',
+      NODE,
+      [path.join(ROOT, 'src', 'app.js')],
+      buildAppServerEnv({
+        httpPort: AUTH_APP_HTTP_PORT,
+        httpsPort: AUTH_APP_HTTPS_PORT,
+        liveModeEnabled: false,
+        hasLiveAzureConfig: false,
+        azureSubscriptionKey: null,
+        apiAuthTokens: API_AUTH_TOKEN,
+      }),
+    );
+    managedChildren.add(authAppServer);
+    authAppServer.once('exit', () => managedChildren.delete(authAppServer));
+  }
   const cleanupSignalHandlers = installSignalCleanup(managedChildren);
 
   try {
@@ -316,6 +388,11 @@ async function main() {
     await waitForUrl(`https://${HOST}:${APP_HTTPS_PORT}/api/health`, {
       insecure: true,
     });
+    if (authAppServer) {
+      await waitForUrl(`https://${HOST}:${AUTH_APP_HTTPS_PORT}/api/health`, {
+        insecure: true,
+      });
+    }
 
     if (mode === 'smoke') {
       assertTopLevelFoldersExist(
@@ -323,6 +400,7 @@ async function main() {
         [
           '00 Core Smoke',
           '07 Route Aliases',
+          '08 API Auth Contract',
           '10 Scraper Contract',
           '20 Single Description (Azure Stub)',
         ],
@@ -333,10 +411,14 @@ async function main() {
         [
           '00 Core Smoke',
           '07 Route Aliases',
+          '08 API Auth Contract',
           '10 Scraper Contract',
           '20 Single Description (Azure Stub)',
         ],
-        ['--insecure'],
+        {
+          envVars: localNewmanEnvVars,
+          extraArgs: ['--insecure'],
+        },
       );
 
       assertTopLevelFoldersExist(
@@ -347,7 +429,10 @@ async function main() {
       await runNewman(
         'routing',
         ['05 Routing & Redirects'],
-        ['--insecure', '--ignore-redirects'],
+        {
+          envVars: localNewmanEnvVars,
+          extraArgs: ['--insecure', '--ignore-redirects'],
+        },
       );
     }
 
@@ -357,6 +442,7 @@ async function main() {
         [
           '00 Core Smoke',
           '07 Route Aliases',
+          '08 API Auth Contract',
           '10 Scraper Contract',
           '20 Single Description (Azure Stub)',
           '30 Page Descriptions (Azure Stub)',
@@ -369,12 +455,16 @@ async function main() {
         [
           '00 Core Smoke',
           '07 Route Aliases',
+          '08 API Auth Contract',
           '10 Scraper Contract',
           '20 Single Description (Azure Stub)',
           '30 Page Descriptions (Azure Stub)',
           '40 Negative Paths',
         ],
-        ['--insecure'],
+        {
+          envVars: localNewmanEnvVars,
+          extraArgs: ['--insecure'],
+        },
       );
 
       assertTopLevelFoldersExist(
@@ -385,7 +475,10 @@ async function main() {
       await runNewman(
         'routing',
         ['05 Routing & Redirects'],
-        ['--insecure', '--ignore-redirects'],
+        {
+          envVars: localNewmanEnvVars,
+          extraArgs: ['--insecure', '--ignore-redirects'],
+        },
       );
     }
 
@@ -421,13 +514,17 @@ async function main() {
       await runNewman(
         'live-provider',
         liveFolders,
-        ['--insecure'],
+        {
+          envVars: localNewmanEnvVars,
+          extraArgs: ['--insecure'],
+        },
       );
     }
   } finally {
     cleanupSignalHandlers();
     terminate(fixtureServer);
     terminate(appServer);
+    terminate(authAppServer);
   }
 }
 

--- a/tests/unit/scripts/runPostmanDeploy.test.js
+++ b/tests/unit/scripts/runPostmanDeploy.test.js
@@ -1,0 +1,30 @@
+const {
+  normalizeBaseUrl,
+  parseArgs,
+} = require('../../../scripts/run-postman-deploy');
+
+describe('scripts/run-postman-deploy', () => {
+  describe('parseArgs', () => {
+    it('uses the production base URL by default', () => {
+      expect(parseArgs([])).toEqual({
+        baseUrl: 'https://wcag.qcraft.com.br',
+      });
+    });
+
+    it('parses the supported base-url flag', () => {
+      expect(parseArgs(['--base-url', 'https://wcag.qcraft.com.br/preview'])).toEqual({
+        baseUrl: 'https://wcag.qcraft.com.br/preview',
+      });
+    });
+
+    it('rejects unsupported flags', () => {
+      expect(() => parseArgs(['--nope', 'value'])).toThrow('Unsupported argument: --nope');
+    });
+  });
+
+  describe('normalizeBaseUrl', () => {
+    it('strips trailing slashes from the base URL', () => {
+      expect(normalizeBaseUrl('https://wcag.qcraft.com.br/')).toBe('https://wcag.qcraft.com.br');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated Newman auth folder that exercises protected endpoint behavior with no auth, X-API-Key, and Bearer token flows
- add a deploy Newman folder and deploy environment, plus a small deploy runner script for hosted smoke verification
- switch the deploy verification workflow to the shared Newman suite and document the new tiers

## Validation
- npm run lint
- NODE_ENV=test REPLICATE_API_TOKEN=test-token npm test -- --runInBand
- npm run postman:smoke
- npm run postman:harness
- npm run postman:deploy -- --base-url https://wcag.qcraft.com.br
- ruby -e 'require "yaml"; Dir[".github/**/*.yml"].sort.each { |f| YAML.load_file(f); puts "ok #{f}" }'
- /tmp/actionlint -color