### PR TITLE
Checkout repo in Pages deployment job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,6 +408,9 @@ jobs:
     outputs:
       page-url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - name: Download Allure report artifact
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:


### PR DESCRIPTION
## Summary
- checkout the repository in the allure-pages job before invoking the Pages deployment helper
- keep the REST-based GitHub Pages deployment flow introduced in #125