### PR TITLE
Improve Allure suite names and Postman status contracts

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -210,7 +210,8 @@ Allure workflow:
 - `npm run postman:harness:allure` enables the official Newman Allure reporter without removing the existing JSON/JUnit exports.
 - `npm run report:allure` mirrors CI by cleaning old results, running Jest, running the deterministic Newman harness, and generating HTML from the merged `reports/allure-results/` directory.
 - GitHub Actions publishes Allure from the canonical Node 20 Jest lane only so matrix lanes 22 and 24 do not duplicate unit tests in the merged report.
-- On pushes to `main`, the CI workflow uploads the generated HTML as both a regular artifact and a GitHub Pages deployment artifact, then deploys the report to `https://jsugg.github.io/alt-text-generator/`.
+- The public GitHub Pages deployment is `https://jsugg.github.io/alt-text-generator/`; the suites view is `https://jsugg.github.io/alt-text-generator/#suites`.
+- On pushes to `main`, the CI workflow uploads the generated HTML as both a regular artifact and a GitHub Pages deployment artifact, then deploys the latest report once the `allure-pages` job succeeds.
 - Pull requests do not deploy Pages; they still produce the downloadable `allure-report` artifact for review.
 
 ## Supported Models

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ Notes:
 - Raw Allure files accumulate under `reports/allure-results/`; generated HTML is written to `reports/allure-report/`.
 - The combined report merges one canonical Jest run with the Newman harness so local and CI results follow the same structure.
 - CI uploads the generated HTML as the `allure-report` artifact.
-- Pushes to `main` also publish the generated report to GitHub Pages at `https://jsugg.github.io/alt-text-generator/` once GitHub Pages is enabled for the repository with GitHub Actions as the source.
+- The public Pages deployment is `https://jsugg.github.io/alt-text-generator/`; the suites view is `https://jsugg.github.io/alt-text-generator/#suites`.
+- Pushes to `main` publish the latest generated report to GitHub Pages after the `allure-pages` job finishes successfully.
 - CI only emits Jest Allure results from the Node 20 lane so unit tests do not appear three times in the merged report.
 - The Allure CLI requires Java when you generate the HTML report locally or in CI.
 

--- a/postman/collections/alt-text-generator.postman_collection.json
+++ b/postman/collections/alt-text-generator.postman_collection.json
@@ -18,21 +18,11 @@
           ");",
           "",
           "const expectedStatusCodeRaw = pm.request.headers.get('X-Expected-Status-Code') || '';",
-          "const expectedStatusClass = pm.request.headers.get('X-Expected-Status-Class') || '';",
           "",
           "if (/^\\d+$/.test(expectedStatusCodeRaw)) {",
           "  const expectedStatusCode = Number(expectedStatusCodeRaw);",
           "  pm.test(`response status is exactly ${expectedStatusCode}`, function () {",
           "    pm.expect(pm.response.code, `unexpected status ${pm.response.code}`).to.eql(expectedStatusCode);",
-          "  });",
-          "} else if (expectedStatusClass === '5xx') {",
-          "  pm.test('response is an expected 5xx', function () {",
-          "    pm.expect(pm.response.code, `unexpected status ${pm.response.code}`).to.be.at.least(500);",
-          "    pm.expect(pm.response.code, `unexpected status ${pm.response.code}`).to.be.below(600);",
-          "  });",
-          "} else {",
-          "  pm.test('response is not 5xx', function () {",
-          "    pm.expect(pm.response.code, `unexpected status ${pm.response.code}`).to.be.below(500);",
           "  });",
           "}",
           "",
@@ -127,6 +117,10 @@
               {
                 "key": "Accept",
                 "value": "text/plain"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               }
             ],
             "url": {
@@ -167,6 +161,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               }
             ],
             "url": {
@@ -235,6 +233,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               }
             ],
             "url": {
@@ -282,6 +284,10 @@
               {
                 "key": "Accept",
                 "value": "text/html"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               }
             ],
             "url": {
@@ -330,6 +336,10 @@
               {
                 "key": "Accept",
                 "value": "application/javascript"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               }
             ],
             "url": {
@@ -394,6 +404,10 @@
               {
                 "key": "Accept",
                 "value": "text/html"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "302"
               }
             ],
             "url": {
@@ -438,6 +452,10 @@
               {
                 "key": "Accept",
                 "value": "text/plain"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "302"
               }
             ],
             "url": {
@@ -487,6 +505,10 @@
               {
                 "key": "Accept",
                 "value": "text/plain"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               }
             ],
             "url": {
@@ -528,6 +550,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               }
             ],
             "url": {
@@ -575,6 +601,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               }
             ],
             "url": {
@@ -630,6 +660,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               }
             ],
             "url": {
@@ -686,6 +720,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               }
             ],
             "url": {
@@ -750,6 +788,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "401"
               }
             ],
             "url": {
@@ -806,6 +848,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               },
               {
                 "key": "X-API-Key",
@@ -867,6 +913,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               },
               {
                 "key": "Authorization",
@@ -932,6 +982,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               }
             ],
             "url": {
@@ -998,6 +1052,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               }
             ],
             "url": {
@@ -1062,8 +1120,8 @@
                 "value": "application/json"
               },
               {
-                "key": "X-Expected-Status-Class",
-                "value": "5xx"
+                "key": "X-Expected-Status-Code",
+                "value": "500"
               }
             ],
             "url": {
@@ -1122,8 +1180,8 @@
                 "value": "application/json"
               },
               {
-                "key": "X-Expected-Status-Class",
-                "value": "5xx"
+                "key": "X-Expected-Status-Code",
+                "value": "500"
               }
             ],
             "url": {
@@ -1185,6 +1243,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               }
             ],
             "url": {
@@ -1287,6 +1349,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               }
             ],
             "url": {
@@ -1355,8 +1421,8 @@
                 "value": "application/json"
               },
               {
-                "key": "X-Expected-Status-Class",
-                "value": "5xx"
+                "key": "X-Expected-Status-Code",
+                "value": "500"
               }
             ],
             "url": {
@@ -1418,6 +1484,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "400"
               }
             ],
             "url": {
@@ -1465,6 +1535,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "400"
               }
             ],
             "url": {
@@ -1518,6 +1592,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "400"
               }
             ],
             "url": {
@@ -1571,6 +1649,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "400"
               }
             ],
             "url": {
@@ -1628,6 +1710,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "400"
               }
             ],
             "url": {
@@ -1685,6 +1771,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "400"
               }
             ],
             "url": {
@@ -1738,6 +1828,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "400"
               }
             ],
             "url": {
@@ -1795,6 +1889,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "400"
               }
             ],
             "url": {
@@ -1852,6 +1950,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "404"
               }
             ],
             "url": {
@@ -1902,6 +2004,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               },
               {
                 "key": "X-Max-Response-Time-Ms",
@@ -1966,6 +2072,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               },
               {
                 "key": "X-Max-Response-Time-Ms",
@@ -2048,6 +2158,10 @@
                 "value": "application/json"
               },
               {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
+              },
+              {
                 "key": "X-Max-Response-Time-Ms",
                 "value": "15000"
               }
@@ -2110,6 +2224,10 @@
               {
                 "key": "Accept",
                 "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               },
               {
                 "key": "X-Max-Response-Time-Ms",
@@ -2193,6 +2311,10 @@
                 "value": "application/json"
               },
               {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
+              },
+              {
                 "key": "X-Max-Response-Time-Ms",
                 "value": "45000"
               }
@@ -2241,6 +2363,10 @@
               {
                 "key": "Accept",
                 "value": "application/javascript"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               }
             ],
             "url": {
@@ -2354,137 +2480,145 @@
       ]
     },
     {
-          "name": "96 Deploy Protected Verification",
-          "item": [
-            {
-              "name": "Hosted scraper contract",
-              "request": {
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "Authorization",
-                    "value": "Bearer {{deployValidationApiToken}}"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/api/scraper/images",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "api",
-                    "scraper",
-                    "images"
-                  ],
-                  "query": [
-                    {
-                      "key": "url",
-                      "value": "{{deployScrapePageUrl}}"
-                    }
-                  ]
-                }
+      "name": "96 Deploy Protected Verification",
+      "item": [
+        {
+          "name": "Hosted scraper contract",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
               },
-              "response": [],
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "type": "text/javascript",
-                    "exec": [
-                      "pm.test('deploy scraper returns 200', function () {",
-                      "  pm.expect(pm.response.code, 'Expected deploy scraper request to succeed. Verify PRODUCTION_DEPLOY_VALIDATION_API_TOKEN matches a token in Render API_AUTH_TOKENS when Render API_AUTH_ENABLED=true.').to.eql(200);",
-                      "});",
-                      "",
-                      "const body = pm.response.json();",
-                      "",
-                      "pm.test('deploy scraper response has an imageSources array', function () {",
-                      "  pm.expect(body).to.have.property('imageSources');",
-                      "  pm.expect(body.imageSources).to.be.an('array');",
-                      "});",
-                      "",
-                      "pm.test('deploy scraper image sources are strings when present', function () {",
-                      "  body.imageSources.forEach((imageUrl) => {",
-                      "    pm.expect(imageUrl).to.be.a('string');",
-                      "  });",
-                      "});"
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              "name": "Hosted azure single description",
-              "request": {
-                "method": "GET",
-                "header": [
-                  {
-                    "key": "Accept",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "X-Max-Response-Time-Ms",
-                    "value": "20000"
-                  },
-                  {
-                    "key": "X-API-Key",
-                    "value": "{{deployValidationApiToken}}"
-                  }
-                ],
-                "url": {
-                  "raw": "{{baseUrl}}/api/accessibility/description",
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "path": [
-                    "api",
-                    "accessibility",
-                    "description"
-                  ],
-                  "query": [
-                    {
-                      "key": "image_source",
-                      "value": "{{deployAzureImageUrl}}"
-                    },
-                    {
-                      "key": "model",
-                      "value": "azure"
-                    }
-                  ]
-                }
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
               },
-              "response": [],
-              "event": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{deployValidationApiToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/scraper/images",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "scraper",
+                "images"
+              ],
+              "query": [
                 {
-                  "listen": "test",
-                  "script": {
-                    "type": "text/javascript",
-                    "exec": [
-                      "pm.test('deploy azure description returns 200', function () {",
-                      "  pm.expect(pm.response.code, 'Expected deploy azure description request to succeed. Verify PRODUCTION_DEPLOY_VALIDATION_API_TOKEN matches a token in Render API_AUTH_TOKENS when Render API_AUTH_ENABLED=true.').to.eql(200);",
-                      "});",
-                      "",
-                      "const body = pm.response.json();",
-                      "",
-                      "pm.test('deploy azure description response is a one-item array', function () {",
-                      "  pm.expect(body).to.be.an('array').with.lengthOf(1);",
-                      "});",
-                      "",
-                      "pm.test('deploy azure description is non-empty for the requested image', function () {",
-                      "  pm.expect(body[0].imageUrl).to.eql(pm.environment.get('deployAzureImageUrl'));",
-                      "  pm.expect(body[0].description).to.be.a('string');",
-                      "  pm.expect(body[0].description.length).to.be.above(0);",
-                      "});"
-                    ]
-                  }
+                  "key": "url",
+                  "value": "{{deployScrapePageUrl}}"
                 }
               ]
             }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('deploy scraper returns 200', function () {",
+                  "  pm.expect(pm.response.code, 'Expected deploy scraper request to succeed. Verify PRODUCTION_DEPLOY_VALIDATION_API_TOKEN matches a token in Render API_AUTH_TOKENS when Render API_AUTH_ENABLED=true.').to.eql(200);",
+                  "});",
+                  "",
+                  "const body = pm.response.json();",
+                  "",
+                  "pm.test('deploy scraper response has an imageSources array', function () {",
+                  "  pm.expect(body).to.have.property('imageSources');",
+                  "  pm.expect(body.imageSources).to.be.an('array');",
+                  "});",
+                  "",
+                  "pm.test('deploy scraper image sources are strings when present', function () {",
+                  "  body.imageSources.forEach((imageUrl) => {",
+                  "    pm.expect(imageUrl).to.be.a('string');",
+                  "  });",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Hosted azure single description",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Expected-Status-Code",
+                "value": "200"
+              },
+              {
+                "key": "X-Max-Response-Time-Ms",
+                "value": "20000"
+              },
+              {
+                "key": "X-API-Key",
+                "value": "{{deployValidationApiToken}}"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/accessibility/description",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "accessibility",
+                "description"
+              ],
+              "query": [
+                {
+                  "key": "image_source",
+                  "value": "{{deployAzureImageUrl}}"
+                },
+                {
+                  "key": "model",
+                  "value": "azure"
+                }
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('deploy azure description returns 200', function () {",
+                  "  pm.expect(pm.response.code, 'Expected deploy azure description request to succeed. Verify PRODUCTION_DEPLOY_VALIDATION_API_TOKEN matches a token in Render API_AUTH_TOKENS when Render API_AUTH_ENABLED=true.').to.eql(200);",
+                  "});",
+                  "",
+                  "const body = pm.response.json();",
+                  "",
+                  "pm.test('deploy azure description response is a one-item array', function () {",
+                  "  pm.expect(body).to.be.an('array').with.lengthOf(1);",
+                  "});",
+                  "",
+                  "pm.test('deploy azure description is non-empty for the requested image', function () {",
+                  "  pm.expect(body[0].imageUrl).to.eql(pm.environment.get('deployAzureImageUrl'));",
+                  "  pm.expect(body[0].description).to.be.a('string');",
+                  "  pm.expect(body[0].description.length).to.be.above(0);",
+                  "});"
+                ]
+              }
+            }
           ]
         }
+      ]
+    }
   ],
   "variable": [
     {

--- a/scripts/postman/collection-utils.js
+++ b/scripts/postman/collection-utils.js
@@ -45,7 +45,20 @@ function listRequestItems(collection) {
 }
 
 /**
- * Returns true when the request item includes an exact status assertion.
+ * Returns true when the request item includes a numeric X-Expected-Status-Code header.
+ *
+ * @param {object} item
+ * @returns {boolean}
+ */
+function hasExpectedStatusCodeHeader(item) {
+  return Boolean((item?.request?.header ?? []).some((header) => (
+    header?.key === 'X-Expected-Status-Code'
+      && /^\d+$/u.test(String(header.value ?? '').trim())
+  )));
+}
+
+/**
+ * Returns true when the request item includes an exact status assertion in its own tests.
  *
  * @param {object} item
  * @returns {boolean}
@@ -64,13 +77,23 @@ function hasExactStatusAssertion(item) {
 }
 
 /**
- * Throws when one or more requests are missing an exact status assertion.
+ * Returns true when the request item includes a specific status contract.
+ *
+ * @param {object} item
+ * @returns {boolean}
+ */
+function hasSpecificStatusExpectation(item) {
+  return hasExpectedStatusCodeHeader(item) || hasExactStatusAssertion(item);
+}
+
+/**
+ * Throws when one or more requests are missing a specific status expectation.
  *
  * @param {object} collection
  */
-function assertRequestItemsHaveExactStatusAssertions(collection) {
+function assertRequestItemsHaveSpecificStatusExpectations(collection) {
   const missingAssertions = listRequestItems(collection)
-    .filter(({ item }) => !hasExactStatusAssertion(item))
+    .filter(({ item }) => !hasSpecificStatusExpectation(item))
     .map(({ item, topLevelFolderName }) => `${topLevelFolderName} > ${item.name}`);
 
   if (missingAssertions.length === 0) {
@@ -78,7 +101,7 @@ function assertRequestItemsHaveExactStatusAssertions(collection) {
   }
 
   throw new Error(
-    `Missing exact status assertions for Postman requests: ${missingAssertions.join(', ')}`,
+    `Missing specific status expectations for Postman requests: ${missingAssertions.join(', ')}`,
   );
 }
 
@@ -155,10 +178,12 @@ function buildItemFolderMap(collection) {
 }
 
 module.exports = {
-  assertRequestItemsHaveExactStatusAssertions,
+  assertRequestItemsHaveSpecificStatusExpectations,
   assertTopLevelFoldersExist,
   buildItemFolderMap,
   hasExactStatusAssertion,
+  hasExpectedStatusCodeHeader,
+  hasSpecificStatusExpectation,
   listTopLevelFolderNames,
   listRequestItems,
   readCollection,

--- a/tests/integration/api.test.js
+++ b/tests/integration/api.test.js
@@ -63,737 +63,739 @@ const buildTestApp = ({
   return { app, appLogger, requestLogger };
 };
 
-describe('request filter', () => {
-  it('redirects direct HTTP traffic to HTTPS', async () => {
-    const { app } = buildTestApp();
+describe('Integration | API', () => {
+  describe('request filter', () => {
+    it('redirects direct HTTP traffic to HTTPS', async () => {
+      const { app } = buildTestApp();
 
-    const res = await request(app)
-      .get('/api/ping')
-      .set('Host', 'localhost:8080');
+      const res = await request(app)
+        .get('/api/ping')
+        .set('Host', 'localhost:8080');
 
-    expect(res.status).toBe(302);
-    const expectedHost = config.https.port === 443
-      ? 'localhost'
-      : `localhost:${config.https.port}`;
-    expect(res.headers.location).toBe(`https://${expectedHost}/api/ping`);
-  });
-
-  it('redirects proxy-forwarded HTTP traffic to HTTPS', async () => {
-    const { app } = buildTestApp();
-
-    const res = await request(app)
-      .get('/api/ping')
-      .set('Host', 'localhost:8080')
-      .set('X-Forwarded-Proto', 'http');
-
-    expect(res.status).toBe(302);
-    const expectedHost = config.https.port === 443
-      ? 'localhost'
-      : `localhost:${config.https.port}`;
-    expect(res.headers.location).toBe(`https://${expectedHost}/api/ping`);
-  });
-
-  it('redirects /api/ to the versioned route for secure requests', async () => {
-    const { app } = buildTestApp();
-
-    const res = await secureGet(app, '/api/');
-
-    expect(res.status).toBe(302);
-    expect(res.headers.location).toMatch(/\/api\/v1\/$/);
-  });
-});
-
-describe('GET /api/ping', () => {
-  it('responds with pong and mounts the request logger middleware', async () => {
-    const { app, requestLogger } = buildTestApp();
-
-    const res = await secureGet(app, '/api/ping');
-
-    expect(res.status).toBe(200);
-    expect(res.text).toBe('pong');
-    expect(requestLogger).toHaveBeenCalled();
-  });
-
-  it('stays available while the instance is draining', async () => {
-    const runtimeState = createRuntimeState({ initialReady: true });
-    runtimeState.markDraining();
-    const { app } = buildTestApp({ runtimeState });
-
-    const res = await secureGet(app, '/api/ping');
-
-    expect(res.status).toBe(200);
-    expect(res.text).toBe('pong');
-  });
-});
-
-describe('GET /', () => {
-  it('responds with a stable public service index', async () => {
-    const { app } = buildTestApp();
-
-    const res = await secureGet(app, '/');
-
-    expect(res.status).toBe(200);
-    expect(res.headers['content-type']).toContain('application/json');
-    expect(res.headers['x-request-id']).toBe(TEST_REQUEST_ID);
-    expect(Object.keys(res.body).sort()).toEqual([
-      'auth',
-      'links',
-      'name',
-      'requestId',
-      'status',
-      'version',
-    ]);
-    expect(res.body).toEqual({
-      name: packageMetadata.name,
-      version: packageMetadata.version,
-      status: 'ok',
-      links: {
-        api: '/api/v1',
-        docs: '/api-docs/',
-        health: '/api/health',
-        ping: '/api/ping',
-      },
-      auth: {
-        schemes: ['X-API-Key', 'Bearer'],
-      },
-      requestId: TEST_REQUEST_ID,
+      expect(res.status).toBe(302);
+      const expectedHost = config.https.port === 443
+        ? 'localhost'
+        : `localhost:${config.https.port}`;
+      expect(res.headers.location).toBe(`https://${expectedHost}/api/ping`);
     });
-  });
-});
 
-describe('GET /api/health', () => {
-  it('responds with health info', async () => {
-    const { app } = buildTestApp();
+    it('redirects proxy-forwarded HTTP traffic to HTTPS', async () => {
+      const { app } = buildTestApp();
 
-    const res = await secureGet(app, '/api/health');
+      const res = await request(app)
+        .get('/api/ping')
+        .set('Host', 'localhost:8080')
+        .set('X-Forwarded-Proto', 'http');
 
-    expect(res.status).toBe(200);
-    expect(res.body).toHaveProperty('message', 'OK');
-    expect(res.body).toHaveProperty('ready', true);
-    expect(res.body).toHaveProperty('uptime');
-    expect(res.body).toHaveProperty('timestamp');
-  });
-
-  it('returns 503 while the instance is draining', async () => {
-    const runtimeState = createRuntimeState({ initialReady: true });
-    runtimeState.markDraining();
-    const { app } = buildTestApp({ runtimeState });
-
-    const res = await secureGet(app, '/api/health');
-
-    expect(res.status).toBe(503);
-    expect(res.body).toMatchObject({
-      message: 'DRAINING',
-      ready: false,
+      expect(res.status).toBe(302);
+      const expectedHost = config.https.port === 443
+        ? 'localhost'
+        : `localhost:${config.https.port}`;
+      expect(res.headers.location).toBe(`https://${expectedHost}/api/ping`);
     });
-  });
-});
 
-describe('rate limiting', () => {
-  const rateLimitedConfig = {
-    rateLimit: {
-      windowMs: 60 * 1000,
-      max: 1,
-    },
-    statusRateLimit: {
-      windowMs: 60 * 1000,
-      max: 2,
-    },
-  };
+    it('redirects /api/ to the versioned route for secure requests', async () => {
+      const { app } = buildTestApp();
 
-  it('keeps health checks available when the default API limiter is exhausted', async () => {
-    const { app } = buildTestApp({ config: rateLimitedConfig });
+      const res = await secureGet(app, '/api/');
 
-    const firstApiCall = await secureGet(app, '/api/v1/does-not-exist');
-    const secondApiCall = await secureGet(app, '/api/v1/does-not-exist');
-    const healthCheck = await secureGet(app, '/api/health');
-
-    expect(firstApiCall.status).toBe(404);
-    expect(secondApiCall.status).toBe(429);
-    expect(healthCheck.status).toBe(200);
-    expect(healthCheck.body).toMatchObject({
-      message: 'OK',
-      ready: true,
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toMatch(/\/api\/v1\/$/);
     });
   });
 
-  it('applies the dedicated status limiter to repeated health checks', async () => {
-    const { app } = buildTestApp({ config: rateLimitedConfig });
+  describe('GET /api/ping', () => {
+    it('responds with pong and mounts the request logger middleware', async () => {
+      const { app, requestLogger } = buildTestApp();
 
-    const first = await secureGet(app, '/api/health');
-    const second = await secureGet(app, '/api/health');
-    const third = await secureGet(app, '/api/health');
+      const res = await secureGet(app, '/api/ping');
 
-    expect(first.status).toBe(200);
-    expect(second.status).toBe(200);
-    expect(third.status).toBe(429);
-    expect(third.text).toContain('Too many status requests');
+      expect(res.status).toBe(200);
+      expect(res.text).toBe('pong');
+      expect(requestLogger).toHaveBeenCalled();
+    });
+
+    it('stays available while the instance is draining', async () => {
+      const runtimeState = createRuntimeState({ initialReady: true });
+      runtimeState.markDraining();
+      const { app } = buildTestApp({ runtimeState });
+
+      const res = await secureGet(app, '/api/ping');
+
+      expect(res.status).toBe(200);
+      expect(res.text).toBe('pong');
+    });
   });
 
-  it('continues to rate limit normal API traffic', async () => {
-    const { app } = buildTestApp({ config: rateLimitedConfig });
+  describe('GET /', () => {
+    it('responds with a stable public service index', async () => {
+      const { app } = buildTestApp();
 
-    const first = await secureGet(app, '/api/v1/does-not-exist');
-    const second = await secureGet(app, '/api/v1/does-not-exist');
+      const res = await secureGet(app, '/');
 
-    expect(first.status).toBe(404);
-    expect(second.status).toBe(429);
-    expect(second.text).toContain('Too many requests');
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('application/json');
+      expect(res.headers['x-request-id']).toBe(TEST_REQUEST_ID);
+      expect(Object.keys(res.body).sort()).toEqual([
+        'auth',
+        'links',
+        'name',
+        'requestId',
+        'status',
+        'version',
+      ]);
+      expect(res.body).toEqual({
+        name: packageMetadata.name,
+        version: packageMetadata.version,
+        status: 'ok',
+        links: {
+          api: '/api/v1',
+          docs: '/api-docs/',
+          health: '/api/health',
+          ping: '/api/ping',
+        },
+        auth: {
+          schemes: ['X-API-Key', 'Bearer'],
+        },
+        requestId: TEST_REQUEST_ID,
+      });
+    });
   });
 
-  it('fails open when the Redis-backed limiter store errors during a request', async () => {
-    const appLogger = createAppLogger();
-    const requestLogger = createRequestLogger();
-    const appConfig = {
-      ...rateLimitedConfig,
-      auth: {
-        enabled: false,
-        tokens: [],
+  describe('GET /api/health', () => {
+    it('responds with health info', async () => {
+      const { app } = buildTestApp();
+
+      const res = await secureGet(app, '/api/health');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('message', 'OK');
+      expect(res.body).toHaveProperty('ready', true);
+      expect(res.body).toHaveProperty('uptime');
+      expect(res.body).toHaveProperty('timestamp');
+    });
+
+    it('returns 503 while the instance is draining', async () => {
+      const runtimeState = createRuntimeState({ initialReady: true });
+      runtimeState.markDraining();
+      const { app } = buildTestApp({ runtimeState });
+
+      const res = await secureGet(app, '/api/health');
+
+      expect(res.status).toBe(503);
+      expect(res.body).toMatchObject({
+        message: 'DRAINING',
+        ready: false,
+      });
+    });
+  });
+
+  describe('rate limiting', () => {
+    const rateLimitedConfig = {
+      rateLimit: {
+        windowMs: 60 * 1000,
+        max: 1,
       },
-      proxy: {
-        trustProxyHops: 1,
-      },
-      rateLimitStore: {
-        kind: 'redis',
-        mode: 'redis',
-        redisPrefix: 'jest:fail-open:',
-        redisTopology: 'external',
-        redisUrl: 'redis://rate-limit.example:6379',
+      statusRateLimit: {
+        windowMs: 60 * 1000,
+        max: 2,
       },
     };
-    const redisClient = {
-      connect: jest.fn().mockResolvedValue(undefined),
-      isOpen: true,
-      on: jest.fn(),
-      quit: jest.fn().mockResolvedValue(undefined),
-      sendCommand: jest.fn().mockResolvedValue('PONG'),
-    };
 
-    class FailingRedisStore {
-      constructor(options) {
-        this.decrement = jest.fn().mockResolvedValue(undefined);
-        this.increment = jest.fn().mockRejectedValue(new Error('rate-limit store unavailable'));
-        this.init = jest.fn();
-        this.prefix = options.prefix;
-        this.resetKey = jest.fn().mockResolvedValue(undefined);
+    it('keeps health checks available when the default API limiter is exhausted', async () => {
+      const { app } = buildTestApp({ config: rateLimitedConfig });
+
+      const firstApiCall = await secureGet(app, '/api/v1/does-not-exist');
+      const secondApiCall = await secureGet(app, '/api/v1/does-not-exist');
+      const healthCheck = await secureGet(app, '/api/health');
+
+      expect(firstApiCall.status).toBe(404);
+      expect(secondApiCall.status).toBe(429);
+      expect(healthCheck.status).toBe(200);
+      expect(healthCheck.body).toMatchObject({
+        message: 'OK',
+        ready: true,
+      });
+    });
+
+    it('applies the dedicated status limiter to repeated health checks', async () => {
+      const { app } = buildTestApp({ config: rateLimitedConfig });
+
+      const first = await secureGet(app, '/api/health');
+      const second = await secureGet(app, '/api/health');
+      const third = await secureGet(app, '/api/health');
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      expect(third.status).toBe(429);
+      expect(third.text).toContain('Too many status requests');
+    });
+
+    it('continues to rate limit normal API traffic', async () => {
+      const { app } = buildTestApp({ config: rateLimitedConfig });
+
+      const first = await secureGet(app, '/api/v1/does-not-exist');
+      const second = await secureGet(app, '/api/v1/does-not-exist');
+
+      expect(first.status).toBe(404);
+      expect(second.status).toBe(429);
+      expect(second.text).toContain('Too many requests');
+    });
+
+    it('fails open when the Redis-backed limiter store errors during a request', async () => {
+      const appLogger = createAppLogger();
+      const requestLogger = createRequestLogger();
+      const appConfig = {
+        ...rateLimitedConfig,
+        auth: {
+          enabled: false,
+          tokens: [],
+        },
+        proxy: {
+          trustProxyHops: 1,
+        },
+        rateLimitStore: {
+          kind: 'redis',
+          mode: 'redis',
+          redisPrefix: 'jest:fail-open:',
+          redisTopology: 'external',
+          redisUrl: 'redis://rate-limit.example:6379',
+        },
+      };
+      const redisClient = {
+        connect: jest.fn().mockResolvedValue(undefined),
+        isOpen: true,
+        on: jest.fn(),
+        quit: jest.fn().mockResolvedValue(undefined),
+        sendCommand: jest.fn().mockResolvedValue('PONG'),
+      };
+
+      class FailingRedisStore {
+        constructor(options) {
+          this.decrement = jest.fn().mockResolvedValue(undefined);
+          this.increment = jest.fn().mockRejectedValue(new Error('rate-limit store unavailable'));
+          this.init = jest.fn();
+          this.prefix = options.prefix;
+          this.resetKey = jest.fn().mockResolvedValue(undefined);
+        }
       }
-    }
 
-    const rateLimitStoreProvider = await initializeRateLimitStoreProvider({
-      config: appConfig,
-      createClientFn: jest.fn(() => redisClient),
-      logger: appLogger,
-      RedisStoreClass: FailingRedisStore,
-    });
-
-    try {
-      const { app } = createApp({
-        appLogger,
-        requestLogger,
+      const rateLimitStoreProvider = await initializeRateLimitStoreProvider({
         config: appConfig,
-        rateLimitStoreProvider,
+        createClientFn: jest.fn(() => redisClient),
+        logger: appLogger,
+        RedisStoreClass: FailingRedisStore,
       });
 
-      const response = await secureGet(app, '/api/v1/does-not-exist');
+      try {
+        const { app } = createApp({
+          appLogger,
+          requestLogger,
+          config: appConfig,
+          rateLimitStoreProvider,
+        });
 
-      expect(response.status).toBe(404);
-      expect(appLogger.warn).toHaveBeenCalledWith(expect.objectContaining({
-        operation: 'increment',
-        scope: 'api',
-        store: 'rate-limit',
-      }), 'Rate-limit store operation failed; allowing request to proceed');
-    } finally {
-      await rateLimitStoreProvider.close();
-    }
-  });
-});
+        const response = await secureGet(app, '/api/v1/does-not-exist');
 
-describe('GET /api/scraper/images', () => {
-  it('returns 400 when url is missing', async () => {
-    const { app } = buildTestApp();
-
-    const res = await secureGet(app, '/api/scraper/images');
-
-    expect(res.status).toBe(400);
-    expect(res.body).toMatchObject({
-      error: 'Missing required query parameter: url',
-      code: 'QUERY_VALIDATION_ERROR',
-      requestId: TEST_REQUEST_ID,
-      details: [{ field: 'url', issue: 'required' }],
+        expect(response.status).toBe(404);
+        expect(appLogger.warn).toHaveBeenCalledWith(expect.objectContaining({
+          operation: 'increment',
+          scope: 'api',
+          store: 'rate-limit',
+        }), 'Rate-limit store operation failed; allowing request to proceed');
+      } finally {
+        await rateLimitStoreProvider.close();
+      }
     });
   });
 
-  it('returns image list on success', async () => {
-    const scraperService = {
-      getImages: jest.fn().mockResolvedValue({
-        imageSources: ['https://example.com/a.jpg'],
-      }),
-    };
-    const { app } = buildTestApp({ scraperService });
+  describe('GET /api/scraper/images', () => {
+    it('returns 400 when url is missing', async () => {
+      const { app } = buildTestApp();
 
-    const res = await secureGet(
-      app,
-      `/api/scraper/images?url=${encodeURIComponent('https://example.com')}`,
-    );
+      const res = await secureGet(app, '/api/scraper/images');
 
-    expect(res.status).toBe(200);
-    expect(res.body.imageSources).toContain('https://example.com/a.jpg');
-  });
-
-  it('returns 500 on scraper failure', async () => {
-    const scraperService = {
-      getImages: jest.fn().mockRejectedValue(new Error('network error')),
-    };
-    const { app } = buildTestApp({ scraperService });
-
-    const res = await secureGet(
-      app,
-      `/api/scraper/images?url=${encodeURIComponent('https://example.com')}`,
-    );
-
-    expect(res.status).toBe(500);
-    expect(res.body).toMatchObject({
-      error: 'Error fetching images from the provided URL',
-      code: 'SCRAPE_FETCH_FAILED',
-      requestId: TEST_REQUEST_ID,
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: 'Missing required query parameter: url',
+        code: 'QUERY_VALIDATION_ERROR',
+        requestId: TEST_REQUEST_ID,
+        details: [{ field: 'url', issue: 'required' }],
+      });
     });
-  });
-});
 
-describe('GET /api/accessibility/description', () => {
-  it('returns 400 when image_source is missing', async () => {
-    const { app } = buildTestApp();
+    it('returns image list on success', async () => {
+      const scraperService = {
+        getImages: jest.fn().mockResolvedValue({
+          imageSources: ['https://example.com/a.jpg'],
+        }),
+      };
+      const { app } = buildTestApp({ scraperService });
 
-    const res = await secureGet(
-      app,
-      '/api/accessibility/description?model=clip',
-    );
+      const res = await secureGet(
+        app,
+        `/api/scraper/images?url=${encodeURIComponent('https://example.com')}`,
+      );
 
-    expect(res.status).toBe(400);
-    expect(res.body).toMatchObject({
-      error: 'Missing required query parameters: image_source and model',
-      code: 'QUERY_VALIDATION_ERROR',
-      requestId: TEST_REQUEST_ID,
-      details: [{ field: 'image_source', issue: 'required' }],
+      expect(res.status).toBe(200);
+      expect(res.body.imageSources).toContain('https://example.com/a.jpg');
+    });
+
+    it('returns 500 on scraper failure', async () => {
+      const scraperService = {
+        getImages: jest.fn().mockRejectedValue(new Error('network error')),
+      };
+      const { app } = buildTestApp({ scraperService });
+
+      const res = await secureGet(
+        app,
+        `/api/scraper/images?url=${encodeURIComponent('https://example.com')}`,
+      );
+
+      expect(res.status).toBe(500);
+      expect(res.body).toMatchObject({
+        error: 'Error fetching images from the provided URL',
+        code: 'SCRAPE_FETCH_FAILED',
+        requestId: TEST_REQUEST_ID,
+      });
     });
   });
 
-  it('returns 400 for an unknown model', async () => {
-    const factory = new ImageDescriberFactory().register('clip', {
-      describeImage: jest.fn(),
+  describe('GET /api/accessibility/description', () => {
+    it('returns 400 when image_source is missing', async () => {
+      const { app } = buildTestApp();
+
+      const res = await secureGet(
+        app,
+        '/api/accessibility/description?model=clip',
+      );
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: 'Missing required query parameters: image_source and model',
+        code: 'QUERY_VALIDATION_ERROR',
+        requestId: TEST_REQUEST_ID,
+        details: [{ field: 'image_source', issue: 'required' }],
+      });
     });
-    const { app } = buildTestApp({ imageDescriberFactory: factory });
 
-    const res = await secureGet(
-      app,
-      `/api/accessibility/description?image_source=${
-        encodeURIComponent('https://example.com/img.jpg')
-      }&model=unknownmodel`,
-    );
+    it('returns 400 for an unknown model', async () => {
+      const factory = new ImageDescriberFactory().register('clip', {
+        describeImage: jest.fn(),
+      });
+      const { app } = buildTestApp({ imageDescriberFactory: factory });
 
-    expect(res.status).toBe(400);
-    expect(res.body.error).toMatch(/Unknown model/);
-    expect(res.body.code).toBe('UNKNOWN_MODEL');
-    expect(res.body.requestId).toBe(TEST_REQUEST_ID);
-  });
+      const res = await secureGet(
+        app,
+        `/api/accessibility/description?image_source=${
+          encodeURIComponent('https://example.com/img.jpg')
+        }&model=unknownmodel`,
+      );
 
-  it('returns description array on success', async () => {
-    const mockDescriber = {
-      describeImage: jest.fn().mockResolvedValue({
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/Unknown model/);
+      expect(res.body.code).toBe('UNKNOWN_MODEL');
+      expect(res.body.requestId).toBe(TEST_REQUEST_ID);
+    });
+
+    it('returns description array on success', async () => {
+      const mockDescriber = {
+        describeImage: jest.fn().mockResolvedValue({
+          description: 'a cat on a mat',
+          imageUrl: 'https://example.com/img.jpg',
+        }),
+      };
+      const factory = new ImageDescriberFactory().register('clip', mockDescriber);
+      const { app } = buildTestApp({ imageDescriberFactory: factory });
+
+      const res = await secureGet(
+        app,
+        `/api/accessibility/description?image_source=${
+          encodeURIComponent('https://example.com/img.jpg')
+        }&model=clip`,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([{
         description: 'a cat on a mat',
         imageUrl: 'https://example.com/img.jpg',
-      }),
-    };
-    const factory = new ImageDescriberFactory().register('clip', mockDescriber);
-    const { app } = buildTestApp({ imageDescriberFactory: factory });
+      }]);
+    });
 
-    const res = await secureGet(
-      app,
-      `/api/accessibility/description?image_source=${
-        encodeURIComponent('https://example.com/img.jpg')
-      }&model=clip`,
-    );
-
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual([{
-      description: 'a cat on a mat',
-      imageUrl: 'https://example.com/img.jpg',
-    }]);
-  });
-
-  it('serves Azure descriptions through the default runtime composition when configured', async () => {
-    const appLogger = createAppLogger();
-    const requestLogger = createRequestLogger();
-    const httpClient = {
-      get: jest.fn().mockResolvedValue({
-        data: Buffer.from('azure-image-bytes'),
-        headers: {
-          'content-type': 'image/jpeg',
+    it('serves Azure descriptions through the default runtime composition when configured', async () => {
+      const appLogger = createAppLogger();
+      const requestLogger = createRequestLogger();
+      const httpClient = {
+        get: jest.fn().mockResolvedValue({
+          data: Buffer.from('azure-image-bytes'),
+          headers: {
+            'content-type': 'image/jpeg',
+          },
+        }),
+        post: jest.fn().mockResolvedValue({
+          data: {
+            description: {
+              captions: [
+                { text: 'an azure-generated caption' },
+              ],
+            },
+          },
+        }),
+      };
+      const replicateClient = { run: jest.fn() };
+      const runtimeConfig = {
+        replicate: {
+          apiToken: 'test-token',
+          apiEndpoint: 'https://replicate.example.com',
+          userAgent: 'alt-text-generator/test',
+          modelOwner: 'owner',
+          modelName: 'model',
+          modelVersion: 'version',
         },
-      }),
-      post: jest.fn().mockResolvedValue({
-        data: {
-          description: {
-            captions: [
-              { text: 'an azure-generated caption' },
-            ],
+        azure: {
+          apiEndpoint: 'https://azure.example.com/vision/v3.2/describe',
+          subscriptionKey: 'azure-key',
+          language: 'en',
+          maxCandidates: 4,
+        },
+        scraper: {
+          requestTimeoutMs: 1500,
+          maxRedirects: 4,
+          maxContentLengthBytes: 2048,
+        },
+        proxy: {
+          trustProxyHops: 1,
+        },
+      };
+      const { app, services } = createApp({
+        appLogger,
+        requestLogger,
+        httpClient,
+        replicateClient,
+        config: runtimeConfig,
+      });
+
+      expect(services.imageDescriberFactory.getAvailableModels()).toEqual(['clip', 'azure']);
+
+      const res = await secureGet(
+        app,
+        `/api/accessibility/description?image_source=${
+          encodeURIComponent('https://example.com/azure-image.jpg')
+        }&model=azure`,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([{
+        description: 'an azure-generated caption',
+        imageUrl: 'https://example.com/azure-image.jpg',
+      }]);
+      expect(httpClient.get).toHaveBeenCalledWith('https://example.com/azure-image.jpg', {
+        timeout: 1500,
+        maxRedirects: 4,
+        maxContentLength: 2048,
+        maxBodyLength: 2048,
+        responseType: 'arraybuffer',
+      });
+      expect(httpClient.post).toHaveBeenCalledWith(
+        'https://azure.example.com/vision/v3.2/describe?maxCandidates=4&language=en&model-version=latest&overload=stream',
+        Buffer.from('azure-image-bytes'),
+        {
+          headers: {
+            'Content-Type': 'application/octet-stream',
+            'Ocp-Apim-Subscription-Key': 'azure-key',
           },
         },
-      }),
-    };
-    const replicateClient = { run: jest.fn() };
-    const runtimeConfig = {
-      replicate: {
-        apiToken: 'test-token',
-        apiEndpoint: 'https://replicate.example.com',
-        userAgent: 'alt-text-generator/test',
-        modelOwner: 'owner',
-        modelName: 'model',
-        modelVersion: 'version',
+      );
+    });
+  });
+
+  describe('GET /api/accessibility/descriptions', () => {
+    it('returns 400 when url is missing', async () => {
+      const { app } = buildTestApp();
+
+      const res = await secureGet(
+        app,
+        '/api/accessibility/descriptions?model=clip',
+      );
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: 'Missing required query parameters: url and model',
+        code: 'QUERY_VALIDATION_ERROR',
+        requestId: TEST_REQUEST_ID,
+        details: [{ field: 'url', issue: 'required' }],
+      });
+    });
+
+    it('preserves duplicate entries while reusing one prediction per unique URL', async () => {
+      const scraperService = {
+        getImages: jest.fn().mockResolvedValue({
+          imageSources: [
+            'https://example.com/a.jpg',
+            'https://example.com/b.jpg',
+            'https://example.com/a.jpg',
+          ],
+        }),
+      };
+      const mockDescriber = {
+        describeImage: jest
+          .fn()
+          .mockImplementation(async (imageUrl) => ({
+            description: `description for ${imageUrl}`,
+            imageUrl,
+          })),
+      };
+      const factory = new ImageDescriberFactory().register('clip', mockDescriber);
+      const { app } = buildTestApp({
+        scraperService,
+        imageDescriberFactory: factory,
+      });
+
+      const res = await secureGet(
+        app,
+        `/api/accessibility/descriptions?url=${
+          encodeURIComponent('https://example.com/page')
+        }&model=clip`,
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockDescriber.describeImage).toHaveBeenCalledTimes(2);
+      expect(res.body).toEqual({
+        pageUrl: 'https://example.com/page',
+        model: 'clip',
+        totalImages: 3,
+        uniqueImages: 2,
+        descriptions: [
+          {
+            description: 'description for https://example.com/a.jpg',
+            imageUrl: 'https://example.com/a.jpg',
+          },
+          {
+            description: 'description for https://example.com/b.jpg',
+            imageUrl: 'https://example.com/b.jpg',
+          },
+          {
+            description: 'description for https://example.com/a.jpg',
+            imageUrl: 'https://example.com/a.jpg',
+          },
+        ],
+      });
+    });
+
+    it('returns partial page descriptions when image-specific Azure failures are skippable', async () => {
+      const scraperService = {
+        getImages: jest.fn().mockResolvedValue({
+          imageSources: [
+            'https://example.com/a.jpg',
+            'https://example.com/missing.jpg',
+            'https://example.com/a.jpg',
+          ],
+        }),
+      };
+      const imageError = new Error('image timeout');
+      const mockDescriber = {
+        describeImage: jest.fn().mockImplementation(async (imageUrl) => {
+          if (imageUrl === 'https://example.com/missing.jpg') {
+            throw imageError;
+          }
+
+          return {
+            description: `description for ${imageUrl}`,
+            imageUrl,
+          };
+        }),
+        shouldSkipDescriptionError: jest.fn((error) => error === imageError),
+      };
+      const factory = new ImageDescriberFactory().register('azure', mockDescriber);
+      const { app } = buildTestApp({
+        scraperService,
+        imageDescriberFactory: factory,
+      });
+
+      const res = await secureGet(
+        app,
+        `/api/accessibility/descriptions?url=${
+          encodeURIComponent('https://example.com/page')
+        }&model=azure`,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        pageUrl: 'https://example.com/page',
+        model: 'azure',
+        totalImages: 2,
+        uniqueImages: 1,
+        descriptions: [
+          {
+            description: 'description for https://example.com/a.jpg',
+            imageUrl: 'https://example.com/a.jpg',
+          },
+          {
+            description: 'description for https://example.com/a.jpg',
+            imageUrl: 'https://example.com/a.jpg',
+          },
+        ],
+      });
+    });
+  });
+
+  describe('unknown routes', () => {
+    it('returns 404 for unregistered paths', async () => {
+      const { app } = buildTestApp();
+
+      const res = await secureGet(app, '/api/v1/does-not-exist');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Endpoint not found');
+      expect(res.body.code).toBe('ENDPOINT_NOT_FOUND');
+      expect(res.body.requestId).toBe(TEST_REQUEST_ID);
+    });
+  });
+
+  describe('API access control', () => {
+    const buildAuthConfig = () => ({
+      auth: {
+        enabled: true,
+        tokens: ['dummy-1', 'dummy-2'],
       },
-      azure: {
-        apiEndpoint: 'https://azure.example.com/vision/v3.2/describe',
-        subscriptionKey: 'azure-key',
-        language: 'en',
-        maxCandidates: 4,
-      },
+      replicate: {},
+      azure: {},
       scraper: {
         requestTimeoutMs: 1500,
         maxRedirects: 4,
         maxContentLengthBytes: 2048,
       },
-      proxy: {
-        trustProxyHops: 1,
-      },
-    };
-    const { app, services } = createApp({
-      appLogger,
-      requestLogger,
-      httpClient,
-      replicateClient,
-      config: runtimeConfig,
     });
 
-    expect(services.imageDescriberFactory.getAvailableModels()).toEqual(['clip', 'azure']);
+    it('allows public health endpoints without authentication', async () => {
+      const { app } = buildTestApp({ config: buildAuthConfig() });
 
-    const res = await secureGet(
-      app,
-      `/api/accessibility/description?image_source=${
-        encodeURIComponent('https://example.com/azure-image.jpg')
-      }&model=azure`,
-    );
+      const res = await secureGet(app, '/api/health');
 
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual([{
-      description: 'an azure-generated caption',
-      imageUrl: 'https://example.com/azure-image.jpg',
-    }]);
-    expect(httpClient.get).toHaveBeenCalledWith('https://example.com/azure-image.jpg', {
-      timeout: 1500,
-      maxRedirects: 4,
-      maxContentLength: 2048,
-      maxBodyLength: 2048,
-      responseType: 'arraybuffer',
-    });
-    expect(httpClient.post).toHaveBeenCalledWith(
-      'https://azure.example.com/vision/v3.2/describe?maxCandidates=4&language=en&model-version=latest&overload=stream',
-      Buffer.from('azure-image-bytes'),
-      {
-        headers: {
-          'Content-Type': 'application/octet-stream',
-          'Ocp-Apim-Subscription-Key': 'azure-key',
-        },
-      },
-    );
-  });
-});
-
-describe('GET /api/accessibility/descriptions', () => {
-  it('returns 400 when url is missing', async () => {
-    const { app } = buildTestApp();
-
-    const res = await secureGet(
-      app,
-      '/api/accessibility/descriptions?model=clip',
-    );
-
-    expect(res.status).toBe(400);
-    expect(res.body).toMatchObject({
-      error: 'Missing required query parameters: url and model',
-      code: 'QUERY_VALIDATION_ERROR',
-      requestId: TEST_REQUEST_ID,
-      details: [{ field: 'url', issue: 'required' }],
-    });
-  });
-
-  it('preserves duplicate entries while reusing one prediction per unique URL', async () => {
-    const scraperService = {
-      getImages: jest.fn().mockResolvedValue({
-        imageSources: [
-          'https://example.com/a.jpg',
-          'https://example.com/b.jpg',
-          'https://example.com/a.jpg',
-        ],
-      }),
-    };
-    const mockDescriber = {
-      describeImage: jest
-        .fn()
-        .mockImplementation(async (imageUrl) => ({
-          description: `description for ${imageUrl}`,
-          imageUrl,
-        })),
-    };
-    const factory = new ImageDescriberFactory().register('clip', mockDescriber);
-    const { app } = buildTestApp({
-      scraperService,
-      imageDescriberFactory: factory,
+      expect(res.status).toBe(200);
     });
 
-    const res = await secureGet(
-      app,
-      `/api/accessibility/descriptions?url=${
-        encodeURIComponent('https://example.com/page')
-      }&model=clip`,
-    );
+    it('keeps the root service index public without authentication', async () => {
+      const { app } = buildTestApp({ config: buildAuthConfig() });
 
-    expect(res.status).toBe(200);
-    expect(mockDescriber.describeImage).toHaveBeenCalledTimes(2);
-    expect(res.body).toEqual({
-      pageUrl: 'https://example.com/page',
-      model: 'clip',
-      totalImages: 3,
-      uniqueImages: 2,
-      descriptions: [
-        {
-          description: 'description for https://example.com/a.jpg',
-          imageUrl: 'https://example.com/a.jpg',
-        },
-        {
-          description: 'description for https://example.com/b.jpg',
-          imageUrl: 'https://example.com/b.jpg',
-        },
-        {
-          description: 'description for https://example.com/a.jpg',
-          imageUrl: 'https://example.com/a.jpg',
-        },
-      ],
-    });
-  });
+      const res = await secureGet(app, '/');
 
-  it('returns partial page descriptions when image-specific Azure failures are skippable', async () => {
-    const scraperService = {
-      getImages: jest.fn().mockResolvedValue({
-        imageSources: [
-          'https://example.com/a.jpg',
-          'https://example.com/missing.jpg',
-          'https://example.com/a.jpg',
-        ],
-      }),
-    };
-    const imageError = new Error('image timeout');
-    const mockDescriber = {
-      describeImage: jest.fn().mockImplementation(async (imageUrl) => {
-        if (imageUrl === 'https://example.com/missing.jpg') {
-          throw imageError;
-        }
-
-        return {
-          description: `description for ${imageUrl}`,
-          imageUrl,
-        };
-      }),
-      shouldSkipDescriptionError: jest.fn((error) => error === imageError),
-    };
-    const factory = new ImageDescriberFactory().register('azure', mockDescriber);
-    const { app } = buildTestApp({
-      scraperService,
-      imageDescriberFactory: factory,
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        name: packageMetadata.name,
+        status: 'ok',
+        requestId: TEST_REQUEST_ID,
+      });
     });
 
-    const res = await secureGet(
-      app,
-      `/api/accessibility/descriptions?url=${
-        encodeURIComponent('https://example.com/page')
-      }&model=azure`,
-    );
+    it('rejects protected endpoints without authentication', async () => {
+      const { app } = buildTestApp({ config: buildAuthConfig() });
 
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({
-      pageUrl: 'https://example.com/page',
-      model: 'azure',
-      totalImages: 2,
-      uniqueImages: 1,
-      descriptions: [
-        {
-          description: 'description for https://example.com/a.jpg',
-          imageUrl: 'https://example.com/a.jpg',
-        },
-        {
-          description: 'description for https://example.com/a.jpg',
-          imageUrl: 'https://example.com/a.jpg',
-        },
-      ],
+      const res = await secureGet(
+        app,
+        `/api/accessibility/description?image_source=${
+          encodeURIComponent('https://example.com/img.jpg')
+        }&model=clip`,
+      );
+
+      expect(res.status).toBe(401);
+      expect(res.body).toMatchObject({
+        error: 'Missing or invalid API authentication credentials',
+        code: 'API_AUTHENTICATION_FAILED',
+        requestId: TEST_REQUEST_ID,
+      });
     });
-  });
-});
 
-describe('unknown routes', () => {
-  it('returns 404 for unregistered paths', async () => {
-    const { app } = buildTestApp();
+    it('accepts X-API-Key authentication on protected endpoints', async () => {
+      const factory = new ImageDescriberFactory().register('clip', {
+        describeImage: jest.fn().mockResolvedValue({
+          description: 'authenticated description',
+          imageUrl: 'https://example.com/img.jpg',
+        }),
+      });
+      const { app } = buildTestApp({
+        config: buildAuthConfig(),
+        imageDescriberFactory: factory,
+      });
 
-    const res = await secureGet(app, '/api/v1/does-not-exist');
+      const res = await secureGet(
+        app,
+        `/api/accessibility/description?image_source=${
+          encodeURIComponent('https://example.com/img.jpg')
+        }&model=clip`,
+      ).set('X-API-Key', 'dummy-2');
 
-    expect(res.status).toBe(404);
-    expect(res.body.error).toBe('Endpoint not found');
-    expect(res.body.code).toBe('ENDPOINT_NOT_FOUND');
-    expect(res.body.requestId).toBe(TEST_REQUEST_ID);
-  });
-});
-
-describe('API access control', () => {
-  const buildAuthConfig = () => ({
-    auth: {
-      enabled: true,
-      tokens: ['dummy-1', 'dummy-2'],
-    },
-    replicate: {},
-    azure: {},
-    scraper: {
-      requestTimeoutMs: 1500,
-      maxRedirects: 4,
-      maxContentLengthBytes: 2048,
-    },
-  });
-
-  it('allows public health endpoints without authentication', async () => {
-    const { app } = buildTestApp({ config: buildAuthConfig() });
-
-    const res = await secureGet(app, '/api/health');
-
-    expect(res.status).toBe(200);
-  });
-
-  it('keeps the root service index public without authentication', async () => {
-    const { app } = buildTestApp({ config: buildAuthConfig() });
-
-    const res = await secureGet(app, '/');
-
-    expect(res.status).toBe(200);
-    expect(res.body).toMatchObject({
-      name: packageMetadata.name,
-      status: 'ok',
-      requestId: TEST_REQUEST_ID,
-    });
-  });
-
-  it('rejects protected endpoints without authentication', async () => {
-    const { app } = buildTestApp({ config: buildAuthConfig() });
-
-    const res = await secureGet(
-      app,
-      `/api/accessibility/description?image_source=${
-        encodeURIComponent('https://example.com/img.jpg')
-      }&model=clip`,
-    );
-
-    expect(res.status).toBe(401);
-    expect(res.body).toMatchObject({
-      error: 'Missing or invalid API authentication credentials',
-      code: 'API_AUTHENTICATION_FAILED',
-      requestId: TEST_REQUEST_ID,
-    });
-  });
-
-  it('accepts X-API-Key authentication on protected endpoints', async () => {
-    const factory = new ImageDescriberFactory().register('clip', {
-      describeImage: jest.fn().mockResolvedValue({
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([{
         description: 'authenticated description',
         imageUrl: 'https://example.com/img.jpg',
-      }),
-    });
-    const { app } = buildTestApp({
-      config: buildAuthConfig(),
-      imageDescriberFactory: factory,
+      }]);
     });
 
-    const res = await secureGet(
-      app,
-      `/api/accessibility/description?image_source=${
-        encodeURIComponent('https://example.com/img.jpg')
-      }&model=clip`,
-    ).set('X-API-Key', 'dummy-2');
+    it('accepts Bearer authentication on protected endpoints', async () => {
+      const scraperService = {
+        getImages: jest.fn().mockResolvedValue({
+          imageSources: ['https://example.com/a.jpg'],
+        }),
+      };
+      const { app } = buildTestApp({
+        config: buildAuthConfig(),
+        scraperService,
+      });
 
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual([{
-      description: 'authenticated description',
-      imageUrl: 'https://example.com/img.jpg',
-    }]);
-  });
+      const res = await secureGet(
+        app,
+        `/api/scraper/images?url=${encodeURIComponent('https://example.com')}`,
+      ).set('Authorization', 'Bearer dummy-1');
 
-  it('accepts Bearer authentication on protected endpoints', async () => {
-    const scraperService = {
-      getImages: jest.fn().mockResolvedValue({
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
         imageSources: ['https://example.com/a.jpg'],
-      }),
-    };
-    const { app } = buildTestApp({
-      config: buildAuthConfig(),
-      scraperService,
+      });
     });
 
-    const res = await secureGet(
-      app,
-      `/api/scraper/images?url=${encodeURIComponent('https://example.com')}`,
-    ).set('Authorization', 'Bearer dummy-1');
+    it('rejects protected endpoints when the token is not in API_AUTH_TOKENS', async () => {
+      const { app } = buildTestApp({ config: buildAuthConfig() });
 
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({
-      imageSources: ['https://example.com/a.jpg'],
+      const res = await secureGet(
+        app,
+        `/api/scraper/images?url=${encodeURIComponent('https://example.com')}`,
+      ).set('Authorization', 'Bearer invalid-token');
+
+      expect(res.status).toBe(401);
+      expect(res.body).toMatchObject({
+        error: 'Missing or invalid API authentication credentials',
+        code: 'API_AUTHENTICATION_FAILED',
+        requestId: TEST_REQUEST_ID,
+      });
     });
-  });
 
-  it('rejects protected endpoints when the token is not in API_AUTH_TOKENS', async () => {
-    const { app } = buildTestApp({ config: buildAuthConfig() });
-
-    const res = await secureGet(
-      app,
-      `/api/scraper/images?url=${encodeURIComponent('https://example.com')}`,
-    ).set('Authorization', 'Bearer invalid-token');
-
-    expect(res.status).toBe(401);
-    expect(res.body).toMatchObject({
-      error: 'Missing or invalid API authentication credentials',
-      code: 'API_AUTHENTICATION_FAILED',
-      requestId: TEST_REQUEST_ID,
-    });
-  });
-
-  it('allows protected endpoints through when auth is explicitly disabled', async () => {
-    const scraperService = {
-      getImages: jest.fn().mockResolvedValue({
-        imageSources: ['https://example.com/a.jpg'],
-      }),
-    };
-    const { app } = buildTestApp({
-      config: {
-        ...buildAuthConfig(),
-        auth: {
-          enabled: false,
-          tokens: ['dummy-1', 'dummy-2'],
+    it('allows protected endpoints through when auth is explicitly disabled', async () => {
+      const scraperService = {
+        getImages: jest.fn().mockResolvedValue({
+          imageSources: ['https://example.com/a.jpg'],
+        }),
+      };
+      const { app } = buildTestApp({
+        config: {
+          ...buildAuthConfig(),
+          auth: {
+            enabled: false,
+            tokens: ['dummy-1', 'dummy-2'],
+          },
         },
-      },
-      scraperService,
-    });
+        scraperService,
+      });
 
-    const res = await secureGet(
-      app,
-      `/api/scraper/images?url=${encodeURIComponent('https://example.com')}`,
-    );
+      const res = await secureGet(
+        app,
+        `/api/scraper/images?url=${encodeURIComponent('https://example.com')}`,
+      );
 
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({
-      imageSources: ['https://example.com/a.jpg'],
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        imageSources: ['https://example.com/a.jpg'],
+      });
     });
   });
 });

--- a/tests/integration/rateLimitRedis.test.js
+++ b/tests/integration/rateLimitRedis.test.js
@@ -91,7 +91,7 @@ const buildRedisConfig = ({
   },
 });
 
-describeIfRedis('Redis-backed rate limiting', () => {
+describeIfRedis('Integration | Redis Rate Limiting', () => {
   let redisServer;
 
   beforeAll(async () => {

--- a/tests/unit/config/index.test.js
+++ b/tests/unit/config/index.test.js
@@ -25,7 +25,7 @@ afterEach(() => {
   jest.resetModules();
 });
 
-describe('config', () => {
+describe('Unit | Config | Index', () => {
   it('uses the documented defaults when optional env vars are unset', () => {
     const config = loadConfig({
       remove: [

--- a/tests/unit/config/rateLimitStore.test.js
+++ b/tests/unit/config/rateLimitStore.test.js
@@ -7,7 +7,7 @@ const {
   resolveEffectiveRateLimitStoreKind,
 } = require('../../../config/rateLimitStore');
 
-describe('rateLimitStore config helpers', () => {
+describe('Unit | Config | Rate Limit Store', () => {
   it('defaults to auto mode with in-memory storage when no Redis URL is configured', () => {
     expect(buildRateLimitStoreConfig({})).toEqual({
       kind: RATE_LIMIT_STORE_MODES.MEMORY,

--- a/tests/unit/config/swagger.test.js
+++ b/tests/unit/config/swagger.test.js
@@ -1,4 +1,4 @@
-describe('config/swagger', () => {
+describe('Unit | Config | Swagger', () => {
   const loadSwaggerDefinition = ({ env, devServerUrl, prodServerUrl }) => {
     jest.resetModules();
     jest.doMock('../../../config', () => ({

--- a/tests/unit/controllers/descriptionController.test.js
+++ b/tests/unit/controllers/descriptionController.test.js
@@ -20,281 +20,283 @@ const makeResMock = () => ({
   json: jest.fn(),
 });
 
-describe('DescriptionController.describe', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('forwards a validation error when image_source is missing', async () => {
-    const controller = createController(new ImageDescriberFactory());
-    const req = { query: { model: 'clip' } };
-    const res = makeResMock();
-    const next = jest.fn();
-
-    await controller.describe(req, res, next);
-
-    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
-    expect(next.mock.calls[0][0]).toMatchObject({
-      statusCode: 400,
-      code: 'QUERY_VALIDATION_ERROR',
-      message: 'Missing required query parameters: image_source and model',
-      details: [{ field: 'image_source', issue: 'required' }],
+describe('Unit | Controllers | Description Controller', () => {
+  describe('DescriptionController.describe', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
     });
-  });
 
-  it('forwards a validation error when model is missing', async () => {
-    const controller = createController(new ImageDescriberFactory());
-    const req = {
-      query: { image_source: encodeURIComponent('https://example.com/img.jpg') },
-    };
-    const res = makeResMock();
-    const next = jest.fn();
+    it('forwards a validation error when image_source is missing', async () => {
+      const controller = createController(new ImageDescriberFactory());
+      const req = { query: { model: 'clip' } };
+      const res = makeResMock();
+      const next = jest.fn();
 
-    await controller.describe(req, res, next);
+      await controller.describe(req, res, next);
 
-    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
-    expect(next.mock.calls[0][0]).toMatchObject({
-      statusCode: 400,
-      code: 'QUERY_VALIDATION_ERROR',
-      details: [{ field: 'model', issue: 'required' }],
+      expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+      expect(next.mock.calls[0][0]).toMatchObject({
+        statusCode: 400,
+        code: 'QUERY_VALIDATION_ERROR',
+        message: 'Missing required query parameters: image_source and model',
+        details: [{ field: 'image_source', issue: 'required' }],
+      });
     });
-  });
 
-  it('forwards a validation error for an invalid image_source URL', async () => {
-    const controller = createController(new ImageDescriberFactory());
-    const req = { query: { image_source: 'not-a-url', model: 'clip' } };
-    const res = makeResMock();
-    const next = jest.fn();
+    it('forwards a validation error when model is missing', async () => {
+      const controller = createController(new ImageDescriberFactory());
+      const req = {
+        query: { image_source: encodeURIComponent('https://example.com/img.jpg') },
+      };
+      const res = makeResMock();
+      const next = jest.fn();
 
-    await controller.describe(req, res, next);
+      await controller.describe(req, res, next);
 
-    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
-    expect(next.mock.calls[0][0]).toMatchObject({
-      statusCode: 400,
-      code: 'INVALID_IMAGE_SOURCE_URL',
-      message: 'Invalid image_source URL',
-      details: [{ field: 'image_source', issue: 'invalid_url' }],
+      expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+      expect(next.mock.calls[0][0]).toMatchObject({
+        statusCode: 400,
+        code: 'QUERY_VALIDATION_ERROR',
+        details: [{ field: 'model', issue: 'required' }],
+      });
     });
-  });
 
-  it('forwards a validation error for an unknown model', async () => {
-    const controller = createController(new ImageDescriberFactory().register('clip', {
-      describeImage: jest.fn(),
-    }));
-    const req = {
-      query: {
-        image_source: encodeURIComponent('https://example.com/img.jpg'),
-        model: 'unknown-model',
-      },
-    };
-    const res = makeResMock();
-    const next = jest.fn();
+    it('forwards a validation error for an invalid image_source URL', async () => {
+      const controller = createController(new ImageDescriberFactory());
+      const req = { query: { image_source: 'not-a-url', model: 'clip' } };
+      const res = makeResMock();
+      const next = jest.fn();
 
-    await controller.describe(req, res, next);
+      await controller.describe(req, res, next);
 
-    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
-    expect(next.mock.calls[0][0]).toMatchObject({
-      statusCode: 400,
-      code: 'UNKNOWN_MODEL',
-      details: [{ field: 'model', issue: 'unsupported_value' }],
+      expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+      expect(next.mock.calls[0][0]).toMatchObject({
+        statusCode: 400,
+        code: 'INVALID_IMAGE_SOURCE_URL',
+        message: 'Invalid image_source URL',
+        details: [{ field: 'image_source', issue: 'invalid_url' }],
+      });
     });
-    expect(next.mock.calls[0][0].message).toMatch(/Unknown model/);
-  });
 
-  it('returns the description array on success', async () => {
-    const mockDescriber = {
-      describeImage: jest.fn().mockResolvedValue({
+    it('forwards a validation error for an unknown model', async () => {
+      const controller = createController(new ImageDescriberFactory().register('clip', {
+        describeImage: jest.fn(),
+      }));
+      const req = {
+        query: {
+          image_source: encodeURIComponent('https://example.com/img.jpg'),
+          model: 'unknown-model',
+        },
+      };
+      const res = makeResMock();
+      const next = jest.fn();
+
+      await controller.describe(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+      expect(next.mock.calls[0][0]).toMatchObject({
+        statusCode: 400,
+        code: 'UNKNOWN_MODEL',
+        details: [{ field: 'model', issue: 'unsupported_value' }],
+      });
+      expect(next.mock.calls[0][0].message).toMatch(/Unknown model/);
+    });
+
+    it('returns the description array on success', async () => {
+      const mockDescriber = {
+        describeImage: jest.fn().mockResolvedValue({
+          description: 'a sunset over the mountains',
+          imageUrl: 'https://example.com/img.jpg',
+        }),
+      };
+      const controller = createController(
+        new ImageDescriberFactory().register('clip', mockDescriber),
+      );
+      const req = {
+        query: {
+          image_source: encodeURIComponent('https://example.com/img.jpg'),
+          model: 'clip',
+        },
+        log: mockLogger,
+      };
+      const res = makeResMock();
+      const next = jest.fn();
+
+      await controller.describe(req, res, next);
+
+      expect(res.json).toHaveBeenCalledWith([{
         description: 'a sunset over the mountains',
         imageUrl: 'https://example.com/img.jpg',
-      }),
-    };
-    const controller = createController(
-      new ImageDescriberFactory().register('clip', mockDescriber),
-    );
-    const req = {
-      query: {
-        image_source: encodeURIComponent('https://example.com/img.jpg'),
-        model: 'clip',
-      },
-      log: mockLogger,
-    };
-    const res = makeResMock();
-    const next = jest.fn();
-
-    await controller.describe(req, res, next);
-
-    expect(res.json).toHaveBeenCalledWith([{
-      description: 'a sunset over the mountains',
-      imageUrl: 'https://example.com/img.jpg',
-    }]);
-    expect(next).not.toHaveBeenCalled();
-  });
-
-  it('forwards an internal error when the describer fails', async () => {
-    const error = new Error('API timeout');
-    const mockDescriber = {
-      describeImage: jest.fn().mockRejectedValue(error),
-    };
-    const controller = createController(
-      new ImageDescriberFactory().register('clip', mockDescriber),
-    );
-    const req = {
-      query: {
-        image_source: encodeURIComponent('https://example.com/img.jpg'),
-        model: 'clip',
-      },
-      log: mockLogger,
-    };
-    const res = makeResMock();
-    const next = jest.fn();
-
-    await controller.describe(req, res, next);
-
-    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
-    expect(next.mock.calls[0][0]).toMatchObject({
-      statusCode: 500,
-      code: 'DESCRIPTION_FETCH_FAILED',
-      message: 'Error fetching description for the provided image',
-      cause: error,
+      }]);
+      expect(next).not.toHaveBeenCalled();
     });
-  });
-});
 
-describe('DescriptionController.describePage', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('forwards a validation error when url is missing', async () => {
-    const controller = createController(new ImageDescriberFactory());
-    const req = { query: { model: 'clip' } };
-    const res = makeResMock();
-    const next = jest.fn();
-
-    await controller.describePage(req, res, next);
-
-    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
-    expect(next.mock.calls[0][0]).toMatchObject({
-      statusCode: 400,
-      code: 'QUERY_VALIDATION_ERROR',
-      message: 'Missing required query parameters: url and model',
-      details: [{ field: 'url', issue: 'required' }],
-    });
-  });
-
-  it('forwards a validation error when url is invalid', async () => {
-    const controller = createController(new ImageDescriberFactory());
-    const req = { query: { url: 'not-a-url', model: 'clip' } };
-    const res = makeResMock();
-    const next = jest.fn();
-
-    await controller.describePage(req, res, next);
-
-    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
-    expect(next.mock.calls[0][0]).toMatchObject({
-      statusCode: 400,
-      code: 'INVALID_PAGE_URL',
-      message: 'Invalid url parameter',
-      details: [{ field: 'url', issue: 'invalid_url' }],
-    });
-  });
-
-  it('forwards a validation error for an unknown model', async () => {
-    const controller = createController(
-      new ImageDescriberFactory(),
-      { describePage: jest.fn().mockRejectedValue(new Error('Unknown model: clip')) },
-    );
-    const req = {
-      query: {
-        url: encodeURIComponent('https://example.com/page'),
-        model: 'clip',
-      },
-    };
-    const res = makeResMock();
-    const next = jest.fn();
-
-    await controller.describePage(req, res, next);
-
-    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
-    expect(next.mock.calls[0][0]).toMatchObject({
-      statusCode: 400,
-      code: 'UNKNOWN_MODEL',
-      message: 'Unknown model: clip',
-    });
-  });
-
-  it('returns ordered descriptions on success', async () => {
-    const expected = {
-      pageUrl: 'https://example.com/page',
-      model: 'clip',
-      totalImages: 3,
-      uniqueImages: 2,
-      descriptions: [
-        {
-          description: 'first',
-          imageUrl: 'https://example.com/a.jpg',
+    it('forwards an internal error when the describer fails', async () => {
+      const error = new Error('API timeout');
+      const mockDescriber = {
+        describeImage: jest.fn().mockRejectedValue(error),
+      };
+      const controller = createController(
+        new ImageDescriberFactory().register('clip', mockDescriber),
+      );
+      const req = {
+        query: {
+          image_source: encodeURIComponent('https://example.com/img.jpg'),
+          model: 'clip',
         },
-        {
-          description: 'second',
-          imageUrl: 'https://example.com/b.jpg',
-        },
-        {
-          description: 'first',
-          imageUrl: 'https://example.com/a.jpg',
-        },
-      ],
-    };
-    const pageDescriptionService = {
-      describePage: jest.fn().mockResolvedValue(expected),
-    };
-    const controller = createController(
-      new ImageDescriberFactory(),
-      pageDescriptionService,
-    );
-    const req = {
-      query: {
-        url: encodeURIComponent('https://example.com/page'),
-        model: 'clip',
-      },
-      log: mockLogger,
-    };
-    const res = makeResMock();
-    const next = jest.fn();
+        log: mockLogger,
+      };
+      const res = makeResMock();
+      const next = jest.fn();
 
-    await controller.describePage(req, res, next);
+      await controller.describe(req, res, next);
 
-    expect(pageDescriptionService.describePage).toHaveBeenCalledWith({
-      pageUrl: 'https://example.com/page',
-      model: 'clip',
+      expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+      expect(next.mock.calls[0][0]).toMatchObject({
+        statusCode: 500,
+        code: 'DESCRIPTION_FETCH_FAILED',
+        message: 'Error fetching description for the provided image',
+        cause: error,
+      });
     });
-    expect(res.json).toHaveBeenCalledWith(expected);
-    expect(next).not.toHaveBeenCalled();
   });
 
-  it('forwards an internal error when page orchestration fails', async () => {
-    const error = new Error('network error');
-    const controller = createController(
-      new ImageDescriberFactory(),
-      { describePage: jest.fn().mockRejectedValue(error) },
-    );
-    const req = {
-      query: {
-        url: encodeURIComponent('https://example.com/page'),
+  describe('DescriptionController.describePage', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('forwards a validation error when url is missing', async () => {
+      const controller = createController(new ImageDescriberFactory());
+      const req = { query: { model: 'clip' } };
+      const res = makeResMock();
+      const next = jest.fn();
+
+      await controller.describePage(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+      expect(next.mock.calls[0][0]).toMatchObject({
+        statusCode: 400,
+        code: 'QUERY_VALIDATION_ERROR',
+        message: 'Missing required query parameters: url and model',
+        details: [{ field: 'url', issue: 'required' }],
+      });
+    });
+
+    it('forwards a validation error when url is invalid', async () => {
+      const controller = createController(new ImageDescriberFactory());
+      const req = { query: { url: 'not-a-url', model: 'clip' } };
+      const res = makeResMock();
+      const next = jest.fn();
+
+      await controller.describePage(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+      expect(next.mock.calls[0][0]).toMatchObject({
+        statusCode: 400,
+        code: 'INVALID_PAGE_URL',
+        message: 'Invalid url parameter',
+        details: [{ field: 'url', issue: 'invalid_url' }],
+      });
+    });
+
+    it('forwards a validation error for an unknown model', async () => {
+      const controller = createController(
+        new ImageDescriberFactory(),
+        { describePage: jest.fn().mockRejectedValue(new Error('Unknown model: clip')) },
+      );
+      const req = {
+        query: {
+          url: encodeURIComponent('https://example.com/page'),
+          model: 'clip',
+        },
+      };
+      const res = makeResMock();
+      const next = jest.fn();
+
+      await controller.describePage(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+      expect(next.mock.calls[0][0]).toMatchObject({
+        statusCode: 400,
+        code: 'UNKNOWN_MODEL',
+        message: 'Unknown model: clip',
+      });
+    });
+
+    it('returns ordered descriptions on success', async () => {
+      const expected = {
+        pageUrl: 'https://example.com/page',
         model: 'clip',
-      },
-      log: mockLogger,
-    };
-    const res = makeResMock();
-    const next = jest.fn();
+        totalImages: 3,
+        uniqueImages: 2,
+        descriptions: [
+          {
+            description: 'first',
+            imageUrl: 'https://example.com/a.jpg',
+          },
+          {
+            description: 'second',
+            imageUrl: 'https://example.com/b.jpg',
+          },
+          {
+            description: 'first',
+            imageUrl: 'https://example.com/a.jpg',
+          },
+        ],
+      };
+      const pageDescriptionService = {
+        describePage: jest.fn().mockResolvedValue(expected),
+      };
+      const controller = createController(
+        new ImageDescriberFactory(),
+        pageDescriptionService,
+      );
+      const req = {
+        query: {
+          url: encodeURIComponent('https://example.com/page'),
+          model: 'clip',
+        },
+        log: mockLogger,
+      };
+      const res = makeResMock();
+      const next = jest.fn();
 
-    await controller.describePage(req, res, next);
+      await controller.describePage(req, res, next);
 
-    expect(next).toHaveBeenCalledWith(expect.any(ApiError));
-    expect(next.mock.calls[0][0]).toMatchObject({
-      statusCode: 500,
-      code: 'PAGE_DESCRIPTION_FETCH_FAILED',
-      message: 'Error fetching descriptions for the provided page',
-      cause: error,
+      expect(pageDescriptionService.describePage).toHaveBeenCalledWith({
+        pageUrl: 'https://example.com/page',
+        model: 'clip',
+      });
+      expect(res.json).toHaveBeenCalledWith(expected);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('forwards an internal error when page orchestration fails', async () => {
+      const error = new Error('network error');
+      const controller = createController(
+        new ImageDescriberFactory(),
+        { describePage: jest.fn().mockRejectedValue(error) },
+      );
+      const req = {
+        query: {
+          url: encodeURIComponent('https://example.com/page'),
+          model: 'clip',
+        },
+        log: mockLogger,
+      };
+      const res = makeResMock();
+      const next = jest.fn();
+
+      await controller.describePage(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ApiError));
+      expect(next.mock.calls[0][0]).toMatchObject({
+        statusCode: 500,
+        code: 'PAGE_DESCRIPTION_FETCH_FAILED',
+        message: 'Error fetching descriptions for the provided page',
+        cause: error,
+      });
     });
   });
 });

--- a/tests/unit/controllers/scraperController.test.js
+++ b/tests/unit/controllers/scraperController.test.js
@@ -11,7 +11,7 @@ const makeResMock = () => ({
   json: jest.fn(),
 });
 
-describe('ScraperController.getImages', () => {
+describe('Unit | Controllers | Scraper Controller', () => {
   it('forwards a validation error when url is missing', async () => {
     const controller = new ScraperController({
       scraperService: {},

--- a/tests/unit/createApp.test.js
+++ b/tests/unit/createApp.test.js
@@ -25,7 +25,7 @@ const createRequestLogger = () => {
   return requestLogger;
 };
 
-describe('createApp', () => {
+describe('Unit | Application Composition', () => {
   it('builds the default services when overrides are not supplied', () => {
     const appLogger = createAppLogger();
     const requestLogger = createRequestLogger();

--- a/tests/unit/infrastructure/loadTlsCredentials.test.js
+++ b/tests/unit/infrastructure/loadTlsCredentials.test.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-describe('loadTlsCredentials', () => {
+describe('Unit | Infrastructure | Load TLS Credentials', () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tls-creds-'));
 
   afterEach(() => {

--- a/tests/unit/infrastructure/logger.test.js
+++ b/tests/unit/infrastructure/logger.test.js
@@ -89,7 +89,7 @@ afterEach(() => {
   jest.resetModules();
 });
 
-describe('infrastructure/logger', () => {
+describe('Unit | Infrastructure | Logger', () => {
   it('uses process-stream logging in production without touching the filesystem', () => {
     const { loggerModule, mockAppLogger } = loadLoggerModule({
       env: {

--- a/tests/unit/infrastructure/outboundTrust.test.js
+++ b/tests/unit/infrastructure/outboundTrust.test.js
@@ -9,7 +9,7 @@ const {
   resolveOptionalFile,
 } = require('../../../src/infrastructure/outboundTrust');
 
-describe('outboundTrust', () => {
+describe('Unit | Infrastructure | Outbound Trust', () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'outbound-trust-'));
 
   afterAll(() => {

--- a/tests/unit/infrastructure/rateLimitStore.test.js
+++ b/tests/unit/infrastructure/rateLimitStore.test.js
@@ -7,7 +7,7 @@ const {
   RATE_LIMIT_STORE_SCOPES,
 } = require('../../../src/infrastructure/rateLimitStore');
 
-describe('rateLimitStore infrastructure', () => {
+describe('Unit | Infrastructure | Rate Limit Store', () => {
   it('builds prefixed Redis store namespaces per limiter scope', () => {
     expect(buildRedisStorePrefix({
       redisPrefix: 'alt-text-generator:rate-limit:',

--- a/tests/unit/jestConfig.test.js
+++ b/tests/unit/jestConfig.test.js
@@ -20,7 +20,7 @@ function loadJestConfig(allureResultsDir) {
   return config;
 }
 
-describe('jest.config.cjs', () => {
+describe('Unit | Jest Configuration', () => {
   const originalAllureResultsDir = process.env.ALLURE_RESULTS_DIR;
 
   afterEach(() => {

--- a/tests/unit/middleware/accessControl.test.js
+++ b/tests/unit/middleware/accessControl.test.js
@@ -14,7 +14,7 @@ const makeRequest = ({
   get: (name) => headers[name.toLowerCase()] ?? null,
 });
 
-describe('access-control middleware', () => {
+describe('Unit | Middleware | Access Control', () => {
   it('treats docs and health endpoints as public', () => {
     expect(isApiPath('/')).toBe(false);
     expect(isApiPath('/api/v1/accessibility/description')).toBe(true);

--- a/tests/unit/middleware/errorHandler.test.js
+++ b/tests/unit/middleware/errorHandler.test.js
@@ -5,7 +5,7 @@ const {
 } = require('../../../src/api/v1/middleware/error-handler');
 const { ApiError } = require('../../../src/errors/ApiError');
 
-describe('error-handler middleware', () => {
+describe('Unit | Middleware | Error Handler', () => {
   it('wraps async handlers and forwards rejected promises', async () => {
     const error = new Error('boom');
     const handler = asyncHandler(async () => {

--- a/tests/unit/middleware/requestFilter.test.js
+++ b/tests/unit/middleware/requestFilter.test.js
@@ -57,7 +57,7 @@ const invokeMiddleware = ({
   };
 };
 
-describe('request-filter', () => {
+describe('Unit | Middleware | Request Filter', () => {
   it('redirects direct HTTP requests to HTTPS using the validated host header', () => {
     const { next, res } = invokeMiddleware();
 

--- a/tests/unit/runPostmanHarness.test.js
+++ b/tests/unit/runPostmanHarness.test.js
@@ -5,7 +5,7 @@ const {
   resolveAllureResultsDir,
 } = require('../../scripts/postman/newman-reporting');
 
-describe('run-postman-harness reporting helpers', () => {
+describe('Unit | Postman Harness Reporting', () => {
   it('keeps the existing CLI, JSON, and JUnit reporters by default', () => {
     const args = buildNewmanReporterArgs({
       label: 'smoke',

--- a/tests/unit/scripts/github/promoteToProduction.test.js
+++ b/tests/unit/scripts/github/promoteToProduction.test.js
@@ -6,7 +6,7 @@ const {
   resolveRequiredChecks,
 } = require('../../../../scripts/github/promote-to-production');
 
-describe('scripts/github/promote-to-production', () => {
+describe('Unit | Scripts | GitHub | Promote To Production', () => {
   describe('parseArgs', () => {
     it('parses supported CLI arguments including required checks', () => {
       expect(parseArgs([

--- a/tests/unit/scripts/github/resolveLiveProviderScope.test.js
+++ b/tests/unit/scripts/github/resolveLiveProviderScope.test.js
@@ -7,7 +7,7 @@ const {
   resolveScopeFromEnv,
 } = require('../../../../scripts/github/resolve-live-provider-scope');
 
-describe('scripts/github/resolve-live-provider-scope', () => {
+describe('Unit | Scripts | GitHub | Resolve Live Provider Scope', () => {
   describe('resolveScopeFromEnv', () => {
     it('respects an explicit manual scope override', () => {
       expect(resolveScopeFromEnv({

--- a/tests/unit/scripts/github/writeNewmanSummary.test.js
+++ b/tests/unit/scripts/github/writeNewmanSummary.test.js
@@ -12,7 +12,7 @@ const createTempDir = () => fs.mkdtempSync(
   path.join(os.tmpdir(), 'newman-summary-test-'),
 );
 
-describe('scripts/github/write-newman-summary', () => {
+describe('Unit | Scripts | GitHub | Write Newman Summary', () => {
   it('parses supported CLI arguments', () => {
     expect(parseArgs([
       '--reports-dir',

--- a/tests/unit/scripts/postman/collectionUtils.test.js
+++ b/tests/unit/scripts/postman/collectionUtils.test.js
@@ -1,16 +1,18 @@
 const path = require('node:path');
 
 const {
-  assertRequestItemsHaveExactStatusAssertions,
+  assertRequestItemsHaveSpecificStatusExpectations,
   assertTopLevelFoldersExist,
   buildItemFolderMap,
   hasExactStatusAssertion,
+  hasExpectedStatusCodeHeader,
+  hasSpecificStatusExpectation,
   listTopLevelFolderNames,
   listRequestItems,
   readCollection,
 } = require('../../../../scripts/postman/collection-utils');
 
-describe('scripts/postman/collection-utils', () => {
+describe('Unit | Scripts | Postman | Collection Utils', () => {
   const collection = {
     item: [
       {
@@ -114,8 +116,64 @@ describe('scripts/postman/collection-utils', () => {
     })).toBe(true);
   });
 
-  it('throws when request items are missing exact status assertions', () => {
-    expect(() => assertRequestItemsHaveExactStatusAssertions({
+  it('detects exact status-code headers on request items', () => {
+    expect(hasExpectedStatusCodeHeader({
+      request: {
+        header: [
+          {
+            key: 'X-Expected-Status-Code',
+            value: '429',
+          },
+        ],
+      },
+    })).toBe(true);
+
+    expect(hasExpectedStatusCodeHeader({
+      request: {
+        header: [
+          {
+            key: 'X-Expected-Status-Code',
+            value: 'not-a-number',
+          },
+        ],
+      },
+    })).toBe(false);
+  });
+
+  it('treats either a header or an exact assertion as a specific status expectation', () => {
+    expect(hasSpecificStatusExpectation({
+      request: {
+        header: [
+          {
+            key: 'X-Expected-Status-Code',
+            value: '200',
+          },
+        ],
+      },
+      event: [],
+    })).toBe(true);
+
+    expect(hasSpecificStatusExpectation({
+      request: {
+        header: [],
+      },
+      event: [
+        {
+          listen: 'test',
+          script: {
+            exec: [
+              "pm.test('root service index returns 200', function () {",
+              '  pm.response.to.have.status(200);',
+              '});',
+            ],
+          },
+        },
+      ],
+    })).toBe(true);
+  });
+
+  it('throws when request items are missing a specific status expectation', () => {
+    expect(() => assertRequestItemsHaveSpecificStatusExpectations({
       item: [
         {
           name: '00 Core Smoke',
@@ -129,17 +187,19 @@ describe('scripts/postman/collection-utils', () => {
         },
       ],
     })).toThrow(
-      'Missing exact status assertions for Postman requests: 00 Core Smoke > Ping',
+      'Missing specific status expectations for Postman requests: 00 Core Smoke > Ping',
     );
   });
 
-  it('enforces exact status assertions across the committed Postman collection', () => {
+  it('enforces specific status expectations across the committed Postman collection', () => {
     const collectionPath = path.join(
       __dirname,
       '../../../../postman/collections/alt-text-generator.postman_collection.json',
     );
     const committedCollection = readCollection(collectionPath);
 
-    expect(() => assertRequestItemsHaveExactStatusAssertions(committedCollection)).not.toThrow();
+    expect(() => assertRequestItemsHaveSpecificStatusExpectations(
+      committedCollection,
+    )).not.toThrow();
   });
 });

--- a/tests/unit/scripts/postman/liveProviderScope.test.js
+++ b/tests/unit/scripts/postman/liveProviderScope.test.js
@@ -5,7 +5,7 @@ const {
   resolveProviderScope,
 } = require('../../../../scripts/postman/live-provider-scope');
 
-describe('scripts/postman/live-provider-scope', () => {
+describe('Unit | Scripts | Postman | Live Provider Scope', () => {
   describe('normalizeProviderScope', () => {
     it('falls back to auto when the value is empty', () => {
       expect(normalizeProviderScope(undefined)).toBe('auto');

--- a/tests/unit/scripts/runPostmanDeploy.test.js
+++ b/tests/unit/scripts/runPostmanDeploy.test.js
@@ -31,7 +31,7 @@ const createJsonResponse = (status, jsonBody, headers = {}) => ({
   text: jest.fn().mockResolvedValue(JSON.stringify(jsonBody)),
 });
 
-describe('scripts/run-postman-deploy', () => {
+describe('Unit | Scripts | Run Postman Deploy', () => {
   describe('parseArgs', () => {
     it('uses the production base URL by default', () => {
       expect(parseArgs([])).toEqual({

--- a/tests/unit/server/clusterManager.test.js
+++ b/tests/unit/server/clusterManager.test.js
@@ -33,7 +33,7 @@ const createWorker = (pid, overrides = {}) => ({
   ...overrides,
 });
 
-describe('clusterManager', () => {
+describe('Unit | Server | Cluster Manager', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2026-03-07T12:00:00.000Z'));

--- a/tests/unit/server/registerFatalHandlers.test.js
+++ b/tests/unit/server/registerFatalHandlers.test.js
@@ -11,7 +11,7 @@ const createProcessRef = () => {
   return processRef;
 };
 
-describe('registerFatalHandlers', () => {
+describe('Unit | Server | Register Fatal Handlers', () => {
   it('normalizes non-error unhandled rejections into structured fatal logs', () => {
     const normalized = normalizeUnhandledRejection({ status: 'bad-gateway' });
 

--- a/tests/unit/server/runtimeBootstrap.test.js
+++ b/tests/unit/server/runtimeBootstrap.test.js
@@ -14,7 +14,7 @@ const createProcessRef = () => {
   return processRef;
 };
 
-describe('runtimeBootstrap', () => {
+describe('Unit | Server | Runtime Bootstrap', () => {
   it('derives worker count and cluster mode from config', () => {
     expect(resolveWorkerCount({ cluster: { workers: 1 } })).toBe(1);
     expect(resolveWorkerCount({ cluster: { workers: 4 } })).toBe(4);

--- a/tests/unit/server/runtimeState.test.js
+++ b/tests/unit/server/runtimeState.test.js
@@ -1,6 +1,6 @@
 const { createRuntimeState } = require('../../../src/server/runtimeState');
 
-describe('runtimeState', () => {
+describe('Unit | Server | Runtime State', () => {
   it('starts not ready by default', () => {
     const runtimeState = createRuntimeState();
 

--- a/tests/unit/server/serverFunctions.test.js
+++ b/tests/unit/server/serverFunctions.test.js
@@ -13,7 +13,7 @@ const createProcessRef = () => {
   return processRef;
 };
 
-describe('serverFunctions', () => {
+describe('Unit | Server | Server Functions', () => {
   it('configures created HTTP servers with conservative timeout defaults', () => {
     const server = createHttpServer(jest.fn());
 

--- a/tests/unit/server/startApplicationRuntime.test.js
+++ b/tests/unit/server/startApplicationRuntime.test.js
@@ -8,7 +8,7 @@ const createProcessRef = () => {
   return processRef;
 };
 
-describe('startApplicationRuntime', () => {
+describe('Unit | Server | Start Application Runtime', () => {
   it('starts both servers and registers graceful shutdown', async () => {
     const app = { name: 'express-app' };
     const httpServer = { kind: 'http' };

--- a/tests/unit/services/AzureDescriberService.test.js
+++ b/tests/unit/services/AzureDescriberService.test.js
@@ -15,7 +15,7 @@ const mockConfig = {
   },
 };
 
-describe('AzureDescriberService.describeImage', () => {
+describe('Unit | Services | Azure Describer Service', () => {
   it('returns joined captions as description', async () => {
     const mockHttpClient = {
       get: jest.fn().mockResolvedValue({

--- a/tests/unit/services/ImageDescriberFactory.test.js
+++ b/tests/unit/services/ImageDescriberFactory.test.js
@@ -3,7 +3,7 @@ const ImageDescriberFactory = require('../../../src/services/ImageDescriberFacto
 const mockDescriber = { describeImage: jest.fn() };
 const mockAzureDescriber = { describeImage: jest.fn() };
 
-describe('ImageDescriberFactory', () => {
+describe('Unit | Services | Image Describer Factory', () => {
   it('returns a registered describer by name', () => {
     const factory = new ImageDescriberFactory().register('clip', mockDescriber);
     expect(factory.get('clip')).toBe(mockDescriber);

--- a/tests/unit/services/PageDescriptionService.test.js
+++ b/tests/unit/services/PageDescriptionService.test.js
@@ -1,7 +1,7 @@
 const PageDescriptionService = require('../../../src/services/PageDescriptionService');
 const ImageDescriberFactory = require('../../../src/services/ImageDescriberFactory');
 
-describe('PageDescriptionService', () => {
+describe('Unit | Services | Page Description Service', () => {
   it('preserves duplicate image entries while deduping provider work', async () => {
     const scraperService = {
       getImages: jest.fn().mockResolvedValue({

--- a/tests/unit/services/ReplicateDescriberService.test.js
+++ b/tests/unit/services/ReplicateDescriberService.test.js
@@ -14,7 +14,7 @@ const mockConfig = {
   },
 };
 
-describe('ReplicateDescriberService.describeImage', () => {
+describe('Unit | Services | Replicate Describer Service', () => {
   it('returns description and imageUrl on success', async () => {
     const mockReplicate = {
       run: jest.fn().mockResolvedValue('a cat sitting on a mat'),

--- a/tests/unit/services/ScraperService.test.js
+++ b/tests/unit/services/ScraperService.test.js
@@ -23,96 +23,98 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-describe('ScraperService.isImage', () => {
-  it.each([
-    ['https://example.com/photo.jpg', true],
-    ['https://example.com/photo.jpeg', true],
-    ['https://example.com/photo.png', true],
-    ['https://example.com/photo.gif', true],
-    ['https://example.com/photo.webp', true],
-    ['https://example.com/photo.svg', true],
-    ['https://example.com/photo.bmp', true],
-    ['https://example.com/photo.jpg?v=123', true],
-    ['https://example.com/page.html', false],
-    ['https://example.com/script.js', false],
-    ['https://example.com/noextension', false],
-    ['', false],
-  ])('isImage(%s) === %s', (url, expected) => {
-    expect(ScraperService.isImage(url)).toBe(expected);
-  });
-});
-
-describe('ScraperService.extractImageSources', () => {
-  const svc = makeService();
-
-  it('extracts absolute image src attributes', () => {
-    const html = `<html><body>
-      <img src="https://example.com/a.jpg">
-      <img src="https://example.com/b.png">
-    </body></html>`;
-    const result = svc.extractImageSources(html, 'https://example.com');
-    expect(result.imageSources).toEqual([
-      'https://example.com/a.jpg',
-      'https://example.com/b.png',
-    ]);
-  });
-
-  it('resolves relative image paths to absolute URLs', () => {
-    const html = '<html><body><img src="/images/photo.jpg"></body></html>';
-    const result = svc.extractImageSources(html, 'https://example.com');
-    expect(result.imageSources).toContain('https://example.com/images/photo.jpg');
-  });
-
-  it('prefers data-src over src for lazy-loaded images', () => {
-    const html = '<html><body><img data-src="https://cdn.example.com/lazy.jpg" src="placeholder.gif"></body></html>';
-    const result = svc.extractImageSources(html, 'https://example.com');
-    expect(result.imageSources).toContain('https://cdn.example.com/lazy.jpg');
-  });
-
-  it('strips query strings from image URLs', () => {
-    const html = '<html><body><img src="https://example.com/photo.jpg?size=large"></body></html>';
-    const result = svc.extractImageSources(html, 'https://example.com');
-    expect(result.imageSources).toContain('https://example.com/photo.jpg');
-  });
-
-  it('returns empty array when no images found', () => {
-    const html = '<html><body><p>No images here</p></body></html>';
-    const result = svc.extractImageSources(html, 'https://example.com');
-    expect(result.imageSources).toEqual([]);
-  });
-
-  it('skips invalid image URLs that cannot be resolved', () => {
-    const html = '<html><body><img src="http://[invalid-url]/photo.jpg"></body></html>';
-
-    const result = svc.extractImageSources(html, 'https://example.com');
-
-    expect(result.imageSources).toEqual([]);
-    expect(mockLogger.warn).toHaveBeenCalled();
-  });
-});
-
-describe('ScraperService.getImages', () => {
-  it('returns image sources on success', async () => {
-    const html = '<html><body><img src="https://example.com/photo.jpg"></body></html>';
-    const mockHttpClient = { get: jest.fn().mockResolvedValue({ data: html }) };
-    const svc = makeService(mockHttpClient);
-
-    const result = await svc.getImages('https://example.com');
-    expect(result.imageSources).toContain('https://example.com/photo.jpg');
-    expect(mockHttpClient.get).toHaveBeenCalledWith('https://example.com', {
-      headers: { Origin: 'https://example.com' },
-      maxBodyLength: 1024,
-      maxContentLength: 1024,
-      maxRedirects: 3,
-      responseType: 'text',
-      timeout: 1000,
+describe('Unit | Services | Scraper Service', () => {
+  describe('ScraperService.isImage', () => {
+    it.each([
+      ['https://example.com/photo.jpg', true],
+      ['https://example.com/photo.jpeg', true],
+      ['https://example.com/photo.png', true],
+      ['https://example.com/photo.gif', true],
+      ['https://example.com/photo.webp', true],
+      ['https://example.com/photo.svg', true],
+      ['https://example.com/photo.bmp', true],
+      ['https://example.com/photo.jpg?v=123', true],
+      ['https://example.com/page.html', false],
+      ['https://example.com/script.js', false],
+      ['https://example.com/noextension', false],
+      ['', false],
+    ])('isImage(%s) === %s', (url, expected) => {
+      expect(ScraperService.isImage(url)).toBe(expected);
     });
   });
 
-  it('throws when the HTTP client rejects', async () => {
-    const mockHttpClient = { get: jest.fn().mockRejectedValue(new Error('Network error')) };
-    const svc = makeService(mockHttpClient);
+  describe('ScraperService.extractImageSources', () => {
+    const svc = makeService();
 
-    await expect(svc.getImages('https://example.com')).rejects.toThrow('Network error');
+    it('extracts absolute image src attributes', () => {
+      const html = `<html><body>
+      <img src="https://example.com/a.jpg">
+      <img src="https://example.com/b.png">
+    </body></html>`;
+      const result = svc.extractImageSources(html, 'https://example.com');
+      expect(result.imageSources).toEqual([
+        'https://example.com/a.jpg',
+        'https://example.com/b.png',
+      ]);
+    });
+
+    it('resolves relative image paths to absolute URLs', () => {
+      const html = '<html><body><img src="/images/photo.jpg"></body></html>';
+      const result = svc.extractImageSources(html, 'https://example.com');
+      expect(result.imageSources).toContain('https://example.com/images/photo.jpg');
+    });
+
+    it('prefers data-src over src for lazy-loaded images', () => {
+      const html = '<html><body><img data-src="https://cdn.example.com/lazy.jpg" src="placeholder.gif"></body></html>';
+      const result = svc.extractImageSources(html, 'https://example.com');
+      expect(result.imageSources).toContain('https://cdn.example.com/lazy.jpg');
+    });
+
+    it('strips query strings from image URLs', () => {
+      const html = '<html><body><img src="https://example.com/photo.jpg?size=large"></body></html>';
+      const result = svc.extractImageSources(html, 'https://example.com');
+      expect(result.imageSources).toContain('https://example.com/photo.jpg');
+    });
+
+    it('returns empty array when no images found', () => {
+      const html = '<html><body><p>No images here</p></body></html>';
+      const result = svc.extractImageSources(html, 'https://example.com');
+      expect(result.imageSources).toEqual([]);
+    });
+
+    it('skips invalid image URLs that cannot be resolved', () => {
+      const html = '<html><body><img src="http://[invalid-url]/photo.jpg"></body></html>';
+
+      const result = svc.extractImageSources(html, 'https://example.com');
+
+      expect(result.imageSources).toEqual([]);
+      expect(mockLogger.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe('ScraperService.getImages', () => {
+    it('returns image sources on success', async () => {
+      const html = '<html><body><img src="https://example.com/photo.jpg"></body></html>';
+      const mockHttpClient = { get: jest.fn().mockResolvedValue({ data: html }) };
+      const svc = makeService(mockHttpClient);
+
+      const result = await svc.getImages('https://example.com');
+      expect(result.imageSources).toContain('https://example.com/photo.jpg');
+      expect(mockHttpClient.get).toHaveBeenCalledWith('https://example.com', {
+        headers: { Origin: 'https://example.com' },
+        maxBodyLength: 1024,
+        maxContentLength: 1024,
+        maxRedirects: 3,
+        responseType: 'text',
+        timeout: 1000,
+      });
+    });
+
+    it('throws when the HTTP client rejects', async () => {
+      const mockHttpClient = { get: jest.fn().mockRejectedValue(new Error('Network error')) };
+      const svc = makeService(mockHttpClient);
+
+      await expect(svc.getImages('https://example.com')).rejects.toThrow('Network error');
+    });
   });
 });

--- a/tests/unit/urlValidator.test.js
+++ b/tests/unit/urlValidator.test.js
@@ -1,6 +1,6 @@
 const { isValidUrl } = require('../../src/utils/urlValidator');
 
-describe('isValidUrl', () => {
+describe('Unit | URL Validator', () => {
   it('returns true for a valid http URL', () => {
     expect(isValidUrl('http://example.com')).toBe(true);
   });

--- a/tests/unit/utils/createRouter.test.js
+++ b/tests/unit/utils/createRouter.test.js
@@ -24,7 +24,7 @@ const logger = {
   debug: jest.fn(),
 };
 
-describe('createRouter', () => {
+describe('Unit | Utils | Create Router', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     swaggerModuleLoaded = false;

--- a/tests/unit/utils/getUpstreamErrorSummary.test.js
+++ b/tests/unit/utils/getUpstreamErrorSummary.test.js
@@ -1,6 +1,6 @@
 const { getUpstreamErrorSummary } = require('../../../src/utils/getUpstreamErrorSummary');
 
-describe('getUpstreamErrorSummary', () => {
+describe('Unit | Utils | Get Upstream Error Summary', () => {
   it('extracts request and response details from fetch-style errors', () => {
     const error = new Error('Request failed');
     error.request = {

--- a/tests/unit/utils/validateEnvVars.test.js
+++ b/tests/unit/utils/validateEnvVars.test.js
@@ -21,7 +21,7 @@ afterEach(() => {
   jest.resetModules();
 });
 
-describe('validateEnvVars', () => {
+describe('Unit | Utils | Validate Env Vars', () => {
   it('accepts a Replicate-only provider configuration', () => {
     const validateEnvVars = loadValidator({
       overrides: {

--- a/tests/unit/writeAllureMetadata.test.js
+++ b/tests/unit/writeAllureMetadata.test.js
@@ -10,7 +10,7 @@ const {
   writeAllureMetadata,
 } = require('../../scripts/reporting/write-allure-metadata');
 
-describe('write-allure-metadata', () => {
+describe('Unit | Allure Metadata Writer', () => {
   it('parses the required results directory argument', () => {
     const { resultsDir } = parseArgs(['--results-dir', 'reports/allure-results']);
 


### PR DESCRIPTION
## Summary
- replace the shared Newman `response is not 5xx` fallback with explicit status-code contracts in the committed Postman collection
- enforce specific status expectations in collection utils and keep Newman report output tied to exact request statuses
- rename top-level Jest suites across the repo to report-friendly `Scope | Area | Subject` names and add outer wrappers for multi-suite files
- update README and DEVELOPMENT with the public GitHub Pages Allure URLs and deployment behavior

## Validation
- npm run lint
- NODE_ENV=test REPLICATE_API_TOKEN=test-token npm test -- --runInBand
- npm run postman:harness
- targeted Allure verification for `loadTlsCredentials` and `ScraperService` suite names
