### PR TITLE
Centralize provider registration metadata

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -3,6 +3,7 @@
 // All other modules read from here instead of process.env directly.
 
 const { buildRateLimitStoreConfig } = require('./rateLimitStore');
+const { buildProviderConfigSections } = require('./providerCatalog');
 
 const toNumber = (value, fallback) => {
   const parsedValue = Number(value);
@@ -96,23 +97,7 @@ module.exports = {
       || process.env.NODE_EXTRA_CA_CERTS,
   },
 
-  replicate: {
-    apiToken: process.env.REPLICATE_API_TOKEN,
-    apiEndpoint: process.env.REPLICATE_API_ENDPOINT,
-    userAgent: process.env.REPLICATE_USER_AGENT || 'alt-text-generator/1.0.0',
-    modelOwner: process.env.REPLICATE_MODEL_OWNER || 'rmokady',
-    modelName: process.env.REPLICATE_MODEL_NAME || 'clip_prefix_caption',
-    modelVersion:
-      process.env.REPLICATE_MODEL_VERSION
-      || '9a34a6339872a03f45236f114321fb51fc7aa8269d38ae0ce5334969981e4cd8',
-  },
-
-  azure: {
-    apiEndpoint: process.env.ACV_API_ENDPOINT,
-    subscriptionKey: process.env.ACV_SUBSCRIPTION_KEY,
-    language: process.env.ACV_LANGUAGE || 'en',
-    maxCandidates: toNumber(process.env.ACV_MAX_CANDIDATES, 4),
-  },
+  ...buildProviderConfigSections(process.env),
 
   rateLimit: {
     windowMs: toNumber(process.env.RATE_LIMIT_WINDOW_MS, 15 * 60 * 1000),

--- a/config/providerCatalog.js
+++ b/config/providerCatalog.js
@@ -1,0 +1,142 @@
+/**
+ * Provider metadata shared across config loading, startup validation, and
+ * live-provider tooling.
+ */
+const toPositiveIntegerOrFallback = (value, fallback) => {
+  const parsedValue = Number(value);
+  return Number.isFinite(parsedValue) && parsedValue > 0 ? parsedValue : fallback;
+};
+
+const PROVIDER_CATALOG = Object.freeze([
+  {
+    key: 'clip',
+    configKey: 'replicate',
+    displayName: 'Replicate CLIP',
+    startupHint: 'REPLICATE_API_TOKEN to enable clip',
+    buildEnvSchema: (Joi) => ({
+      REPLICATE_API_TOKEN: Joi.string().optional(),
+      REPLICATE_API_ENDPOINT: Joi.string().uri().optional(),
+      REPLICATE_USER_AGENT: Joi.string().optional(),
+      REPLICATE_MODEL_OWNER: Joi.string().optional(),
+      REPLICATE_MODEL_NAME: Joi.string().optional(),
+      REPLICATE_MODEL_VERSION: Joi.string().optional(),
+    }),
+    buildConfig: (env) => ({
+      apiToken: env.REPLICATE_API_TOKEN,
+      apiEndpoint: env.REPLICATE_API_ENDPOINT,
+      userAgent: env.REPLICATE_USER_AGENT || 'alt-text-generator/1.0.0',
+      modelOwner: env.REPLICATE_MODEL_OWNER || 'rmokady',
+      modelName: env.REPLICATE_MODEL_NAME || 'clip_prefix_caption',
+      modelVersion:
+        env.REPLICATE_MODEL_VERSION
+        || '9a34a6339872a03f45236f114321fb51fc7aa8269d38ae0ce5334969981e4cd8',
+    }),
+    isConfiguredInEnv: (env = {}) => Boolean(env.REPLICATE_API_TOKEN),
+    isConfiguredInConfig: (config = {}) => Boolean(config.replicate?.apiToken),
+    validateEnv: () => [],
+    liveValidation: {
+      scopeKey: 'replicate',
+      autoPriority: 20,
+      folderName: '90 Live Provider Validation',
+      scopeRequirement: 'REPLICATE_API_TOKEN',
+      allRequirement: 'REPLICATE_API_TOKEN',
+    },
+  },
+  {
+    key: 'azure',
+    configKey: 'azure',
+    displayName: 'Azure Computer Vision',
+    startupHint: 'ACV_API_ENDPOINT and ACV_SUBSCRIPTION_KEY to enable azure',
+    buildEnvSchema: (Joi) => ({
+      ACV_API_ENDPOINT: Joi.string().uri().optional(),
+      ACV_SUBSCRIPTION_KEY: Joi.string().optional(),
+      ACV_LANGUAGE: Joi.string().optional(),
+      ACV_MAX_CANDIDATES: Joi.number().integer().min(1).optional(),
+    }),
+    buildConfig: (env) => ({
+      apiEndpoint: env.ACV_API_ENDPOINT,
+      subscriptionKey: env.ACV_SUBSCRIPTION_KEY,
+      language: env.ACV_LANGUAGE || 'en',
+      maxCandidates: toPositiveIntegerOrFallback(env.ACV_MAX_CANDIDATES, 4),
+    }),
+    isConfiguredInEnv: (env = {}) => Boolean(
+      env.ACV_API_ENDPOINT && env.ACV_SUBSCRIPTION_KEY,
+    ),
+    isConfiguredInConfig: (config = {}) => Boolean(
+      config.azure?.apiEndpoint && config.azure?.subscriptionKey,
+    ),
+    validateEnv: (env = {}) => {
+      const hasAzureEndpoint = Boolean(env.ACV_API_ENDPOINT);
+      const hasAzureCredential = Boolean(env.ACV_SUBSCRIPTION_KEY);
+
+      if (hasAzureEndpoint !== hasAzureCredential) {
+        return [
+          'Config validation error: ACV_API_ENDPOINT and ACV_SUBSCRIPTION_KEY '
+            + 'must be set together to enable the Azure provider',
+        ];
+      }
+
+      return [];
+    },
+    liveValidation: {
+      scopeKey: 'azure',
+      autoPriority: 10,
+      folderName: '91 Live Azure Validation',
+      scopeRequirement: 'ACV_API_ENDPOINT and ACV_SUBSCRIPTION_KEY',
+      allRequirement: 'Azure credentials',
+    },
+  },
+]);
+
+const getProviderCatalog = () => PROVIDER_CATALOG.slice();
+
+/**
+ * Builds the provider-specific sections merged into the runtime config object.
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {Record<string, object>}
+ */
+const buildProviderConfigSections = (env = process.env) => {
+  const sections = {};
+
+  getProviderCatalog().forEach((provider) => {
+    sections[provider.configKey] = provider.buildConfig(env);
+  });
+
+  return sections;
+};
+
+const buildProviderEnvSchema = (Joi) => getProviderCatalog().reduce((schema, provider) => ({
+  ...schema,
+  ...provider.buildEnvSchema(Joi),
+}), {});
+
+const getConfiguredProvidersFromEnv = (env = process.env) => getProviderCatalog()
+  .filter((provider) => provider.isConfiguredInEnv(env));
+
+const getConfiguredProvidersFromConfig = (config = {}) => getProviderCatalog()
+  .filter((provider) => provider.isConfiguredInConfig(config));
+
+const validateProviderEnv = (env = process.env) => getProviderCatalog()
+  .flatMap((provider) => provider.validateEnv(env));
+
+const getLiveValidationProviders = () => getProviderCatalog()
+  .filter((provider) => provider.liveValidation);
+
+const getAvailableLiveProviderScopes = () => getLiveValidationProviders()
+  .map((provider) => provider.liveValidation.scopeKey);
+
+const getLiveProviderByScope = (scopeKey) => getLiveValidationProviders()
+  .find((provider) => provider.liveValidation.scopeKey === scopeKey);
+
+module.exports = {
+  buildProviderConfigSections,
+  buildProviderEnvSchema,
+  getAvailableLiveProviderScopes,
+  getConfiguredProvidersFromConfig,
+  getConfiguredProvidersFromEnv,
+  getLiveProviderByScope,
+  getLiveValidationProviders,
+  getProviderCatalog,
+  validateProviderEnv,
+};

--- a/scripts/github/resolve-live-provider-scope.js
+++ b/scripts/github/resolve-live-provider-scope.js
@@ -42,17 +42,12 @@ function appendSummary(summaryFile, lines) {
  * @returns {'azure'|'replicate'|'all'}
  */
 function resolveScopeFromEnv(env = process.env) {
-  const availableProviders = detectAvailableProviders({
-    replicateApiToken: env.REPLICATE_API_TOKEN,
-    azureApiEndpoint: env.ACV_API_ENDPOINT,
-    azureSubscriptionKey: env.ACV_SUBSCRIPTION_KEY,
-  });
+  const availableProviders = detectAvailableProviders(env);
 
   return resolveProviderScope({
     requestedScope: env.INPUT_PROVIDER_SCOPE,
     configuredScope: env.LIVE_PROVIDER_SCOPE,
-    hasAzureProvider: availableProviders.hasAzureProvider,
-    hasReplicateProvider: availableProviders.hasReplicateProvider,
+    configuredProviderScopes: availableProviders.configuredProviderScopes,
   });
 }
 

--- a/scripts/postman/live-provider-scope.js
+++ b/scripts/postman/live-provider-scope.js
@@ -1,9 +1,54 @@
+const {
+  getAvailableLiveProviderScopes,
+  getLiveProviderByScope,
+  getLiveValidationProviders,
+} = require('../../config/providerCatalog');
+
+const getSortedLiveValidationProviders = () => getLiveValidationProviders()
+  .sort((left, right) => left.liveValidation.autoPriority - right.liveValidation.autoPriority);
+
 const VALID_PROVIDER_SCOPES = new Set([
   'auto',
-  'azure',
-  'replicate',
+  ...getSortedLiveValidationProviders()
+    .map((provider) => provider.liveValidation.scopeKey),
   'all',
 ]);
+
+const resolveConfiguredProviderScopes = ({
+  configuredProviderScopes,
+  hasAzureProvider,
+  hasReplicateProvider,
+} = {}) => {
+  if (Array.isArray(configuredProviderScopes)) {
+    return configuredProviderScopes;
+  }
+
+  return getLiveValidationProviders()
+    .filter((provider) => (
+      (provider.liveValidation.scopeKey === 'azure' && hasAzureProvider)
+      || (provider.liveValidation.scopeKey === 'replicate' && hasReplicateProvider)
+    ))
+    .map((provider) => provider.liveValidation.scopeKey);
+};
+
+const buildAllRequirementMessage = () => {
+  const requirements = getSortedLiveValidationProviders()
+    .map((provider) => provider.liveValidation.allRequirement);
+
+  if (requirements.length === 0) {
+    return 'live provider credentials';
+  }
+
+  if (requirements.length === 1) {
+    return requirements[0];
+  }
+
+  if (requirements.length === 2) {
+    return `${requirements[0]} and ${requirements[1]}`;
+  }
+
+  return requirements.join(', ');
+};
 
 /**
  * Normalizes a provider-scope string.
@@ -37,21 +82,22 @@ function normalizeProviderScope(
 /**
  * Detects which live providers are configured from the supplied environment.
  *
- * @param {{
- *   replicateApiToken?: string|undefined,
- *   azureApiEndpoint?: string|undefined,
- *   azureSubscriptionKey?: string|undefined,
- * }} options
- * @returns {{ hasAzureProvider: boolean, hasReplicateProvider: boolean }}
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {{
+ *   configuredProviderScopes: string[],
+ *   hasAzureProvider: boolean,
+ *   hasReplicateProvider: boolean,
+ * }}
  */
-function detectAvailableProviders({
-  replicateApiToken,
-  azureApiEndpoint,
-  azureSubscriptionKey,
-}) {
+function detectAvailableProviders(env = process.env) {
+  const configuredProviderScopes = getLiveValidationProviders()
+    .filter((provider) => provider.isConfiguredInEnv(env))
+    .map((provider) => provider.liveValidation.scopeKey);
+
   return {
-    hasReplicateProvider: Boolean(replicateApiToken),
-    hasAzureProvider: Boolean(azureApiEndpoint && azureSubscriptionKey),
+    configuredProviderScopes,
+    hasAzureProvider: configuredProviderScopes.includes('azure'),
+    hasReplicateProvider: configuredProviderScopes.includes('replicate'),
   };
 }
 
@@ -64,14 +110,16 @@ function detectAvailableProviders({
  * @param {{
  *   requestedScope?: string|undefined,
  *   configuredScope?: string|undefined,
- *   hasAzureProvider: boolean,
- *   hasReplicateProvider: boolean,
+ *   configuredProviderScopes?: string[]|undefined,
+ *   hasAzureProvider?: boolean|undefined,
+ *   hasReplicateProvider?: boolean|undefined,
  * }} options
  * @returns {'azure'|'replicate'|'all'}
  */
 function resolveProviderScope({
   requestedScope,
   configuredScope,
+  configuredProviderScopes,
   hasAzureProvider,
   hasReplicateProvider,
 }) {
@@ -84,34 +132,41 @@ function resolveProviderScope({
   const desiredScope = normalizedRequestedScope === 'auto'
     ? normalizedConfiguredScope
     : normalizedRequestedScope;
+  const resolvedProviderScopes = resolveConfiguredProviderScopes({
+    configuredProviderScopes,
+    hasAzureProvider,
+    hasReplicateProvider,
+  });
+  const configuredProviderScopeSet = new Set(resolvedProviderScopes);
 
   if (desiredScope === 'auto') {
-    if (hasAzureProvider) {
-      return 'azure';
-    }
+    const autoProvider = getSortedLiveValidationProviders()
+      .filter((provider) => configuredProviderScopeSet.has(provider.liveValidation.scopeKey))
+      .at(0);
 
-    if (hasReplicateProvider) {
-      return 'replicate';
+    if (autoProvider) {
+      return autoProvider.liveValidation.scopeKey;
     }
 
     throw new Error(
-      'Live provider validation requires Azure credentials or REPLICATE_API_TOKEN',
+      `Live provider validation requires ${buildAllRequirementMessage()}`,
     );
   }
 
-  if (desiredScope === 'azure' && !hasAzureProvider) {
+  if (
+    desiredScope === 'all'
+    && resolvedProviderScopes.length !== getAvailableLiveProviderScopes().length
+  ) {
     throw new Error(
-      'provider_scope=azure requires ACV_API_ENDPOINT and ACV_SUBSCRIPTION_KEY',
+      `provider_scope=all requires ${buildAllRequirementMessage()}`,
     );
   }
 
-  if (desiredScope === 'replicate' && !hasReplicateProvider) {
-    throw new Error('provider_scope=replicate requires REPLICATE_API_TOKEN');
-  }
+  if (desiredScope !== 'all' && !configuredProviderScopeSet.has(desiredScope)) {
+    const provider = getLiveProviderByScope(desiredScope);
 
-  if (desiredScope === 'all' && (!hasAzureProvider || !hasReplicateProvider)) {
     throw new Error(
-      'provider_scope=all requires Azure credentials and REPLICATE_API_TOKEN',
+      `provider_scope=${desiredScope} requires ${provider.liveValidation.scopeRequirement}`,
     );
   }
 
@@ -122,24 +177,43 @@ function resolveProviderScope({
  * Expands a resolved scope into provider booleans.
  *
  * @param {'azure'|'replicate'|'all'} scope
- * @returns {{ runAzure: boolean, runReplicate: boolean }}
+ * @returns {{
+ *   selectedProviderScopes: string[],
+ *   runAzure: boolean,
+ *   runReplicate: boolean,
+ * }}
  */
 function getSelectedProviders(scope) {
-  switch (scope) {
-    case 'azure':
-      return { runAzure: true, runReplicate: false };
-    case 'replicate':
-      return { runAzure: false, runReplicate: true };
-    case 'all':
-      return { runAzure: true, runReplicate: true };
-    default:
+  const selectedProviderScopes = scope === 'all'
+    ? getAvailableLiveProviderScopes()
+    : [scope];
+
+  selectedProviderScopes.forEach((selectedScope) => {
+    if (!getLiveProviderByScope(selectedScope)) {
       throw new Error(`Resolved live provider scope is invalid: ${scope}`);
-  }
+    }
+  });
+
+  return {
+    selectedProviderScopes,
+    runAzure: selectedProviderScopes.includes('azure'),
+    runReplicate: selectedProviderScopes.includes('replicate'),
+  };
+}
+
+function getSelectedProviderFolders(scope) {
+  const { selectedProviderScopes } = getSelectedProviders(scope);
+
+  return selectedProviderScopes.map((selectedScope) => {
+    const provider = getLiveProviderByScope(selectedScope);
+    return provider.liveValidation.folderName;
+  });
 }
 
 module.exports = {
   VALID_PROVIDER_SCOPES: Array.from(VALID_PROVIDER_SCOPES),
   detectAvailableProviders,
+  getSelectedProviderFolders,
   getSelectedProviders,
   normalizeProviderScope,
   resolveProviderScope,

--- a/scripts/run-postman-harness.js
+++ b/scripts/run-postman-harness.js
@@ -17,6 +17,7 @@ const {
 } = require('./postman/collection-utils');
 const {
   detectAvailableProviders,
+  getSelectedProviderFolders,
   getSelectedProviders,
   resolveProviderScope,
 } = require('./postman/live-provider-scope');
@@ -347,15 +348,12 @@ async function main() {
   const liveProviderScopeInput = process.env.LIVE_PROVIDER_SCOPE || 'auto';
   const liveAzureSubscriptionKey = process.env.ACV_SUBSCRIPTION_KEY || null;
   const availableLiveProviders = detectAvailableProviders({
-    replicateApiToken: process.env.REPLICATE_API_TOKEN,
-    azureApiEndpoint: process.env.ACV_API_ENDPOINT,
-    azureSubscriptionKey: process.env.ACV_SUBSCRIPTION_KEY,
+    ...process.env,
   });
   const liveProviderScope = liveModeEnabled
     ? resolveProviderScope({
       requestedScope: liveProviderScopeInput,
-      hasAzureProvider: availableLiveProviders.hasAzureProvider,
-      hasReplicateProvider: availableLiveProviders.hasReplicateProvider,
+      configuredProviderScopes: availableLiveProviders.configuredProviderScopes,
     })
     : null;
   const selectedLiveProviders = liveProviderScope
@@ -539,21 +537,7 @@ async function main() {
     }
 
     if (liveModeEnabled) {
-      const liveFolders = [];
-
-      if (selectedLiveProviders.runReplicate) {
-        liveFolders.push('90 Live Provider Validation');
-      } else {
-        // eslint-disable-next-line no-console
-        console.log(`Skipping 90 Live Provider Validation: LIVE_PROVIDER_SCOPE=${liveProviderScope}`);
-      }
-
-      if (selectedLiveProviders.runAzure) {
-        liveFolders.push('91 Live Azure Validation');
-      } else {
-        // eslint-disable-next-line no-console
-        console.log(`Skipping 91 Live Azure Validation: LIVE_PROVIDER_SCOPE=${liveProviderScope}`);
-      }
+      const liveFolders = getSelectedProviderFolders(liveProviderScope);
 
       if (liveFolders.length === 0) {
         throw new Error(`Live mode enabled but provider scope "${liveProviderScope}" selected no folders`);

--- a/src/createApp.js
+++ b/src/createApp.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const axios = require('axios');
-const Replicate = require('replicate');
 
 const defaultConfig = require('../config');
 const {
@@ -9,10 +8,8 @@ const {
 } = require('./infrastructure/logger');
 const { createOutboundClients } = require('./infrastructure/outboundTrust');
 const ScraperService = require('./services/ScraperService');
-const ReplicateDescriberService = require('./services/ReplicateDescriberService');
-const AzureDescriberService = require('./services/AzureDescriberService');
-const ImageDescriberFactory = require('./services/ImageDescriberFactory');
 const PageDescriptionService = require('./services/PageDescriptionService');
+const { buildImageDescriberFactory } = require('./providers/runtimeRegistry');
 const { createHealthController } = require('./api/v1/controllers/healthController');
 const ScraperController = require('./api/v1/controllers/scraperController');
 const DescriptionController = require('./api/v1/controllers/descriptionController');
@@ -26,53 +23,6 @@ const createRequestFilter = require('./api/v1/middleware/request-filter');
 const { createRouter } = require('./utils/createRouter');
 const buildApiRouter = require('./api/v1/routes/api');
 
-const buildReplicateClient = (config, fetch) => new Replicate({
-  auth: config.replicate.apiToken,
-  baseUrl: config.replicate.apiEndpoint,
-  fetch,
-  userAgent: config.replicate.userAgent,
-});
-
-const hasReplicateProviderConfig = (replicateConfig = {}) => Boolean(
-  replicateConfig.apiToken,
-);
-
-const hasAzureProviderConfig = (azureConfig = {}) => Boolean(
-  azureConfig.apiEndpoint && azureConfig.subscriptionKey,
-);
-
-const buildImageDescriberFactory = ({
-  config,
-  logger,
-  replicateClient,
-  httpClient,
-  requestOptions,
-}) => {
-  const factory = new ImageDescriberFactory();
-  if (hasReplicateProviderConfig(config.replicate)) {
-    const replicateDescriber = new ReplicateDescriberService({
-      logger,
-      replicateClient,
-      config,
-    });
-
-    factory.register('clip', replicateDescriber);
-  }
-
-  if (hasAzureProviderConfig(config.azure)) {
-    const azureDescriber = new AzureDescriberService({
-      logger,
-      httpClient,
-      config,
-      requestOptions,
-    });
-
-    factory.register('azure', azureDescriber);
-  }
-
-  return factory;
-};
-
 const createApp = ({
   config = defaultConfig,
   appLogger = defaultAppLogger,
@@ -84,6 +34,7 @@ const createApp = ({
   health,
   outboundClients,
   rateLimitStoreProvider,
+  providerClients,
   replicateClient,
   runtimeState,
 } = {}) => {
@@ -105,14 +56,16 @@ const createApp = ({
       config,
       logger: appLogger,
       httpClient: resolvedHttpClient,
+      outboundClients: resolvedOutboundClients,
       requestOptions: {
         timeout: scraperConfig.requestTimeoutMs,
         maxRedirects: scraperConfig.maxRedirects,
         maxContentLength: scraperConfig.maxContentLengthBytes,
       },
-      replicateClient: hasReplicateProviderConfig(config.replicate)
-        ? (replicateClient ?? buildReplicateClient(config, resolvedOutboundClients.fetch))
-        : undefined,
+      providerClients: {
+        ...(providerClients ?? {}),
+        ...(replicateClient ? { clip: replicateClient, replicate: replicateClient } : {}),
+      },
     });
   const resolvedPageDescriptionService = pageDescriptionService
     ?? new PageDescriptionService({

--- a/src/providers/runtimeRegistry.js
+++ b/src/providers/runtimeRegistry.js
@@ -1,0 +1,99 @@
+const Replicate = require('replicate');
+
+const {
+  getConfiguredProvidersFromConfig,
+} = require('../../config/providerCatalog');
+const ImageDescriberFactory = require('../services/ImageDescriberFactory');
+const ReplicateDescriberService = require('../services/ReplicateDescriberService');
+const AzureDescriberService = require('../services/AzureDescriberService');
+
+const buildReplicateClient = (config, fetch) => new Replicate({
+  auth: config.replicate.apiToken,
+  baseUrl: config.replicate.apiEndpoint,
+  fetch,
+  userAgent: config.replicate.userAgent,
+});
+
+const runtimeProviderBuilders = {
+  clip: ({
+    config,
+    logger,
+    outboundClients,
+    providerClient,
+  }) => {
+    const replicateClient = providerClient ?? buildReplicateClient(
+      config,
+      outboundClients.fetch,
+    );
+
+    return new ReplicateDescriberService({
+      logger,
+      replicateClient,
+      config,
+    });
+  },
+  azure: ({
+    config,
+    logger,
+    httpClient,
+    requestOptions,
+  }) => new AzureDescriberService({
+    logger,
+    httpClient,
+    config,
+    requestOptions,
+  }),
+};
+
+const resolveProviderClient = (provider, providerClients = {}) => (
+  providerClients[provider.key]
+  ?? providerClients[provider.configKey]
+);
+
+/**
+ * Creates the runtime image-describer registry from the shared provider catalog.
+ *
+ * @param {object} params
+ * @param {object} params.config
+ * @param {object} params.logger
+ * @param {object} params.httpClient
+ * @param {object} params.outboundClients
+ * @param {object} params.requestOptions
+ * @param {Record<string, object>} [params.providerClients]
+ * @returns {ImageDescriberFactory}
+ */
+const buildImageDescriberFactory = ({
+  config,
+  logger,
+  httpClient,
+  outboundClients,
+  requestOptions,
+  providerClients = {},
+}) => {
+  const factory = new ImageDescriberFactory();
+
+  getConfiguredProvidersFromConfig(config).forEach((provider) => {
+    const buildProvider = runtimeProviderBuilders[provider.key];
+
+    if (!buildProvider) {
+      throw new Error(`No runtime builder registered for provider '${provider.key}'`);
+    }
+
+    const describer = buildProvider({
+      config,
+      logger,
+      httpClient,
+      outboundClients,
+      requestOptions,
+      providerClient: resolveProviderClient(provider, providerClients),
+    });
+
+    factory.register(provider.key, describer);
+  });
+
+  return factory;
+};
+
+module.exports = {
+  buildImageDescriberFactory,
+};

--- a/src/utils/validateEnvVars.js
+++ b/src/utils/validateEnvVars.js
@@ -1,4 +1,10 @@
 const Joi = require('joi');
+const {
+  buildProviderEnvSchema,
+  getConfiguredProvidersFromEnv,
+  getProviderCatalog,
+  validateProviderEnv,
+} = require('../../config/providerCatalog');
 
 const {
   buildRateLimitStoreConfig,
@@ -46,14 +52,6 @@ const envVarsSchema = Joi.object({
   }),
   OUTBOUND_CA_BUNDLE_FILE: Joi.string().optional(),
 
-  // Replicate is optional and only required when the clip provider is enabled
-  REPLICATE_API_TOKEN: Joi.string().optional(),
-  REPLICATE_API_ENDPOINT: Joi.string().uri().optional(),
-  REPLICATE_USER_AGENT: Joi.string().optional(),
-  REPLICATE_MODEL_OWNER: Joi.string().optional(),
-  REPLICATE_MODEL_NAME: Joi.string().optional(),
-  REPLICATE_MODEL_VERSION: Joi.string().optional(),
-
   // Scraper HTTP safeguards
   SCRAPER_REQUEST_TIMEOUT_MS: Joi.number().integer().min(1).optional(),
   SCRAPER_MAX_REDIRECTS: Joi.number().integer().min(0).optional(),
@@ -63,12 +61,6 @@ const envVarsSchema = Joi.object({
   LOG_LEVEL: Joi.string()
     .valid('trace', 'debug', 'info', 'warn', 'error', 'fatal')
     .optional(),
-
-  // Azure Computer Vision (optional provider)
-  ACV_API_ENDPOINT: Joi.string().uri().optional(),
-  ACV_SUBSCRIPTION_KEY: Joi.string().optional(),
-  ACV_LANGUAGE: Joi.string().optional(),
-  ACV_MAX_CANDIDATES: Joi.number().integer().min(1).optional(),
 
   // Rate limiting
   RATE_LIMIT_WINDOW_MS: Joi.number().optional(),
@@ -91,6 +83,7 @@ const envVarsSchema = Joi.object({
   // Swagger
   SWAGGER_DEV_URL: Joi.string().uri().optional(),
   SWAGGER_PROD_URL: Joi.string().uri().optional(),
+  ...buildProviderEnvSchema(Joi),
 }).unknown();
 
 const validateEnvVars = () => {
@@ -99,26 +92,23 @@ const validateEnvVars = () => {
     throw new Error(`Config validation error: ${error.message}`);
   }
 
-  const hasAzureEndpoint = Boolean(process.env.ACV_API_ENDPOINT);
-  const hasAzureCredential = Boolean(process.env.ACV_SUBSCRIPTION_KEY);
-  const hasReplicateProvider = Boolean(process.env.REPLICATE_API_TOKEN);
-  const hasAzureProvider = hasAzureEndpoint && hasAzureCredential;
+  const providerValidationErrors = validateProviderEnv(process.env);
+  const configuredProviders = getConfiguredProvidersFromEnv(process.env);
   const authTokens = parseAuthTokens(process.env.API_AUTH_TOKENS);
   const workerCount = Number(process.env.WORKER_COUNT ?? 1);
   const rateLimitStore = buildRateLimitStoreConfig(process.env);
 
-  if (!hasReplicateProvider && !hasAzureProvider) {
-    throw new Error(
-      'Config validation error: at least one provider must be configured. '
-        + 'Set REPLICATE_API_TOKEN to enable clip, or set ACV_API_ENDPOINT and '
-        + 'ACV_SUBSCRIPTION_KEY to enable azure',
-    );
+  if (providerValidationErrors.length > 0) {
+    throw new Error(providerValidationErrors[0]);
   }
 
-  if (hasAzureEndpoint !== hasAzureCredential) {
+  if (configuredProviders.length === 0) {
+    const providerHints = getProviderCatalog()
+      .map((provider) => provider.startupHint)
+      .join(', or set ');
+
     throw new Error(
-      'Config validation error: ACV_API_ENDPOINT and ACV_SUBSCRIPTION_KEY '
-        + 'must be set together to enable the Azure provider',
+      `Config validation error: at least one provider must be configured. Set ${providerHints}`,
     );
   }
 

--- a/tests/unit/config/providerCatalog.test.js
+++ b/tests/unit/config/providerCatalog.test.js
@@ -1,0 +1,85 @@
+const Joi = require('joi');
+
+const {
+  buildProviderConfigSections,
+  buildProviderEnvSchema,
+  getAvailableLiveProviderScopes,
+  getConfiguredProvidersFromConfig,
+  getConfiguredProvidersFromEnv,
+  getLiveProviderByScope,
+  getLiveValidationProviders,
+  getProviderCatalog,
+  validateProviderEnv,
+} = require('../../../config/providerCatalog');
+
+describe('Unit | Config | Provider Catalog', () => {
+  it('builds provider config sections with documented defaults and explicit overrides', () => {
+    const sections = buildProviderConfigSections({
+      REPLICATE_API_TOKEN: 'replicate-token',
+      REPLICATE_API_ENDPOINT: 'https://replicate.example.com',
+      REPLICATE_USER_AGENT: 'alt-text-generator/test',
+      REPLICATE_MODEL_OWNER: 'owner',
+      REPLICATE_MODEL_NAME: 'model',
+      REPLICATE_MODEL_VERSION: 'version',
+      ACV_API_ENDPOINT: 'https://azure.example.com/vision/v3.2/describe',
+      ACV_SUBSCRIPTION_KEY: 'azure-key',
+      ACV_LANGUAGE: 'pt-BR',
+      ACV_MAX_CANDIDATES: '7',
+    });
+
+    expect(sections).toEqual({
+      replicate: {
+        apiToken: 'replicate-token',
+        apiEndpoint: 'https://replicate.example.com',
+        userAgent: 'alt-text-generator/test',
+        modelOwner: 'owner',
+        modelName: 'model',
+        modelVersion: 'version',
+      },
+      azure: {
+        apiEndpoint: 'https://azure.example.com/vision/v3.2/describe',
+        subscriptionKey: 'azure-key',
+        language: 'pt-BR',
+        maxCandidates: 7,
+      },
+    });
+    expect(buildProviderConfigSections({
+      ACV_MAX_CANDIDATES: '0',
+    }).azure.maxCandidates).toBe(4);
+  });
+
+  it('builds the provider env schema and detects configured providers', () => {
+    const schema = buildProviderEnvSchema(Joi);
+
+    expect(schema).toHaveProperty('REPLICATE_API_TOKEN');
+    expect(schema).toHaveProperty('ACV_API_ENDPOINT');
+    expect(getConfiguredProvidersFromEnv({})).toEqual([]);
+    expect(getConfiguredProvidersFromEnv({
+      REPLICATE_API_TOKEN: 'replicate-token',
+      ACV_API_ENDPOINT: 'https://azure.example.com/vision/v3.2/describe',
+      ACV_SUBSCRIPTION_KEY: 'azure-key',
+    }).map((provider) => provider.key)).toEqual(['clip', 'azure']);
+    expect(getConfiguredProvidersFromConfig({
+      replicate: { apiToken: 'replicate-token' },
+      azure: {},
+    }).map((provider) => provider.key)).toEqual(['clip']);
+  });
+
+  it('validates provider-specific env rules and exposes live-provider metadata', () => {
+    const errors = validateProviderEnv({
+      ACV_API_ENDPOINT: 'https://azure.example.com/vision/v3.2/describe',
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/ACV_API_ENDPOINT and ACV_SUBSCRIPTION_KEY/);
+    expect(validateProviderEnv({
+      ACV_API_ENDPOINT: 'https://azure.example.com/vision/v3.2/describe',
+      ACV_SUBSCRIPTION_KEY: 'azure-key',
+    })).toEqual([]);
+    expect(getProviderCatalog().map((provider) => provider.key)).toEqual(['clip', 'azure']);
+    expect(getLiveValidationProviders().map((provider) => provider.liveValidation.scopeKey))
+      .toEqual(['replicate', 'azure']);
+    expect(getAvailableLiveProviderScopes()).toEqual(['replicate', 'azure']);
+    expect(getLiveProviderByScope('azure').displayName).toBe('Azure Computer Vision');
+  });
+});

--- a/tests/unit/providers/runtimeRegistry.test.js
+++ b/tests/unit/providers/runtimeRegistry.test.js
@@ -1,0 +1,29 @@
+describe('Unit | Providers | Runtime Registry', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('throws when a configured provider is missing a runtime builder', () => {
+    jest.doMock('../../../config/providerCatalog', () => ({
+      getConfiguredProvidersFromConfig: jest.fn(() => [
+        { key: 'unsupported', configKey: 'unsupported' },
+      ]),
+    }));
+
+    // eslint-disable-next-line global-require
+    const { buildImageDescriberFactory } = require('../../../src/providers/runtimeRegistry');
+
+    expect(() => buildImageDescriberFactory({
+      config: {},
+      logger: {
+        info: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+      },
+      httpClient: {},
+      outboundClients: {},
+      requestOptions: {},
+    })).toThrow("No runtime builder registered for provider 'unsupported'");
+  });
+});

--- a/tests/unit/scripts/postman/liveProviderScope.test.js
+++ b/tests/unit/scripts/postman/liveProviderScope.test.js
@@ -1,5 +1,6 @@
 const {
   detectAvailableProviders,
+  getSelectedProviderFolders,
   getSelectedProviders,
   normalizeProviderScope,
   resolveProviderScope,
@@ -29,7 +30,11 @@ describe('Unit | Scripts | Postman | Live Provider Scope', () => {
         replicateApiToken: 'replicate-token',
         azureApiEndpoint: 'https://azure.example.com',
         azureSubscriptionKey: 'azure-key',
+        REPLICATE_API_TOKEN: 'replicate-token',
+        ACV_API_ENDPOINT: 'https://azure.example.com',
+        ACV_SUBSCRIPTION_KEY: 'azure-key',
       })).toEqual({
+        configuredProviderScopes: ['replicate', 'azure'],
         hasAzureProvider: true,
         hasReplicateProvider: true,
       });
@@ -37,8 +42,9 @@ describe('Unit | Scripts | Postman | Live Provider Scope', () => {
 
     it('requires both azure endpoint and credential', () => {
       expect(detectAvailableProviders({
-        azureApiEndpoint: 'https://azure.example.com',
+        ACV_API_ENDPOINT: 'https://azure.example.com',
       })).toEqual({
+        configuredProviderScopes: [],
         hasAzureProvider: false,
         hasReplicateProvider: false,
       });
@@ -50,8 +56,7 @@ describe('Unit | Scripts | Postman | Live Provider Scope', () => {
       expect(resolveProviderScope({
         requestedScope: 'auto',
         configuredScope: 'auto',
-        hasAzureProvider: true,
-        hasReplicateProvider: true,
+        configuredProviderScopes: ['replicate', 'azure'],
       })).toBe('azure');
     });
 
@@ -59,8 +64,7 @@ describe('Unit | Scripts | Postman | Live Provider Scope', () => {
       expect(resolveProviderScope({
         requestedScope: 'auto',
         configuredScope: 'all',
-        hasAzureProvider: true,
-        hasReplicateProvider: true,
+        configuredProviderScopes: ['replicate', 'azure'],
       })).toBe('all');
     });
 
@@ -68,8 +72,7 @@ describe('Unit | Scripts | Postman | Live Provider Scope', () => {
       expect(resolveProviderScope({
         requestedScope: 'auto',
         configuredScope: 'auto',
-        hasAzureProvider: false,
-        hasReplicateProvider: true,
+        configuredProviderScopes: ['replicate'],
       })).toBe('replicate');
     });
 
@@ -77,8 +80,7 @@ describe('Unit | Scripts | Postman | Live Provider Scope', () => {
       expect(() => resolveProviderScope({
         requestedScope: 'azure',
         configuredScope: 'auto',
-        hasAzureProvider: false,
-        hasReplicateProvider: true,
+        configuredProviderScopes: ['replicate'],
       })).toThrow(
         'provider_scope=azure requires ACV_API_ENDPOINT and ACV_SUBSCRIPTION_KEY',
       );
@@ -88,8 +90,7 @@ describe('Unit | Scripts | Postman | Live Provider Scope', () => {
       expect(() => resolveProviderScope({
         requestedScope: 'all',
         configuredScope: 'auto',
-        hasAzureProvider: true,
-        hasReplicateProvider: false,
+        configuredProviderScopes: ['azure'],
       })).toThrow(
         'provider_scope=all requires Azure credentials and REPLICATE_API_TOKEN',
       );
@@ -99,6 +100,7 @@ describe('Unit | Scripts | Postman | Live Provider Scope', () => {
   describe('getSelectedProviders', () => {
     it('maps all to both providers', () => {
       expect(getSelectedProviders('all')).toEqual({
+        selectedProviderScopes: ['replicate', 'azure'],
         runAzure: true,
         runReplicate: true,
       });
@@ -106,9 +108,19 @@ describe('Unit | Scripts | Postman | Live Provider Scope', () => {
 
     it('maps azure to azure only', () => {
       expect(getSelectedProviders('azure')).toEqual({
+        selectedProviderScopes: ['azure'],
         runAzure: true,
         runReplicate: false,
       });
+    });
+  });
+
+  describe('getSelectedProviderFolders', () => {
+    it('maps the all scope to every live provider folder', () => {
+      expect(getSelectedProviderFolders('all')).toEqual([
+        '90 Live Provider Validation',
+        '91 Live Azure Validation',
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- centralize provider metadata for runtime config, startup validation, and live-provider tooling
- build the image describer registry from the shared provider catalog
- keep the existing clip/azure API contract while removing duplicated provider branching