### PR TITLE
Restore workflow-based Pages publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,9 +399,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: write
+      contents: read
+      id-token: write
+      pages: write
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     outputs:
-      page-url: ${{ steps.publish.outputs.page_url }}
+      page-url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Download Allure report artifact
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
@@ -409,11 +416,8 @@ jobs:
           name: allure-report
           path: reports/allure-report
 
-      - name: Publish report to gh-pages
-        id: publish
+      - name: Pack GitHub Pages artifact
         shell: bash
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -422,47 +426,35 @@ jobs:
             exit 1
           fi
 
-          temp_dir="$(mktemp -d)"
-          cleanup() {
-            rm -rf "${temp_dir}"
-          }
-          trap cleanup EXIT
+          tar \
+            --dereference --hard-dereference \
+            --directory reports/allure-report \
+            -cvf "${RUNNER_TEMP}/github-pages.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            --exclude=".[^/]*" \
+            .
 
-          git init "${temp_dir}"
-          git -C "${temp_dir}" config user.name "github-actions[bot]"
-          git -C "${temp_dir}" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git -C "${temp_dir}" remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: github-pages
+          path: ${{ runner.temp }}/github-pages.tar
+          if-no-files-found: error
+          retention-days: 1
 
-          if git -C "${temp_dir}" fetch --depth=1 origin gh-pages; then
-            git -C "${temp_dir}" checkout -B gh-pages FETCH_HEAD
-            find "${temp_dir}" -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
-          else
-            git -C "${temp_dir}" checkout --orphan gh-pages
-            find "${temp_dir}" -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
-          fi
-
-          cp -R reports/allure-report/. "${temp_dir}/"
-          touch "${temp_dir}/.nojekyll"
-
-          git -C "${temp_dir}" add --all
-          if git -C "${temp_dir}" diff --cached --quiet; then
-            echo "published=false" >> "${GITHUB_OUTPUT}"
-          else
-            git -C "${temp_dir}" commit -m "Publish Allure report for ${GITHUB_SHA}"
-            git -C "${temp_dir}" push origin HEAD:gh-pages
-            echo "published=true" >> "${GITHUB_OUTPUT}"
-          fi
-
-          repo_name="${GITHUB_REPOSITORY#*/}"
-          echo "page_url=https://${GITHUB_REPOSITORY_OWNER}.github.io/${repo_name}/" >> "${GITHUB_OUTPUT}"
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
       - name: Write GitHub Pages summary
         run: |
           {
             echo "## Allure Pages"
             echo
-            echo "- Published URL: ${{ steps.publish.outputs.page_url }}"
-            echo "- Published via gh-pages branch: ${{ steps.publish.outputs.published || 'false' }}"
+            echo "- Published URL: ${{ steps.deployment.outputs.page_url }}"
+            echo "- Published via workflow deployment: true"
+            echo "- Forced JavaScript actions runtime: Node 24"
           } >> "$GITHUB_STEP_SUMMARY"
 
   ci-summary:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -216,7 +216,7 @@ Allure workflow:
 - The `allure-report` job now restores Allure history from the most recent matching history artifact for that stream. `ci-main` keeps a one-time GitHub Pages fallback so the public trend line carries forward through the artifact migration.
 - After generating the report, CI packages `reports/allure-report/history` into a dedicated `allure-history-*` artifact instead of reusing the full HTML bundle as the restore source.
 - Pull requests from forks remain ephemeral: they generate the downloadable `allure-report` artifact but do not restore or persist history.
-- The public GitHub Pages deployment still publishes only `main`; PR reports remain downloadable artifacts. The `allure-pages` job pushes the generated site to the `gh-pages` branch, and the repository Pages source should remain configured to serve that branch from `/`.
+- The public GitHub Pages deployment still publishes only `main`; PR reports remain downloadable artifacts. The `allure-pages` job uploads a Pages deployment artifact and deploys it through the workflow-based GitHub Pages path.
 - Deploy verification now emits Allure output as well. Pushes to `production` persist a `deploy-production` history stream, while manual deploy verification runs only persist that stream when the workflow dispatch input `persist_history=true` is selected for the canonical production URL.
 
 ## Supported Models

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Notes:
 - The combined report merges one canonical Jest run with the Newman harness so local and CI results follow the same structure.
 - CI uploads the generated HTML as the `allure-report` artifact.
 - The public Pages deployment is `https://jsugg.github.io/alt-text-generator/`; the suites view is `https://jsugg.github.io/alt-text-generator/#suites`.
-- Pushes to `main` publish the latest generated report to the `gh-pages` branch after the `allure-pages` job finishes successfully; GitHub Pages serves that branch at the public URL above.
+- Pushes to `main` publish the latest generated report through the `allure-pages` workflow deployment after the job finishes successfully.
 - CI now keeps separate Allure history streams for `main` (`ci-main`) and same-repository pull requests (`ci-pr-<number>`), while deploy verification keeps its own `deploy-production` stream.
 - GitHub Pages remains the public HTML surface for `main` only; PR and deploy-verification reports are action artifacts.
 - Same-repository PRs restore and persist their own history artifacts, so failure trends follow the PR instead of borrowing `main` history.


### PR DESCRIPTION
## Summary
- replace legacy gh-pages branch publication in CI with workflow-based Pages deployment
- opt the Pages deployment job into the Node 24 JavaScript action runtime
- update the Allure Pages docs to match the workflow deployment path