### PR TITLE
Promote main to production

### DIFF
--- a/postman/environments/alt-text-generator.production.postman_environment.json
+++ b/postman/environments/alt-text-generator.production.postman_environment.json
@@ -16,7 +16,7 @@
     },
     {
       "key": "deployScrapePageUrl",
-      "value": "https://developer.mozilla.org/en-US/",
+      "value": "https://wcag.qcraft.com.br/api-docs/",
       "type": "default",
       "enabled": true
     },

--- a/scripts/run-postman-deploy.js
+++ b/scripts/run-postman-deploy.js
@@ -147,6 +147,38 @@ function parseArgs(argv) {
 }
 
 /**
+ * Builds the Newman environment variables for deploy verification.
+ *
+ * @param {string} baseUrl
+ * @param {{
+ *   deployValidationApiToken: string,
+ *   productionApiAuthEnabled: 'true'|'false',
+ * }} options
+ * @returns {{
+ *   baseUrl: string,
+ *   deployScrapePageUrl: string,
+ *   deployValidationApiToken: string,
+ *   expectedSwaggerServerUrl: string,
+ *   productionApiAuthEnabled: 'true'|'false',
+ * }}
+ */
+function buildDeployEnvVars(
+  baseUrl,
+  {
+    deployValidationApiToken,
+    productionApiAuthEnabled,
+  },
+) {
+  return {
+    baseUrl,
+    deployScrapePageUrl: new URL('api-docs/', `${baseUrl}/`).toString(),
+    deployValidationApiToken,
+    expectedSwaggerServerUrl: baseUrl,
+    productionApiAuthEnabled,
+  };
+}
+
+/**
  * Runs the deploy Newman folder.
  *
  * @param {string} baseUrl
@@ -166,6 +198,10 @@ function runNewman(
   },
 ) {
   const folderArgs = folders.flatMap((folder) => ['--folder', folder]);
+  const envVarArgs = Object.entries(buildDeployEnvVars(baseUrl, {
+    deployValidationApiToken,
+    productionApiAuthEnabled,
+  })).flatMap(([key, value]) => ['--env-var', `${key}=${value}`]);
   const args = [
     '--no-install',
     'newman',
@@ -173,14 +209,7 @@ function runNewman(
     COLLECTION_PATH,
     '-e',
     ENV_PATH,
-    '--env-var',
-    `baseUrl=${baseUrl}`,
-    '--env-var',
-    `expectedSwaggerServerUrl=${baseUrl}`,
-    '--env-var',
-    `productionApiAuthEnabled=${productionApiAuthEnabled}`,
-    '--env-var',
-    `deployValidationApiToken=${deployValidationApiToken}`,
+    ...envVarArgs,
     '--timeout-request',
     '45000',
     '--timeout-script',
@@ -256,6 +285,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  buildDeployEnvVars,
   normalizeBaseUrl,
   normalizeBooleanFlag,
   parseArgs,

--- a/tests/unit/scripts/runPostmanDeploy.test.js
+++ b/tests/unit/scripts/runPostmanDeploy.test.js
@@ -1,4 +1,5 @@
 const {
+  buildDeployEnvVars,
   normalizeBooleanFlag,
   normalizeBaseUrl,
   parseArgs,
@@ -27,6 +28,21 @@ describe('scripts/run-postman-deploy', () => {
   describe('normalizeBaseUrl', () => {
     it('strips trailing slashes from the base URL', () => {
       expect(normalizeBaseUrl('https://wcag.qcraft.com.br/')).toBe('https://wcag.qcraft.com.br');
+    });
+  });
+
+  describe('buildDeployEnvVars', () => {
+    it('targets the hosted api-docs page for deploy scraper verification', () => {
+      expect(buildDeployEnvVars('https://wcag.qcraft.com.br', {
+        productionApiAuthEnabled: 'true',
+        deployValidationApiToken: 'deploy-token',
+      })).toEqual({
+        baseUrl: 'https://wcag.qcraft.com.br',
+        deployScrapePageUrl: 'https://wcag.qcraft.com.br/api-docs/',
+        deployValidationApiToken: 'deploy-token',
+        expectedSwaggerServerUrl: 'https://wcag.qcraft.com.br',
+        productionApiAuthEnabled: 'true',
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- promote the latest validated main changes to production
- includes the deploy scraper verification stabilization fix

## Validation
- npm run lint
- NODE_ENV=test REPLICATE_API_TOKEN=test-token npm test -- --runInBand
- npm run postman:smoke
- npx jest tests/unit/scripts/runPostmanDeploy.test.js --runInBand --coverage=false