### PR TITLE
Retain Allure report history across runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,13 @@ jobs:
             echo "has-results=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Restore published Allure history
+        if: steps.allure-inputs.outputs.has-results == 'true'
+        run: >-
+          node scripts/reporting/fetch-allure-history.js
+          --results-dir reports/allure-results
+          --report-url https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
+
       - name: Write Allure metadata
         if: steps.allure-inputs.outputs.has-results == 'true'
         run: node scripts/reporting/write-allure-metadata.js --results-dir reports/allure-results
@@ -318,6 +325,7 @@ jobs:
             if [[ "${{ steps.allure-inputs.outputs.has-results }}" == "true" ]]; then
               echo "- HTML report uploaded as the \`allure-report\` artifact."
               echo "- Raw results merged from the canonical Node 20 Jest lane and the \`${{ github.event_name == 'pull_request' && 'smoke' || 'harness' }}\` Newman run."
+              echo "- The report generator restores the currently published Allure \`history/\` payload before building the next report."
             else
               echo "- No Allure raw results were available to merge."
             fi

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -212,6 +212,7 @@ Allure workflow:
 - GitHub Actions publishes Allure from the canonical Node 20 Jest lane only so matrix lanes 22 and 24 do not duplicate unit tests in the merged report.
 - The public GitHub Pages deployment is `https://jsugg.github.io/alt-text-generator/`; the suites view is `https://jsugg.github.io/alt-text-generator/#suites`.
 - On pushes to `main`, the CI workflow uploads the generated HTML as both a regular artifact and a GitHub Pages deployment artifact, then deploys the latest report once the `allure-pages` job succeeds.
+- The `allure-report` job restores the currently published Pages `history/` files into `reports/allure-results/history` before `allure generate`, so PR artifacts and `main` deployments both keep Allure trend history.
 - Pull requests do not deploy Pages; they still produce the downloadable `allure-report` artifact for review.
 
 ## Supported Models

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Notes:
 - CI uploads the generated HTML as the `allure-report` artifact.
 - The public Pages deployment is `https://jsugg.github.io/alt-text-generator/`; the suites view is `https://jsugg.github.io/alt-text-generator/#suites`.
 - Pushes to `main` publish the latest generated report to GitHub Pages after the `allure-pages` job finishes successfully.
+- Each generated Allure report first restores the currently published Pages `history/` payload, so trend data carries forward into PR artifacts and the next `main` publication.
 - CI only emits Jest Allure results from the Node 20 lane so unit tests do not appear three times in the merged report.
 - The Allure CLI requires Java when you generate the HTML report locally or in CI.
 

--- a/scripts/reporting/fetch-allure-history.js
+++ b/scripts/reporting/fetch-allure-history.js
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+const HISTORY_FILENAMES = Object.freeze([
+  'categories-trend.json',
+  'duration-trend.json',
+  'history-trend.json',
+  'history.json',
+  'retry-trend.json',
+]);
+
+/**
+ * Normalizes a public report URL by trimming trailing slashes.
+ *
+ * @param {string} reportUrl
+ * @returns {string}
+ */
+function normalizeReportUrl(reportUrl) {
+  return reportUrl.replace(/\/+$/u, '');
+}
+
+/**
+ * Builds the public URL for a specific Allure history file.
+ *
+ * @param {string} reportUrl
+ * @param {string} filename
+ * @returns {string}
+ */
+function buildHistoryFileUrl(reportUrl, filename) {
+  return `${normalizeReportUrl(reportUrl)}/history/${filename}`;
+}
+
+/**
+ * Parses CLI arguments.
+ *
+ * @param {string[]} argv
+ * @returns {{ reportUrl: string | null, resultsDir: string, timeoutMs: number }}
+ */
+function parseArgs(argv) {
+  let reportUrl = null;
+  let resultsDir = null;
+  let timeoutMs = DEFAULT_TIMEOUT_MS;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+
+    if (token === '--report-url') {
+      reportUrl = argv[index + 1] || null;
+      index += 1;
+    } else if (token === '--results-dir') {
+      resultsDir = argv[index + 1] || null;
+      index += 1;
+    } else if (token === '--timeout-ms') {
+      timeoutMs = Number(argv[index + 1]);
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${token}`);
+    }
+  }
+
+  if (!resultsDir) {
+    throw new Error('Missing required argument: --results-dir <path>');
+  }
+
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error('Expected --timeout-ms to be a positive number');
+  }
+
+  return {
+    reportUrl: reportUrl ? normalizeReportUrl(reportUrl) : null,
+    resultsDir: path.resolve(process.cwd(), resultsDir),
+    timeoutMs,
+  };
+}
+
+/**
+ * Fetches a single history file from the previously published report.
+ *
+ * @param {{
+ *   fetchImpl?: typeof fetch,
+ *   filename: string,
+ *   reportUrl: string,
+ *   timeoutMs?: number,
+ * }} options
+ * @returns {Promise<{
+ *   content?: string,
+ *   filename: string,
+ *   status: 'restored' | 'missing' | 'error',
+ *   url: string,
+ *   message?: string,
+ * }>}
+ */
+async function fetchHistoryFile({
+  filename,
+  reportUrl,
+  fetchImpl = fetch,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}) {
+  const url = buildHistoryFileUrl(reportUrl, filename);
+
+  try {
+    const response = await fetchImpl(url, {
+      redirect: 'follow',
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+
+    if (response.status === 404) {
+      return {
+        filename,
+        status: 'missing',
+        url,
+      };
+    }
+
+    if (!response.ok) {
+      return {
+        filename,
+        status: 'error',
+        url,
+        message: `unexpected status ${response.status}`,
+      };
+    }
+
+    const content = await response.text();
+    JSON.parse(content);
+
+    return {
+      content: `${content.trimEnd()}\n`,
+      filename,
+      status: 'restored',
+      url,
+    };
+  } catch (error) {
+    return {
+      filename,
+      status: 'error',
+      url,
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Restores Allure history files into the given results directory.
+ *
+ * @param {{
+ *   fetchImpl?: typeof fetch,
+ *   logger?: Pick<Console, 'info' | 'warn'>,
+ *   reportUrl: string | null,
+ *   resultsDir: string,
+ *   timeoutMs?: number,
+ * }} options
+ * @returns {Promise<{
+ *   errors: { filename: string, message: string, url: string }[],
+ *   restoredFiles: string[],
+ *   skippedFiles: string[],
+ * }>}
+ */
+async function restoreAllureHistory({
+  reportUrl,
+  resultsDir,
+  fetchImpl = fetch,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  logger = console,
+}) {
+  if (!reportUrl) {
+    logger.info?.('No public Allure report URL configured; skipping history restore.');
+    return {
+      errors: [],
+      restoredFiles: [],
+      skippedFiles: [...HISTORY_FILENAMES],
+    };
+  }
+
+  const historyDir = path.join(resultsDir, 'history');
+  await fs.mkdir(historyDir, { recursive: true });
+
+  const results = await Promise.all(HISTORY_FILENAMES.map((filename) => fetchHistoryFile({
+    fetchImpl,
+    filename,
+    reportUrl,
+    timeoutMs,
+  })));
+
+  const restoredResults = results.filter((result) => result.status === 'restored');
+  const skippedResults = results.filter((result) => result.status === 'missing');
+  const errorResults = results.filter((result) => result.status === 'error');
+
+  await Promise.all(restoredResults.map((result) => fs.writeFile(
+    path.join(historyDir, result.filename),
+    result.content,
+    'utf8',
+  )));
+
+  errorResults.forEach((result) => {
+    logger.warn?.(
+      `Unable to restore Allure history file ${result.filename} from ${result.url}: ${result.message || 'unknown error'}`,
+    );
+  });
+
+  const errors = errorResults.map((result) => ({
+    filename: result.filename,
+    message: result.message || 'unknown error',
+    url: result.url,
+  }));
+  const restoredFiles = restoredResults.map((result) => result.filename);
+  const skippedFiles = skippedResults.map((result) => result.filename);
+
+  if (restoredFiles.length === 0) {
+    await fs.rm(historyDir, { force: true, recursive: true });
+  }
+
+  return {
+    errors,
+    restoredFiles,
+    skippedFiles,
+  };
+}
+
+if (require.main === module) {
+  const options = parseArgs(process.argv.slice(2));
+
+  restoreAllureHistory(options)
+    .then(({ errors, restoredFiles, skippedFiles }) => {
+      // eslint-disable-next-line no-console
+      console.info(
+        `Allure history restore complete: restored=${restoredFiles.length}, skipped=${skippedFiles.length}, errors=${errors.length}`,
+      );
+    })
+    .catch((error) => {
+      // eslint-disable-next-line no-console
+      console.error(error);
+      process.exit(1);
+    });
+}
+
+module.exports = {
+  DEFAULT_TIMEOUT_MS,
+  HISTORY_FILENAMES,
+  buildHistoryFileUrl,
+  fetchHistoryFile,
+  normalizeReportUrl,
+  parseArgs,
+  restoreAllureHistory,
+};

--- a/tests/unit/fetchAllureHistory.test.js
+++ b/tests/unit/fetchAllureHistory.test.js
@@ -1,0 +1,156 @@
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  DEFAULT_TIMEOUT_MS,
+  HISTORY_FILENAMES,
+  buildHistoryFileUrl,
+  fetchHistoryFile,
+  normalizeReportUrl,
+  parseArgs,
+  restoreAllureHistory,
+} = require('../../scripts/reporting/fetch-allure-history');
+
+describe('Unit | Allure History Fetcher', () => {
+  it('normalizes the report URL and builds history file URLs', () => {
+    expect(normalizeReportUrl('https://jsugg.github.io/alt-text-generator///')).toBe(
+      'https://jsugg.github.io/alt-text-generator',
+    );
+    expect(buildHistoryFileUrl(
+      'https://jsugg.github.io/alt-text-generator/',
+      'history.json',
+    )).toBe('https://jsugg.github.io/alt-text-generator/history/history.json');
+  });
+
+  it('parses CLI arguments with defaults', () => {
+    expect(parseArgs([
+      '--results-dir',
+      'reports/allure-results',
+      '--report-url',
+      'https://jsugg.github.io/alt-text-generator/',
+    ])).toEqual({
+      reportUrl: 'https://jsugg.github.io/alt-text-generator',
+      resultsDir: path.join(process.cwd(), 'reports', 'allure-results'),
+      timeoutMs: DEFAULT_TIMEOUT_MS,
+    });
+  });
+
+  it('rejects invalid timeout values', () => {
+    expect(() => parseArgs([
+      '--results-dir',
+      'reports/allure-results',
+      '--timeout-ms',
+      '0',
+    ])).toThrow('Expected --timeout-ms to be a positive number');
+  });
+
+  it('fetches and validates a history file', async () => {
+    const result = await fetchHistoryFile({
+      filename: 'history.json',
+      reportUrl: 'https://jsugg.github.io/alt-text-generator',
+      fetchImpl: jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue('{"items": []}'),
+      }),
+    });
+
+    expect(result).toEqual({
+      content: '{"items": []}\n',
+      filename: 'history.json',
+      status: 'restored',
+      url: 'https://jsugg.github.io/alt-text-generator/history/history.json',
+    });
+  });
+
+  it('treats 404 history files as missing instead of failing the build', async () => {
+    const result = await fetchHistoryFile({
+      filename: 'history.json',
+      reportUrl: 'https://jsugg.github.io/alt-text-generator',
+      fetchImpl: jest.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: jest.fn(),
+      }),
+    });
+
+    expect(result).toEqual({
+      filename: 'history.json',
+      status: 'missing',
+      url: 'https://jsugg.github.io/alt-text-generator/history/history.json',
+    });
+  });
+
+  it('warns and continues when a history file is invalid', async () => {
+    const warn = jest.fn();
+    const resultsDir = await fs.mkdtemp(path.join(os.tmpdir(), 'allure-history-'));
+    const fetchImpl = jest.fn(async (url) => {
+      if (url.endsWith('/history.json')) {
+        return {
+          ok: true,
+          status: 200,
+          text: async () => '<html>not json</html>',
+        };
+      }
+
+      return {
+        ok: false,
+        status: 404,
+        text: async () => '',
+      };
+    });
+
+    try {
+      const result = await restoreAllureHistory({
+        fetchImpl,
+        logger: { info: jest.fn(), warn },
+        reportUrl: 'https://jsugg.github.io/alt-text-generator',
+        resultsDir,
+      });
+
+      expect(result.restoredFiles).toEqual([]);
+      expect(result.skippedFiles).toEqual(HISTORY_FILENAMES.filter((name) => name !== 'history.json'));
+      expect(result.errors).toEqual([
+        {
+          filename: 'history.json',
+          message: expect.stringContaining('Unexpected token'),
+          url: 'https://jsugg.github.io/alt-text-generator/history/history.json',
+        },
+      ]);
+      expect(warn).toHaveBeenCalledTimes(1);
+      await expect(fs.stat(path.join(resultsDir, 'history'))).rejects.toThrow();
+    } finally {
+      await fs.rm(resultsDir, { recursive: true, force: true });
+    }
+  });
+
+  it('restores the published history files into the results directory', async () => {
+    const resultsDir = await fs.mkdtemp(path.join(os.tmpdir(), 'allure-history-'));
+    const fetchImpl = jest.fn(async (url) => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({
+        source: url,
+      }),
+    }));
+
+    try {
+      const result = await restoreAllureHistory({
+        fetchImpl,
+        logger: { info: jest.fn(), warn: jest.fn() },
+        reportUrl: 'https://jsugg.github.io/alt-text-generator',
+        resultsDir,
+      });
+
+      expect(result.errors).toEqual([]);
+      expect(result.skippedFiles).toEqual([]);
+      expect(result.restoredFiles).toEqual(HISTORY_FILENAMES);
+
+      const writtenFiles = await fs.readdir(path.join(resultsDir, 'history'));
+      expect(writtenFiles.sort()).toEqual([...HISTORY_FILENAMES].sort());
+    } finally {
+      await fs.rm(resultsDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- restore the previously published GitHub Pages Allure history payload before generating the next report
- keep the restore path non-fatal so missing or malformed remote history does not block report generation
- document the history carry-forward behavior and cover the fetcher with unit tests