### PR TITLE
Use owner-scoped Pages OIDC audience

### DIFF
--- a/scripts/github/deploy-pages-artifact.js
+++ b/scripts/github/deploy-pages-artifact.js
@@ -293,6 +293,16 @@ function requireEnv(env, key) {
   return value;
 }
 
+function resolveOidcAudience(repository) {
+  const owner = repository.split('/')[0];
+
+  if (!owner) {
+    throw new Error(`Invalid GitHub repository value: ${repository}`);
+  }
+
+  return `https://github.com/${owner}`;
+}
+
 async function deployPagesArtifact(options, env = process.env, helpers = {}) {
   const fetchImpl = helpers.fetchImpl || fetch;
   const sleepImpl = helpers.sleepImpl || sleep;
@@ -301,7 +311,7 @@ async function deployPagesArtifact(options, env = process.env, helpers = {}) {
   const token = requireEnv(env, 'GITHUB_TOKEN');
   const oidcRequestToken = requireEnv(env, 'ACTIONS_ID_TOKEN_REQUEST_TOKEN');
   const oidcRequestUrl = requireEnv(env, 'ACTIONS_ID_TOKEN_REQUEST_URL');
-  const oidcAudience = `https://github.com/${repository}`;
+  const oidcAudience = resolveOidcAudience(repository);
 
   const artifacts = await listRunArtifacts({
     apiBaseUrl: options.apiBaseUrl,
@@ -384,6 +394,7 @@ module.exports = {
   listRunArtifacts,
   normalizePageUrl,
   parseArgs,
+  resolveOidcAudience,
   selectArtifact,
   waitForDeployment,
 };

--- a/tests/unit/scripts/github/deployPagesArtifact.test.js
+++ b/tests/unit/scripts/github/deployPagesArtifact.test.js
@@ -5,6 +5,7 @@ const {
   listRunArtifacts,
   normalizePageUrl,
   parseArgs,
+  resolveOidcAudience,
   selectArtifact,
   waitForDeployment,
 } = require('../../../../scripts/github/deploy-pages-artifact');
@@ -179,6 +180,16 @@ describe('Unit | Scripts | GitHub | Deploy Pages Artifact', () => {
         'https://jsugg.github.io/alt-text-generator/',
       );
       expect(normalizePageUrl('')).toBe('');
+    });
+  });
+
+  describe('resolveOidcAudience', () => {
+    it('uses the repository owner as the Pages OIDC audience', () => {
+      expect(resolveOidcAudience('jsugg/alt-text-generator')).toBe('https://github.com/jsugg');
+    });
+
+    it('rejects invalid repository identifiers', () => {
+      expect(() => resolveOidcAudience('')).toThrow('Invalid GitHub repository value: ');
     });
   });
 
@@ -395,7 +406,7 @@ describe('Unit | Scripts | GitHub | Deploy Pages Artifact', () => {
       });
 
       expect(fetchImpl.mock.calls[0][0]).toContain('/actions/runs/23032044656/artifacts');
-      expect(fetchImpl.mock.calls[1][0].toString()).toContain('audience=https%3A%2F%2Fgithub.com%2Fjsugg%2Falt-text-generator');
+      expect(fetchImpl.mock.calls[1][0].toString()).toContain('audience=https%3A%2F%2Fgithub.com%2Fjsugg');
       expect(fetchImpl.mock.calls[2][1]).toMatchObject({
         method: 'POST',
       });


### PR DESCRIPTION
## Summary
- request the GitHub Pages OIDC token with the repository owner audience instead of the full repo path
- keep the REST-based Pages deployment helper and cover the audience rule in unit tests