### PR TITLE
Replace Pages deploy action with REST deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,8 +402,6 @@ jobs:
       contents: read
       id-token: write
       pages: write
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -445,7 +443,13 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        run: >-
+          node scripts/github/deploy-pages-artifact.js
+          --artifact-name github-pages
+          --pages-build-version "${GITHUB_SHA}"
+          --output-file "${GITHUB_OUTPUT}"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Write GitHub Pages summary
         run: |
@@ -454,7 +458,7 @@ jobs:
             echo
             echo "- Published URL: ${{ steps.deployment.outputs.page_url }}"
             echo "- Published via workflow deployment: true"
-            echo "- Forced JavaScript actions runtime: Node 24"
+            echo "- Deployment transport: GitHub Pages REST API"
           } >> "$GITHUB_STEP_SUMMARY"
 
   ci-summary:

--- a/scripts/github/deploy-pages-artifact.js
+++ b/scripts/github/deploy-pages-artifact.js
@@ -1,0 +1,389 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+
+function parseArgs(argv) {
+  const args = {
+    apiBaseUrl: 'https://api.github.com/',
+    environment: 'github-pages',
+    outputFile: null,
+    pollIntervalMs: 5000,
+    timeoutMs: 600000,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+
+    if (!token.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${token}`);
+    }
+
+    const separatorIndex = token.indexOf('=');
+    const key = separatorIndex >= 0 ? token.slice(2, separatorIndex) : token.slice(2);
+    const rawValue = separatorIndex >= 0 ? token.slice(separatorIndex + 1) : argv[index + 1];
+
+    if (separatorIndex < 0) {
+      index += 1;
+    }
+
+    if (rawValue === undefined) {
+      throw new Error(`Missing value for --${key}`);
+    }
+
+    switch (key) {
+      case 'api-base-url':
+        args.apiBaseUrl = rawValue;
+        break;
+      case 'artifact-name':
+        args.artifactName = rawValue;
+        break;
+      case 'environment':
+        args.environment = rawValue;
+        break;
+      case 'output-file':
+        args.outputFile = rawValue;
+        break;
+      case 'pages-build-version':
+        args.pagesBuildVersion = rawValue;
+        break;
+      case 'poll-interval-ms':
+        args.pollIntervalMs = Number.parseInt(rawValue, 10);
+        break;
+      case 'timeout-ms':
+        args.timeoutMs = Number.parseInt(rawValue, 10);
+        break;
+      default:
+        throw new Error(`Unsupported argument: --${key}`);
+    }
+  }
+
+  if (!args.artifactName) {
+    throw new Error('--artifact-name is required');
+  }
+
+  if (!args.pagesBuildVersion) {
+    throw new Error('--pages-build-version is required');
+  }
+
+  if (!Number.isInteger(args.pollIntervalMs) || args.pollIntervalMs <= 0) {
+    throw new Error('--poll-interval-ms must be a positive integer');
+  }
+
+  if (!Number.isInteger(args.timeoutMs) || args.timeoutMs <= 0) {
+    throw new Error('--timeout-ms must be a positive integer');
+  }
+
+  return args;
+}
+
+function appendOutput(outputFile, key, value) {
+  if (!outputFile) {
+    return;
+  }
+
+  fs.appendFileSync(outputFile, `${key}=${value}\n`);
+}
+
+function buildApiUrl(apiBaseUrl, pathname, query = {}) {
+  const url = new URL(pathname, apiBaseUrl.endsWith('/') ? apiBaseUrl : `${apiBaseUrl}/`);
+  Object.entries(query).forEach(([key, value]) => {
+    url.searchParams.set(key, value);
+  });
+  return url.toString();
+}
+
+async function fetchJson({
+  body,
+  fetchImpl = fetch,
+  method = 'GET',
+  token,
+  url,
+}) {
+  const response = await fetchImpl(url, {
+    body: body === undefined ? undefined : JSON.stringify(body),
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'Content-Type': body === undefined ? undefined : 'application/json',
+      'User-Agent': 'alt-text-generator-pages-deploy',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    method,
+    redirect: 'follow',
+  });
+  const text = await response.text();
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API request failed with status ${response.status}: ${text.trim() || '<empty>'}`,
+    );
+  }
+
+  return text ? JSON.parse(text) : {};
+}
+
+async function getOidcToken({
+  audience,
+  fetchImpl = fetch,
+  requestToken,
+  requestUrl,
+}) {
+  const url = new URL(requestUrl);
+  url.searchParams.set('audience', audience);
+
+  const response = await fetchImpl(url, {
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${requestToken}`,
+      'User-Agent': 'alt-text-generator-pages-deploy',
+    },
+    redirect: 'follow',
+  });
+  const text = await response.text();
+
+  if (!response.ok) {
+    throw new Error(
+      `OIDC token request failed with status ${response.status}: ${text.trim() || '<empty>'}`,
+    );
+  }
+
+  const payload = text ? JSON.parse(text) : {};
+  if (!payload.value) {
+    throw new Error('OIDC token request did not return a token value');
+  }
+
+  return payload.value;
+}
+
+async function listRunArtifacts({
+  apiBaseUrl,
+  fetchImpl = fetch,
+  repo,
+  runId,
+  token,
+}) {
+  const artifacts = [];
+  let page = 1;
+
+  for (;;) {
+    // The next page depends on the previous response metadata.
+    // eslint-disable-next-line no-await-in-loop
+    const response = await fetchJson({
+      fetchImpl,
+      token,
+      url: buildApiUrl(apiBaseUrl, `/repos/${repo}/actions/runs/${runId}/artifacts`, {
+        page: String(page),
+        per_page: '100',
+      }),
+    });
+
+    const nextArtifacts = Array.isArray(response.artifacts) ? response.artifacts : [];
+    artifacts.push(...nextArtifacts);
+
+    if (nextArtifacts.length === 0 || nextArtifacts.length < 100) {
+      return artifacts;
+    }
+
+    page += 1;
+  }
+}
+
+function selectArtifact({
+  artifactName,
+  artifacts,
+}) {
+  const matches = artifacts
+    .filter((artifact) => artifact?.name === artifactName && !artifact.expired)
+    .sort((left, right) => {
+      const createdDelta = new Date(right.created_at || 0) - new Date(left.created_at || 0);
+      if (createdDelta !== 0) {
+        return createdDelta;
+      }
+      return Number(right.id || 0) - Number(left.id || 0);
+    });
+
+  if (matches.length === 0) {
+    throw new Error(`No non-expired artifact named "${artifactName}" was found for this workflow run.`);
+  }
+
+  return matches[0];
+}
+
+async function createPagesDeployment({
+  apiBaseUrl,
+  artifactId,
+  environment,
+  fetchImpl = fetch,
+  oidcToken,
+  pagesBuildVersion,
+  repo,
+  token,
+}) {
+  return fetchJson({
+    body: {
+      artifact_id: artifactId,
+      environment,
+      oidc_token: oidcToken,
+      pages_build_version: pagesBuildVersion,
+    },
+    fetchImpl,
+    method: 'POST',
+    token,
+    url: buildApiUrl(apiBaseUrl, `/repos/${repo}/pages/deployments`),
+  });
+}
+
+function normalizePageUrl(pageUrl) {
+  if (!pageUrl) {
+    return '';
+  }
+
+  return /^https?:\/\//u.test(pageUrl) ? pageUrl : `https://${pageUrl}`;
+}
+
+function sleep(timeoutMs) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeoutMs);
+  });
+}
+
+async function waitForDeployment({
+  fetchImpl = fetch,
+  pollIntervalMs,
+  sleepImpl = sleep,
+  statusUrl,
+  timeoutMs,
+  token,
+}) {
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus = 'unknown';
+
+  while (Date.now() <= deadline) {
+    // Polling must remain sequential so each status check observes the latest state.
+    // eslint-disable-next-line no-await-in-loop
+    const response = await fetchJson({
+      fetchImpl,
+      token,
+      url: statusUrl,
+    });
+    const status = typeof response.status === 'string' ? response.status : 'unknown';
+    lastStatus = status;
+
+    if (status === 'succeed' || status === 'success') {
+      return response;
+    }
+
+    if (['cancelled', 'canceled', 'errored', 'error', 'failed', 'failure'].includes(status)) {
+      throw new Error(`GitHub Pages deployment failed with status ${status}`);
+    }
+
+    // Sleep between polls to avoid hammering the Pages status endpoint.
+    // eslint-disable-next-line no-await-in-loop
+    await sleepImpl(pollIntervalMs);
+  }
+
+  throw new Error(`Timed out waiting for GitHub Pages deployment. Last status: ${lastStatus}`);
+}
+
+function requireEnv(env, key) {
+  const value = env[key];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+  return value;
+}
+
+async function deployPagesArtifact(options, env = process.env, helpers = {}) {
+  const fetchImpl = helpers.fetchImpl || fetch;
+  const sleepImpl = helpers.sleepImpl || sleep;
+  const repository = requireEnv(env, 'GITHUB_REPOSITORY');
+  const runId = requireEnv(env, 'GITHUB_RUN_ID');
+  const token = requireEnv(env, 'GITHUB_TOKEN');
+  const oidcRequestToken = requireEnv(env, 'ACTIONS_ID_TOKEN_REQUEST_TOKEN');
+  const oidcRequestUrl = requireEnv(env, 'ACTIONS_ID_TOKEN_REQUEST_URL');
+  const oidcAudience = `https://github.com/${repository}`;
+
+  const artifacts = await listRunArtifacts({
+    apiBaseUrl: options.apiBaseUrl,
+    fetchImpl,
+    repo: repository,
+    runId,
+    token,
+  });
+  const artifact = selectArtifact({
+    artifactName: options.artifactName,
+    artifacts,
+  });
+  const oidcToken = await getOidcToken({
+    audience: oidcAudience,
+    fetchImpl,
+    requestToken: oidcRequestToken,
+    requestUrl: oidcRequestUrl,
+  });
+  const deployment = await createPagesDeployment({
+    apiBaseUrl: options.apiBaseUrl,
+    artifactId: artifact.id,
+    environment: options.environment,
+    fetchImpl,
+    oidcToken,
+    pagesBuildVersion: options.pagesBuildVersion,
+    repo: repository,
+    token,
+  });
+
+  if (!deployment.status_url) {
+    throw new Error('GitHub Pages deployment response did not include a status_url');
+  }
+
+  const completedDeployment = await waitForDeployment({
+    fetchImpl,
+    pollIntervalMs: options.pollIntervalMs,
+    sleepImpl,
+    statusUrl: deployment.status_url,
+    timeoutMs: options.timeoutMs,
+    token,
+  });
+
+  return {
+    artifactId: artifact.id,
+    deploymentId: deployment.id,
+    pageUrl: normalizePageUrl(deployment.page_url || completedDeployment.page_url),
+    status: completedDeployment.status,
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const result = await deployPagesArtifact(options);
+
+  appendOutput(options.outputFile, 'artifact_id', result.artifactId);
+  appendOutput(options.outputFile, 'deployment_id', result.deploymentId);
+  appendOutput(options.outputFile, 'page_url', result.pageUrl);
+  appendOutput(options.outputFile, 'status', result.status);
+
+  // eslint-disable-next-line no-console
+  console.log(
+    `Published GitHub Pages artifact ${result.artifactId} as deployment ${result.deploymentId}`
+      + ` with status ${result.status}.`,
+  );
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  buildApiUrl,
+  createPagesDeployment,
+  deployPagesArtifact,
+  getOidcToken,
+  listRunArtifacts,
+  normalizePageUrl,
+  parseArgs,
+  selectArtifact,
+  waitForDeployment,
+};

--- a/tests/unit/scripts/github/deployPagesArtifact.test.js
+++ b/tests/unit/scripts/github/deployPagesArtifact.test.js
@@ -1,0 +1,525 @@
+const {
+  createPagesDeployment,
+  deployPagesArtifact,
+  getOidcToken,
+  listRunArtifacts,
+  normalizePageUrl,
+  parseArgs,
+  selectArtifact,
+  waitForDeployment,
+} = require('../../../../scripts/github/deploy-pages-artifact');
+
+describe('Unit | Scripts | GitHub | Deploy Pages Artifact', () => {
+  describe('parseArgs', () => {
+    it('parses supported CLI arguments', () => {
+      expect(parseArgs([
+        '--artifact-name',
+        'github-pages',
+        '--pages-build-version',
+        'abc123',
+        '--output-file',
+        '/tmp/output.txt',
+        '--poll-interval-ms',
+        '2500',
+        '--timeout-ms',
+        '120000',
+      ])).toEqual({
+        apiBaseUrl: 'https://api.github.com/',
+        artifactName: 'github-pages',
+        environment: 'github-pages',
+        outputFile: '/tmp/output.txt',
+        pagesBuildVersion: 'abc123',
+        pollIntervalMs: 2500,
+        timeoutMs: 120000,
+      });
+    });
+
+    it('supports equals syntax and validates integer timeouts', () => {
+      expect(parseArgs([
+        '--artifact-name=github-pages',
+        '--environment=preview-pages',
+        '--pages-build-version=abc123',
+        '--api-base-url=https://api.example.test',
+        '--timeout-ms=42',
+      ])).toEqual({
+        apiBaseUrl: 'https://api.example.test',
+        artifactName: 'github-pages',
+        environment: 'preview-pages',
+        outputFile: null,
+        pagesBuildVersion: 'abc123',
+        pollIntervalMs: 5000,
+        timeoutMs: 42,
+      });
+    });
+
+    it('rejects missing required arguments', () => {
+      expect(() => parseArgs([
+        '--artifact-name',
+        'github-pages',
+      ])).toThrow('--pages-build-version is required');
+
+      expect(() => parseArgs([
+        '--pages-build-version',
+        'abc123',
+      ])).toThrow('--artifact-name is required');
+    });
+
+    it('rejects unsupported and malformed arguments', () => {
+      expect(() => parseArgs([
+        'github-pages',
+      ])).toThrow('Unexpected argument: github-pages');
+
+      expect(() => parseArgs([
+        '--artifact-name',
+        'github-pages',
+        '--pages-build-version',
+        'abc123',
+        '--timeout-ms',
+        '0',
+      ])).toThrow('--timeout-ms must be a positive integer');
+
+      expect(() => parseArgs([
+        '--artifact-name',
+        'github-pages',
+        '--pages-build-version',
+        'abc123',
+        '--poll-interval-ms',
+        'nope',
+      ])).toThrow('--poll-interval-ms must be a positive integer');
+
+      expect(() => parseArgs([
+        '--artifact-name',
+        'github-pages',
+        '--pages-build-version',
+      ])).toThrow('Missing value for --pages-build-version');
+
+      expect(() => parseArgs([
+        '--artifact-name',
+        'github-pages',
+        '--pages-build-version',
+        'abc123',
+        '--nope',
+        'value',
+      ])).toThrow('Unsupported argument: --nope');
+    });
+  });
+
+  describe('selectArtifact', () => {
+    it('prefers the most recent non-expired matching artifact', () => {
+      expect(selectArtifact({
+        artifactName: 'github-pages',
+        artifacts: [
+          {
+            created_at: '2026-03-12T00:00:00Z',
+            expired: false,
+            id: 1,
+            name: 'github-pages',
+          },
+          {
+            created_at: '2026-03-13T00:00:00Z',
+            expired: true,
+            id: 2,
+            name: 'github-pages',
+          },
+          {
+            created_at: '2026-03-13T01:00:00Z',
+            expired: false,
+            id: 3,
+            name: 'github-pages',
+          },
+        ],
+      })).toMatchObject({
+        id: 3,
+        name: 'github-pages',
+      });
+    });
+
+    it('falls back to artifact id ordering when timestamps are equal', () => {
+      expect(selectArtifact({
+        artifactName: 'github-pages',
+        artifacts: [
+          {
+            created_at: '2026-03-13T00:00:00Z',
+            expired: false,
+            id: 10,
+            name: 'github-pages',
+          },
+          {
+            created_at: '2026-03-13T00:00:00Z',
+            expired: false,
+            id: 20,
+            name: 'github-pages',
+          },
+        ],
+      })).toMatchObject({
+        id: 20,
+      });
+    });
+
+    it('fails when no matching artifact is available', () => {
+      expect(() => selectArtifact({
+        artifactName: 'github-pages',
+        artifacts: [
+          {
+            expired: true,
+            id: 1,
+            name: 'github-pages',
+          },
+        ],
+      })).toThrow('No non-expired artifact named "github-pages" was found for this workflow run.');
+    });
+  });
+
+  describe('normalizePageUrl', () => {
+    it('preserves absolute URLs and prefixes bare domains', () => {
+      expect(normalizePageUrl('https://jsugg.github.io/alt-text-generator/')).toBe(
+        'https://jsugg.github.io/alt-text-generator/',
+      );
+      expect(normalizePageUrl('jsugg.github.io/alt-text-generator/')).toBe(
+        'https://jsugg.github.io/alt-text-generator/',
+      );
+      expect(normalizePageUrl('')).toBe('');
+    });
+  });
+
+  describe('getOidcToken', () => {
+    it('fails when the OIDC endpoint does not return a token value', async () => {
+      await expect(getOidcToken({
+        audience: 'https://github.com/jsugg/alt-text-generator',
+        fetchImpl: jest.fn().mockResolvedValue({
+          ok: true,
+          text: async () => '{}',
+        }),
+        requestToken: 'request-token',
+        requestUrl: 'https://token.actions.githubusercontent.com?id=123',
+      })).rejects.toThrow('OIDC token request did not return a token value');
+    });
+
+    it('surfaces non-successful OIDC responses', async () => {
+      await expect(getOidcToken({
+        audience: 'https://github.com/jsugg/alt-text-generator',
+        fetchImpl: jest.fn().mockResolvedValue({
+          ok: false,
+          status: 500,
+          text: async () => 'boom',
+        }),
+        requestToken: 'request-token',
+        requestUrl: 'https://token.actions.githubusercontent.com?id=123',
+      })).rejects.toThrow('OIDC token request failed with status 500: boom');
+    });
+  });
+
+  describe('listRunArtifacts', () => {
+    it('paginates until it reaches the last artifacts page', async () => {
+      const firstPageArtifacts = Array.from({ length: 100 }, (_, index) => ({
+        expired: false,
+        id: index + 1,
+        name: 'github-pages',
+      }));
+      const fetchImpl = jest
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => JSON.stringify({ artifacts: firstPageArtifacts }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => JSON.stringify({
+            artifacts: [
+              {
+                expired: false,
+                id: 101,
+                name: 'github-pages',
+              },
+            ],
+          }),
+        });
+
+      await expect(listRunArtifacts({
+        apiBaseUrl: 'https://api.github.com',
+        fetchImpl,
+        repo: 'jsugg/alt-text-generator',
+        runId: '23032044656',
+        token: 'github-token',
+      })).resolves.toHaveLength(101);
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('createPagesDeployment', () => {
+    it('surfaces GitHub API errors from the deployment request', async () => {
+      await expect(createPagesDeployment({
+        apiBaseUrl: 'https://api.github.com/',
+        artifactId: 123,
+        environment: 'github-pages',
+        fetchImpl: jest.fn().mockResolvedValue({
+          ok: false,
+          status: 403,
+          text: async () => 'forbidden',
+        }),
+        oidcToken: 'oidc-token',
+        pagesBuildVersion: 'abc123',
+        repo: 'jsugg/alt-text-generator',
+        token: 'github-token',
+      })).rejects.toThrow('GitHub API request failed with status 403: forbidden');
+    });
+  });
+
+  describe('waitForDeployment', () => {
+    it('polls until the deployment succeeds', async () => {
+      const fetchImpl = jest
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => JSON.stringify({ status: 'deploying' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => JSON.stringify({ page_url: 'jsugg.github.io/alt-text-generator/', status: 'succeed' }),
+        });
+      const sleepImpl = jest.fn().mockResolvedValue(undefined);
+
+      await expect(waitForDeployment({
+        fetchImpl,
+        pollIntervalMs: 10,
+        sleepImpl,
+        statusUrl: 'https://api.github.com/status',
+        timeoutMs: 100,
+        token: 'github-token',
+      })).resolves.toEqual({
+        page_url: 'jsugg.github.io/alt-text-generator/',
+        status: 'succeed',
+      });
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(sleepImpl).toHaveBeenCalledTimes(1);
+    });
+
+    it('fails immediately for terminal deployment errors', async () => {
+      await expect(waitForDeployment({
+        fetchImpl: jest.fn().mockResolvedValue({
+          ok: true,
+          text: async () => JSON.stringify({ status: 'failed' }),
+        }),
+        pollIntervalMs: 10,
+        sleepImpl: jest.fn(),
+        statusUrl: 'https://api.github.com/status',
+        timeoutMs: 100,
+        token: 'github-token',
+      })).rejects.toThrow('GitHub Pages deployment failed with status failed');
+    });
+
+    it('times out when the deployment never reaches a terminal state', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        text: async () => JSON.stringify({ status: 'building' }),
+      });
+      const sleepImpl = jest.fn().mockResolvedValue(undefined);
+      const dateNowSpy = jest.spyOn(Date, 'now');
+
+      dateNowSpy
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(1)
+        .mockReturnValueOnce(5);
+
+      await expect(waitForDeployment({
+        fetchImpl,
+        pollIntervalMs: 10,
+        sleepImpl,
+        statusUrl: 'https://api.github.com/status',
+        timeoutMs: 2,
+        token: 'github-token',
+      })).rejects.toThrow('Timed out waiting for GitHub Pages deployment. Last status: building');
+
+      dateNowSpy.mockRestore();
+    });
+  });
+
+  describe('deployPagesArtifact', () => {
+    it('creates and waits for a Pages deployment using the current run artifact', async () => {
+      const fetchImpl = jest
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => JSON.stringify({
+            artifacts: [
+              {
+                created_at: '2026-03-13T01:31:02Z',
+                expired: false,
+                id: 5903084096,
+                name: 'github-pages',
+              },
+            ],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => JSON.stringify({ value: 'oidc-token' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => JSON.stringify({
+            id: 'deployment-123',
+            page_url: 'jsugg.github.io/alt-text-generator/',
+            status_url: 'https://api.github.com/status',
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => JSON.stringify({
+            page_url: 'jsugg.github.io/alt-text-generator/',
+            status: 'succeed',
+          }),
+        });
+
+      await expect(deployPagesArtifact({
+        apiBaseUrl: 'https://api.github.com/',
+        artifactName: 'github-pages',
+        environment: 'github-pages',
+        pagesBuildVersion: 'a4082b5',
+        pollIntervalMs: 10,
+        timeoutMs: 100,
+      }, {
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'request-token',
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com?id=123',
+        GITHUB_REPOSITORY: 'jsugg/alt-text-generator',
+        GITHUB_RUN_ID: '23032044656',
+        GITHUB_TOKEN: 'github-token',
+      }, {
+        fetchImpl,
+        sleepImpl: jest.fn().mockResolvedValue(undefined),
+      })).resolves.toEqual({
+        artifactId: 5903084096,
+        deploymentId: 'deployment-123',
+        pageUrl: 'https://jsugg.github.io/alt-text-generator/',
+        status: 'succeed',
+      });
+
+      expect(fetchImpl.mock.calls[0][0]).toContain('/actions/runs/23032044656/artifacts');
+      expect(fetchImpl.mock.calls[1][0].toString()).toContain('audience=https%3A%2F%2Fgithub.com%2Fjsugg%2Falt-text-generator');
+      expect(fetchImpl.mock.calls[2][1]).toMatchObject({
+        method: 'POST',
+      });
+    });
+
+    it('falls back to the completed deployment page URL and enforces required env vars', async () => {
+      const fetchImpl = jest
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => JSON.stringify({
+            artifacts: [
+              {
+                created_at: '2026-03-13T01:31:02Z',
+                expired: false,
+                id: 5903084096,
+                name: 'github-pages',
+              },
+            ],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => JSON.stringify({ value: 'oidc-token' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => JSON.stringify({
+            id: 'deployment-123',
+            status_url: 'https://api.github.com/status',
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => JSON.stringify({
+            page_url: 'jsugg.github.io/alt-text-generator/',
+            status: 'success',
+          }),
+        });
+
+      await expect(deployPagesArtifact({
+        apiBaseUrl: 'https://api.github.com/',
+        artifactName: 'github-pages',
+        environment: 'github-pages',
+        pagesBuildVersion: 'a4082b5',
+        pollIntervalMs: 10,
+        timeoutMs: 100,
+      }, {
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'request-token',
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com?id=123',
+        GITHUB_REPOSITORY: 'jsugg/alt-text-generator',
+        GITHUB_RUN_ID: '23032044656',
+        GITHUB_TOKEN: 'github-token',
+      }, {
+        fetchImpl,
+        sleepImpl: jest.fn().mockResolvedValue(undefined),
+      })).resolves.toMatchObject({
+        pageUrl: 'https://jsugg.github.io/alt-text-generator/',
+        status: 'success',
+      });
+
+      await expect(deployPagesArtifact({
+        apiBaseUrl: 'https://api.github.com/',
+        artifactName: 'github-pages',
+        environment: 'github-pages',
+        pagesBuildVersion: 'a4082b5',
+        pollIntervalMs: 10,
+        timeoutMs: 100,
+      }, {
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'request-token',
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com?id=123',
+        GITHUB_RUN_ID: '23032044656',
+        GITHUB_TOKEN: 'github-token',
+      }, {
+        fetchImpl: jest.fn(),
+        sleepImpl: jest.fn(),
+      })).rejects.toThrow('Missing required environment variable: GITHUB_REPOSITORY');
+    });
+
+    it('fails when the deployment response omits the status URL', async () => {
+      const fetchImpl = jest
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => JSON.stringify({
+            artifacts: [
+              {
+                created_at: '2026-03-13T01:31:02Z',
+                expired: false,
+                id: 5903084096,
+                name: 'github-pages',
+              },
+            ],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => JSON.stringify({ value: 'oidc-token' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => JSON.stringify({
+            id: 'deployment-123',
+            page_url: 'jsugg.github.io/alt-text-generator/',
+          }),
+        });
+
+      await expect(deployPagesArtifact({
+        apiBaseUrl: 'https://api.github.com/',
+        artifactName: 'github-pages',
+        environment: 'github-pages',
+        pagesBuildVersion: 'a4082b5',
+        pollIntervalMs: 10,
+        timeoutMs: 100,
+      }, {
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'request-token',
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com?id=123',
+        GITHUB_REPOSITORY: 'jsugg/alt-text-generator',
+        GITHUB_RUN_ID: '23032044656',
+        GITHUB_TOKEN: 'github-token',
+      }, {
+        fetchImpl,
+        sleepImpl: jest.fn().mockResolvedValue(undefined),
+      })).rejects.toThrow('GitHub Pages deployment response did not include a status_url');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- replace the actions/deploy-pages step with a repo-owned Pages deployment helper
- keep the existing Allure Pages artifact flow and environment URL output
- add unit coverage for the new deployment helper branches