### PR TITLE
Opt Pages jobs into Node 24 actions runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,8 @@ jobs:
       publish_pages: ${{ steps.history-policy.outputs.publish_pages }}
       report_kind: ${{ steps.history-policy.outputs.report_kind }}
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -425,6 +427,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     outputs:
       page-url: ${{ steps.deployment.outputs.page_url }}
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Summary
- opt the Pages-related CI jobs into the Node 24 JavaScript actions runtime
- keep the change scoped to the Allure report generation and Pages deployment jobs
- preserve the existing workflow structure and action pins