### PR TITLE
Harden live provider workflow defaults

### DIFF
--- a/.github/workflows/live-provider-validation.yml
+++ b/.github/workflows/live-provider-validation.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       run_replicate:
-        description: Include Replicate live validation. Use auto to defer to environment defaults.
+        description: Include Replicate live validation. Use auto to keep Replicate opt-in unless explicitly enabled.
         required: false
         default: auto
         type: choice
@@ -13,7 +13,7 @@ on:
           - true
           - false
       run_azure:
-        description: Include Azure live validation when Azure secrets are configured. Use auto to defer to environment defaults.
+        description: Include Azure live validation when Azure secrets are configured. Use auto to prefer Azure when available.
         required: false
         default: auto
         type: choice
@@ -71,6 +71,10 @@ jobs:
           SECRET_RUN_REPLICATE: ${{ secrets.RUN_REPLICATE }}
           SECRET_RUN_LIVE_AZURE: ${{ secrets.RUN_LIVE_AZURE }}
           SECRET_RUN_AZURE: ${{ secrets.RUN_AZURE }}
+          REPLICATE_API_TOKEN_CONFIGURED: ${{ secrets.REPLICATE_API_TOKEN != '' && 'true' || 'false' }}
+          ACV_API_ENDPOINT_CONFIGURED: ${{ secrets.ACV_API_ENDPOINT != '' && 'true' || 'false' }}
+          ACV_SUBSCRIPTION_KEY_CONFIGURED: ${{ secrets.ACV_SUBSCRIPTION_KEY != '' && 'true' || 'false' }}
+          ACV_API_KEY_CONFIGURED: ${{ secrets.ACV_API_KEY != '' && 'true' || 'false' }}
           ENABLE_SCHEDULED_AZURE_LIVE_VALIDATION: ${{ vars.ENABLE_SCHEDULED_AZURE_LIVE_VALIDATION }}
         run: |
           normalize_boolean() {
@@ -143,17 +147,38 @@ jobs:
             printf '%s\n' "$default_value"
           }
 
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "RUN_REPLICATE=true" >> "$GITHUB_ENV"
-            if [ "${ENABLE_SCHEDULED_AZURE_LIVE_VALIDATION}" = "true" ]; then
-              echo "RUN_AZURE=true" >> "$GITHUB_ENV"
-            else
-              echo "RUN_AZURE=false" >> "$GITHUB_ENV"
-            fi
-          else
-            echo "RUN_REPLICATE=$(resolve_manual_toggle "$INPUT_RUN_REPLICATE" "$ENV_RUN_LIVE_REPLICATE" "$ENV_RUN_REPLICATE" "$SECRET_RUN_LIVE_REPLICATE" "$SECRET_RUN_REPLICATE" "true")" >> "$GITHUB_ENV"
-            echo "RUN_AZURE=$(resolve_manual_toggle "$INPUT_RUN_AZURE" "$ENV_RUN_LIVE_AZURE" "$ENV_RUN_AZURE" "$SECRET_RUN_LIVE_AZURE" "$SECRET_RUN_AZURE" "true")" >> "$GITHUB_ENV"
+          azure_configured='false'
+          if [ "${ACV_API_ENDPOINT_CONFIGURED}" = "true" ] && { [ "${ACV_SUBSCRIPTION_KEY_CONFIGURED}" = "true" ] || [ "${ACV_API_KEY_CONFIGURED}" = "true" ]; }; then
+            azure_configured='true'
           fi
+
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            run_replicate="$(resolve_manual_toggle "auto" "$ENV_RUN_LIVE_REPLICATE" "$ENV_RUN_REPLICATE" "$SECRET_RUN_LIVE_REPLICATE" "$SECRET_RUN_REPLICATE" "false")"
+            scheduled_azure_default='false'
+            if [ "${ENABLE_SCHEDULED_AZURE_LIVE_VALIDATION}" = "true" ] && [ "${azure_configured}" = "true" ]; then
+              scheduled_azure_default='true'
+            fi
+            run_azure="$(resolve_manual_toggle "auto" "$ENV_RUN_LIVE_AZURE" "$ENV_RUN_AZURE" "$SECRET_RUN_LIVE_AZURE" "$SECRET_RUN_AZURE" "${scheduled_azure_default}")"
+          else
+            manual_azure_default='false'
+            if [ "${azure_configured}" = "true" ]; then
+              manual_azure_default='true'
+            fi
+
+            run_replicate="$(resolve_manual_toggle "$INPUT_RUN_REPLICATE" "$ENV_RUN_LIVE_REPLICATE" "$ENV_RUN_REPLICATE" "$SECRET_RUN_LIVE_REPLICATE" "$SECRET_RUN_REPLICATE" "false")"
+            run_azure="$(resolve_manual_toggle "$INPUT_RUN_AZURE" "$ENV_RUN_LIVE_AZURE" "$ENV_RUN_AZURE" "$SECRET_RUN_LIVE_AZURE" "$SECRET_RUN_AZURE" "${manual_azure_default}")"
+
+            if [ "${run_replicate}" = "false" ] && [ "${run_azure}" = "false" ]; then
+              if [ "${azure_configured}" = "true" ]; then
+                run_azure='true'
+              elif [ "${REPLICATE_API_TOKEN_CONFIGURED}" = "true" ]; then
+                run_replicate='true'
+              fi
+            fi
+          fi
+
+          echo "RUN_REPLICATE=${run_replicate}" >> "$GITHUB_ENV"
+          echo "RUN_AZURE=${run_azure}" >> "$GITHUB_ENV"
 
       - name: Validate live-provider secrets
         env:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Notes:
 - `postman:deploy` runs the hosted deploy-smoke folder from the same Postman collection against a supplied base URL.
 - CI runs `postman:smoke` on pull requests and `postman:harness` on `main` / `production` pushes.
 - Deploy verification runs `postman:deploy` on `production` pushes so hosted smoke checks stay inside the Newman contract layer.
-- Live mode validates Replicate by default and also validates Azure when `ACV_API_ENDPOINT` and either `ACV_SUBSCRIPTION_KEY` or `ACV_API_KEY` are set.
+- Live mode is opt-in, prefers Azure when Azure credentials are configured, and only runs Replicate when it is explicitly enabled or it is the only configured live provider.
 - Local harness runs accept self-signed development TLS.
 - The deterministic harness uses a local Azure stub and can boot with a dummy Replicate token or Azure-only configuration.
 


### PR DESCRIPTION
## Summary
- make live provider auto-selection prefer Azure and keep Replicate opt-in
- stop scheduled validation from forcing Replicate when no toggle enables it
- update the README note for live contract validation defaults

## Validation
- actionlint .github/workflows/live-provider-validation.yml .github/workflows/deploy-verification.yml
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts "OK #{f}" }'
