### PR TITLE
Replace GitHub App token action in promotion

### DIFF
--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -42,12 +42,14 @@ jobs:
       - name: Create promotion GitHub App token
         id: promotion-app-token
         if: steps.promotion-auth.outputs.use_github_app == 'true'
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        with:
-          app-id: ${{ vars.REPO_TOOLING_GITHUB_APP_ID }}
-          private-key: ${{ secrets.REPO_TOOLING_GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
+        env:
+          REPO_TOOLING_GITHUB_APP_PRIVATE_KEY: ${{ secrets.REPO_TOOLING_GITHUB_APP_PRIVATE_KEY }}
+        run: >-
+          node scripts/github/create-github-app-installation-token.js
+          --app-id "${{ vars.REPO_TOOLING_GITHUB_APP_ID }}"
+          --owner "${{ github.repository_owner }}"
+          --repo "${{ github.event.repository.name }}"
+          --output-file "${GITHUB_OUTPUT}"
 
       - name: Require repository automation GitHub App
         if: steps.promotion-auth.outputs.use_github_app != 'true'

--- a/scripts/github/create-github-app-installation-token.js
+++ b/scripts/github/create-github-app-installation-token.js
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+
+function parseArgs(argv) {
+  const args = {
+    apiBaseUrl: 'https://api.github.com/',
+    outputFile: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+
+    if (!token.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${token}`);
+    }
+
+    const separatorIndex = token.indexOf('=');
+    const key = separatorIndex >= 0 ? token.slice(2, separatorIndex) : token.slice(2);
+    const rawValue = separatorIndex >= 0 ? token.slice(separatorIndex + 1) : argv[index + 1];
+
+    if (separatorIndex < 0) {
+      index += 1;
+    }
+
+    if (rawValue === undefined) {
+      throw new Error(`Missing value for --${key}`);
+    }
+
+    switch (key) {
+      case 'api-base-url':
+        args.apiBaseUrl = rawValue;
+        break;
+      case 'app-id':
+        args.appId = rawValue;
+        break;
+      case 'owner':
+        args.owner = rawValue;
+        break;
+      case 'output-file':
+        args.outputFile = rawValue;
+        break;
+      case 'repo':
+        args.repo = rawValue;
+        break;
+      default:
+        throw new Error(`Unsupported argument: --${key}`);
+    }
+  }
+
+  if (!args.appId || !args.owner || !args.repo) {
+    throw new Error('--app-id, --owner, and --repo are required');
+  }
+
+  return args;
+}
+
+function appendOutput(outputFile, key, value) {
+  if (!outputFile) {
+    return;
+  }
+
+  fs.appendFileSync(outputFile, `${key}=${value}\n`);
+}
+
+function normalizePrivateKey(privateKey) {
+  return privateKey.includes('\n') ? privateKey : privateKey.replace(/\\n/gu, '\n');
+}
+
+function base64UrlEncode(value) {
+  return Buffer.from(value).toString('base64url');
+}
+
+function buildApiUrl(apiBaseUrl, pathname) {
+  return new URL(pathname, apiBaseUrl.endsWith('/') ? apiBaseUrl : `${apiBaseUrl}/`).toString();
+}
+
+function buildAppJwt({
+  appId,
+  nowMs = Date.now(),
+  privateKey,
+}) {
+  const nowSeconds = Math.floor(nowMs / 1000);
+  const header = base64UrlEncode(JSON.stringify({
+    alg: 'RS256',
+    typ: 'JWT',
+  }));
+  const payload = base64UrlEncode(JSON.stringify({
+    exp: nowSeconds + (9 * 60),
+    iat: nowSeconds - 60,
+    iss: appId,
+  }));
+  const signer = crypto.createSign('RSA-SHA256');
+  signer.update(`${header}.${payload}`);
+  signer.end();
+  const signature = signer.sign(normalizePrivateKey(privateKey), 'base64url');
+
+  return `${header}.${payload}.${signature}`;
+}
+
+async function fetchGitHubJson({
+  body,
+  fetchImpl = fetch,
+  method = 'GET',
+  token,
+  url,
+}) {
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${token}`,
+    'User-Agent': 'alt-text-generator-github-app-token',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+
+  if (body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  const response = await fetchImpl(url, {
+    body: body === undefined ? undefined : JSON.stringify(body),
+    headers,
+    method,
+    redirect: 'follow',
+  });
+  const text = await response.text();
+
+  if (!response.ok) {
+    throw new Error(`GitHub API request failed with status ${response.status}: ${text.trim() || '<empty>'}`);
+  }
+
+  return text ? JSON.parse(text) : {};
+}
+
+async function resolveInstallationId({
+  apiBaseUrl,
+  appJwt,
+  fetchImpl = fetch,
+  owner,
+  repo,
+}) {
+  const response = await fetchGitHubJson({
+    fetchImpl,
+    token: appJwt,
+    url: buildApiUrl(apiBaseUrl, `/repos/${owner}/${repo}/installation`),
+  });
+
+  if (!response.id) {
+    throw new Error('GitHub App installation lookup did not return an installation id');
+  }
+
+  return response.id;
+}
+
+async function createInstallationAccessToken({
+  apiBaseUrl,
+  appJwt,
+  fetchImpl = fetch,
+  installationId,
+  repo,
+}) {
+  const response = await fetchGitHubJson({
+    body: {
+      repositories: [repo],
+    },
+    fetchImpl,
+    method: 'POST',
+    token: appJwt,
+    url: buildApiUrl(apiBaseUrl, `/app/installations/${installationId}/access_tokens`),
+  });
+
+  if (!response.token) {
+    throw new Error('GitHub App installation token response did not include a token');
+  }
+
+  return response;
+}
+
+function requireEnv(env, key) {
+  const value = env[key];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+  return value;
+}
+
+async function createGitHubAppInstallationToken(options, env = process.env, helpers = {}) {
+  const fetchImpl = helpers.fetchImpl || fetch;
+  const privateKey = requireEnv(env, 'REPO_TOOLING_GITHUB_APP_PRIVATE_KEY');
+  const appJwt = buildAppJwt({
+    appId: options.appId,
+    nowMs: helpers.nowMs,
+    privateKey,
+  });
+  const installationId = await resolveInstallationId({
+    apiBaseUrl: options.apiBaseUrl,
+    appJwt,
+    fetchImpl,
+    owner: options.owner,
+    repo: options.repo,
+  });
+  const accessToken = await createInstallationAccessToken({
+    apiBaseUrl: options.apiBaseUrl,
+    appJwt,
+    fetchImpl,
+    installationId,
+    repo: options.repo,
+  });
+
+  return {
+    expiresAt: accessToken.expires_at || '',
+    installationId,
+    token: accessToken.token,
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const token = await createGitHubAppInstallationToken(options);
+
+  // eslint-disable-next-line no-console
+  console.log(`::add-mask::${token.token}`);
+  appendOutput(options.outputFile, 'expires_at', token.expiresAt);
+  appendOutput(options.outputFile, 'installation_id', token.installationId);
+  appendOutput(options.outputFile, 'token', token.token);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  appendOutput,
+  buildAppJwt,
+  buildApiUrl,
+  createGitHubAppInstallationToken,
+  createInstallationAccessToken,
+  fetchGitHubJson,
+  normalizePrivateKey,
+  parseArgs,
+  resolveInstallationId,
+};

--- a/tests/unit/scripts/github/createGitHubAppInstallationToken.test.js
+++ b/tests/unit/scripts/github/createGitHubAppInstallationToken.test.js
@@ -1,0 +1,241 @@
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  appendOutput,
+  buildAppJwt,
+  createGitHubAppInstallationToken,
+  createInstallationAccessToken,
+  fetchGitHubJson,
+  normalizePrivateKey,
+  parseArgs,
+  resolveInstallationId,
+} = require('../../../../scripts/github/create-github-app-installation-token');
+
+describe('Unit | Scripts | GitHub | Create GitHub App Installation Token', () => {
+  describe('parseArgs', () => {
+    it('parses supported CLI arguments', () => {
+      expect(parseArgs([
+        '--app-id',
+        '12345',
+        '--api-base-url',
+        'https://api.github.example',
+        '--owner',
+        'jsugg',
+        '--repo',
+        'alt-text-generator',
+        '--output-file',
+        '/tmp/output.txt',
+      ])).toEqual({
+        apiBaseUrl: 'https://api.github.example',
+        appId: '12345',
+        outputFile: '/tmp/output.txt',
+        owner: 'jsugg',
+        repo: 'alt-text-generator',
+      });
+    });
+
+    it('rejects unsupported and incomplete arguments', () => {
+      expect(() => parseArgs([
+        '--app-id',
+        '12345',
+        '--owner',
+        'jsugg',
+      ])).toThrow('--app-id, --owner, and --repo are required');
+
+      expect(() => parseArgs([
+        '--app-id',
+        '12345',
+        '--owner',
+        'jsugg',
+        '--repo',
+        'alt-text-generator',
+        '--unknown',
+        'value',
+      ])).toThrow('Unsupported argument: --unknown');
+
+      expect(() => parseArgs([
+        '--app-id',
+        '12345',
+        '--owner',
+        'jsugg',
+        '--repo',
+      ])).toThrow('Missing value for --repo');
+
+      expect(() => parseArgs([
+        '12345',
+      ])).toThrow('Unexpected argument: 12345');
+    });
+  });
+
+  describe('appendOutput', () => {
+    it('writes key-value outputs when a file is provided', () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'github-app-token-'));
+      const outputFile = path.join(tempDir, 'github-output.txt');
+
+      appendOutput(outputFile, 'token', 'installation-token');
+
+      expect(fs.readFileSync(outputFile, 'utf8')).toBe('token=installation-token\n');
+    });
+  });
+
+  describe('normalizePrivateKey', () => {
+    it('preserves multiline keys and expands escaped newlines', () => {
+      expect(normalizePrivateKey('line1\nline2')).toBe('line1\nline2');
+      expect(normalizePrivateKey('line1\\nline2')).toBe('line1\nline2');
+    });
+  });
+
+  describe('buildAppJwt', () => {
+    it('creates a signed JWT with the expected issuer and validity window', () => {
+      const { privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+      const token = buildAppJwt({
+        appId: '12345',
+        nowMs: 1_700_000_000_000,
+        privateKey: privateKey.export({ format: 'pem', type: 'pkcs8' }).toString(),
+      });
+      const [, payload] = token.split('.');
+      const decodedPayload = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+
+      expect(decodedPayload).toMatchObject({
+        exp: 1_700_000_540,
+        iat: 1_699_999_940,
+        iss: '12345',
+      });
+    });
+  });
+
+  describe('resolveInstallationId', () => {
+    it('loads the installation id for the repository', async () => {
+      await expect(resolveInstallationId({
+        apiBaseUrl: 'https://api.github.com/',
+        appJwt: 'app-jwt',
+        fetchImpl: jest.fn().mockResolvedValue({
+          ok: true,
+          text: async () => JSON.stringify({ id: 98765 }),
+        }),
+        owner: 'jsugg',
+        repo: 'alt-text-generator',
+      })).resolves.toBe(98765);
+    });
+
+    it('rejects installation lookups that return no installation id', async () => {
+      await expect(resolveInstallationId({
+        apiBaseUrl: 'https://api.github.com/',
+        appJwt: 'app-jwt',
+        fetchImpl: jest.fn().mockResolvedValue({
+          ok: true,
+          text: async () => '{}',
+        }),
+        owner: 'jsugg',
+        repo: 'alt-text-generator',
+      })).rejects.toThrow('GitHub App installation lookup did not return an installation id');
+    });
+  });
+
+  describe('fetchGitHubJson', () => {
+    it('surfaces GitHub API failures', async () => {
+      await expect(fetchGitHubJson({
+        fetchImpl: jest.fn().mockResolvedValue({
+          ok: false,
+          status: 403,
+          text: async () => 'forbidden',
+        }),
+        token: 'app-jwt',
+        url: 'https://api.github.com/repos/jsugg/alt-text-generator/installation',
+      })).rejects.toThrow('GitHub API request failed with status 403: forbidden');
+    });
+  });
+
+  describe('createInstallationAccessToken', () => {
+    it('creates a scoped installation token for the repository', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        text: async () => JSON.stringify({
+          expires_at: '2026-03-13T03:00:00Z',
+          token: 'installation-token',
+        }),
+      });
+
+      await expect(createInstallationAccessToken({
+        apiBaseUrl: 'https://api.github.com/',
+        appJwt: 'app-jwt',
+        fetchImpl,
+        installationId: 98765,
+        repo: 'alt-text-generator',
+      })).resolves.toEqual({
+        expires_at: '2026-03-13T03:00:00Z',
+        token: 'installation-token',
+      });
+      expect(fetchImpl.mock.calls[0][1]).toMatchObject({
+        body: JSON.stringify({
+          repositories: ['alt-text-generator'],
+        }),
+        method: 'POST',
+      });
+    });
+
+    it('rejects token responses that omit the token value', async () => {
+      await expect(createInstallationAccessToken({
+        apiBaseUrl: 'https://api.github.com/',
+        appJwt: 'app-jwt',
+        fetchImpl: jest.fn().mockResolvedValue({
+          ok: true,
+          text: async () => '{}',
+        }),
+        installationId: 98765,
+        repo: 'alt-text-generator',
+      })).rejects.toThrow('GitHub App installation token response did not include a token');
+    });
+  });
+
+  describe('createGitHubAppInstallationToken', () => {
+    it('creates an installation token from the configured GitHub App secret', async () => {
+      const { privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+      const fetchImpl = jest
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => JSON.stringify({ id: 98765 }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => JSON.stringify({
+            expires_at: '2026-03-13T03:00:00Z',
+            token: 'installation-token',
+          }),
+        });
+
+      await expect(createGitHubAppInstallationToken({
+        apiBaseUrl: 'https://api.github.com/',
+        appId: '12345',
+        owner: 'jsugg',
+        repo: 'alt-text-generator',
+      }, {
+        REPO_TOOLING_GITHUB_APP_PRIVATE_KEY: privateKey.export({ format: 'pem', type: 'pkcs8' }).toString(),
+      }, {
+        fetchImpl,
+        nowMs: 1_700_000_000_000,
+      })).resolves.toEqual({
+        expiresAt: '2026-03-13T03:00:00Z',
+        installationId: 98765,
+        token: 'installation-token',
+      });
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(fetchImpl.mock.calls[0][1].headers.Authorization).toMatch(/^Bearer /u);
+    });
+
+    it('requires the GitHub App private key secret', async () => {
+      await expect(createGitHubAppInstallationToken({
+        apiBaseUrl: 'https://api.github.com/',
+        appId: '12345',
+        owner: 'jsugg',
+        repo: 'alt-text-generator',
+      }, {}, {
+        fetchImpl: jest.fn(),
+      })).rejects.toThrow('Missing required environment variable: REPO_TOOLING_GITHUB_APP_PRIVATE_KEY');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- replace the Node 20 create-github-app-token action with a repo-owned GitHub App installation token helper
- keep the promotion workflow contract intact by writing the same token output for downstream steps
- add unit coverage for JWT creation, installation lookup, and token issuance