### PR TITLE
Publish Allure Pages from gh-pages branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,6 @@ on:
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -234,8 +231,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-      pages: write
-      id-token: write
     outputs:
       has-results: ${{ steps.allure-inputs.outputs.has-results }}
       history_artifact_name: ${{ steps.history-policy.outputs.history_artifact_name }}
@@ -364,20 +359,6 @@ jobs:
           if-no-files-found: ignore
           retention-days: ${{ steps.history-policy.outputs.history_retention_days }}
 
-      - name: Configure GitHub Pages
-        if: >-
-          steps.history-policy.outputs.publish_pages == 'true' &&
-          steps.allure-inputs.outputs.has-results == 'true'
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
-
-      - name: Upload GitHub Pages artifact
-        if: >-
-          steps.history-policy.outputs.publish_pages == 'true' &&
-          steps.allure-inputs.outputs.has-results == 'true'
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
-        with:
-          path: reports/allure-report
-
       - name: Upload Allure report
         if: always() && steps.allure-inputs.outputs.has-results == 'true'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
@@ -417,28 +398,71 @@ jobs:
       - allure-report
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pages: write
-      id-token: write
-    concurrency:
-      group: github-pages
-      cancel-in-progress: false
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      actions: read
+      contents: write
     outputs:
-      page-url: ${{ steps.deployment.outputs.page_url }}
+      page-url: ${{ steps.publish.outputs.page_url }}
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+      - name: Download Allure report artifact
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          name: allure-report
+          path: reports/allure-report
+
+      - name: Publish report to gh-pages
+        id: publish
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if ! find reports/allure-report -type f ! -name '.gitkeep' -print -quit | grep -q .; then
+            echo "Allure report artifact is empty; cannot publish GitHub Pages content." >&2
+            exit 1
+          fi
+
+          temp_dir="$(mktemp -d)"
+          cleanup() {
+            rm -rf "${temp_dir}"
+          }
+          trap cleanup EXIT
+
+          git init "${temp_dir}"
+          git -C "${temp_dir}" config user.name "github-actions[bot]"
+          git -C "${temp_dir}" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "${temp_dir}" remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          if git -C "${temp_dir}" fetch --depth=1 origin gh-pages; then
+            git -C "${temp_dir}" checkout -B gh-pages FETCH_HEAD
+            find "${temp_dir}" -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+          else
+            git -C "${temp_dir}" checkout --orphan gh-pages
+            find "${temp_dir}" -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+          fi
+
+          cp -R reports/allure-report/. "${temp_dir}/"
+          touch "${temp_dir}/.nojekyll"
+
+          git -C "${temp_dir}" add --all
+          if git -C "${temp_dir}" diff --cached --quiet; then
+            echo "published=false" >> "${GITHUB_OUTPUT}"
+          else
+            git -C "${temp_dir}" commit -m "Publish Allure report for ${GITHUB_SHA}"
+            git -C "${temp_dir}" push origin HEAD:gh-pages
+            echo "published=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+          repo_name="${GITHUB_REPOSITORY#*/}"
+          echo "page_url=https://${GITHUB_REPOSITORY_OWNER}.github.io/${repo_name}/" >> "${GITHUB_OUTPUT}"
 
       - name: Write GitHub Pages summary
         run: |
           {
             echo "## Allure Pages"
             echo
-            echo "- Published URL: ${{ steps.deployment.outputs.page_url }}"
+            echo "- Published URL: ${{ steps.publish.outputs.page_url }}"
+            echo "- Published via gh-pages branch: ${{ steps.publish.outputs.published || 'false' }}"
           } >> "$GITHUB_STEP_SUMMARY"
 
   ci-summary:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -216,7 +216,7 @@ Allure workflow:
 - The `allure-report` job now restores Allure history from the most recent matching history artifact for that stream. `ci-main` keeps a one-time GitHub Pages fallback so the public trend line carries forward through the artifact migration.
 - After generating the report, CI packages `reports/allure-report/history` into a dedicated `allure-history-*` artifact instead of reusing the full HTML bundle as the restore source.
 - Pull requests from forks remain ephemeral: they generate the downloadable `allure-report` artifact but do not restore or persist history.
-- The public GitHub Pages deployment still publishes only `main`; PR reports remain downloadable artifacts.
+- The public GitHub Pages deployment still publishes only `main`; PR reports remain downloadable artifacts. The `allure-pages` job pushes the generated site to the `gh-pages` branch, and the repository Pages source should remain configured to serve that branch from `/`.
 - Deploy verification now emits Allure output as well. Pushes to `production` persist a `deploy-production` history stream, while manual deploy verification runs only persist that stream when the workflow dispatch input `persist_history=true` is selected for the canonical production URL.
 
 ## Supported Models

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Notes:
 - The combined report merges one canonical Jest run with the Newman harness so local and CI results follow the same structure.
 - CI uploads the generated HTML as the `allure-report` artifact.
 - The public Pages deployment is `https://jsugg.github.io/alt-text-generator/`; the suites view is `https://jsugg.github.io/alt-text-generator/#suites`.
-- Pushes to `main` publish the latest generated report to GitHub Pages after the `allure-pages` job finishes successfully.
+- Pushes to `main` publish the latest generated report to the `gh-pages` branch after the `allure-pages` job finishes successfully; GitHub Pages serves that branch at the public URL above.
 - CI now keeps separate Allure history streams for `main` (`ci-main`) and same-repository pull requests (`ci-pr-<number>`), while deploy verification keeps its own `deploy-production` stream.
 - GitHub Pages remains the public HTML surface for `main` only; PR and deploy-verification reports are action artifacts.
 - Same-repository PRs restore and persist their own history artifacts, so failure trends follow the PR instead of borrowing `main` history.


### PR DESCRIPTION
## Summary
- replace the Pages workflow-artifact deployment path with a gh-pages branch publish step
- remove the deprecated official Pages actions that still run on Node 20 upstream
- update the Allure docs to reflect the branch-backed Pages deployment