### PR TITLE
Set low-cost multimodal defaults for Hugging Face and OpenRouter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,14 +80,14 @@ TLS_PORT=8443
 # for `HF_API_KEY`.
 # HF_API_KEY=
 # HF_BASE_URL=https://router.huggingface.co/v1
-# HF_MODEL=Qwen/Qwen2.5-VL-7B-Instruct:cheapest
+# HF_MODEL=Qwen/Qwen3-VL-8B-Instruct:novita
 # HF_MAX_TOKENS=160
 # HF_PROMPT=Write concise alt text for this image.
 
 # Optional OpenRouter provider settings.
 # OPENROUTER_API_KEY=
 # OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
-# OPENROUTER_MODEL=openrouter/auto
+# OPENROUTER_MODEL=openrouter/free
 # OPENROUTER_MAX_TOKENS=160
 # OPENROUTER_PROMPT=Write concise alt text for this image.
 # OPENROUTER_HTTP_REFERER=https://your-app.example.com

--- a/.github/workflows/live-provider-validation.yml
+++ b/.github/workflows/live-provider-validation.yml
@@ -12,6 +12,8 @@ on:
           - auto
           - azure
           - replicate
+          - huggingface
+          - openrouter
           - all
   schedule:
     - cron: '23 8 * * 1'
@@ -58,6 +60,8 @@ jobs:
           REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
           ACV_API_ENDPOINT: ${{ secrets.ACV_API_ENDPOINT }}
           ACV_SUBSCRIPTION_KEY: ${{ secrets.ACV_SUBSCRIPTION_KEY }}
+          HF_API_KEY: ${{ secrets.HF_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: node scripts/github/resolve-live-provider-scope.js
 
       - name: Run live provider validation
@@ -67,6 +71,8 @@ jobs:
           REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
           ACV_API_ENDPOINT: ${{ secrets.ACV_API_ENDPOINT }}
           ACV_SUBSCRIPTION_KEY: ${{ secrets.ACV_SUBSCRIPTION_KEY }}
+          HF_API_KEY: ${{ secrets.HF_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
 
       - name: Upload live validation artifacts
         if: always()

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -91,10 +91,12 @@ The repository uses a small workflow set with separate responsibilities:
 - `Live Provider Validation` in `.github/workflows/live-provider-validation.yml`
   - manual only
   - runs `npm run postman:live`
-  - uses the `prod-validation` GitHub Actions variable `LIVE_PROVIDER_SCOPE` with `auto`, `azure`, `replicate`, or `all`
+  - uses the `prod-validation` GitHub Actions variable `LIVE_PROVIDER_SCOPE` with `auto`, `azure`, `replicate`, `huggingface`, `openrouter`, or `all`
   - requires GitHub Actions secrets, not Render env vars
   - requires `REPLICATE_API_TOKEN` only when the resolved scope includes Replicate
   - requires `ACV_API_ENDPOINT` plus `ACV_SUBSCRIPTION_KEY` only when the resolved scope includes Azure
+  - requires `HF_API_KEY` only when the resolved scope includes Hugging Face
+  - requires `OPENROUTER_API_KEY` only when the resolved scope includes OpenRouter
   - also supports a guarded weekly schedule when the repository variable `ENABLE_SCHEDULED_LIVE_PROVIDER_VALIDATION` is set to `true`
   - uploads Newman artifacts and writes request, assertion, failure, and response-time metrics into the workflow summary
 - `Deploy Verification` in `.github/workflows/deploy-verification.yml`
@@ -374,12 +376,12 @@ At least one provider must be configured at startup: `REPLICATE_API_TOKEN`, Azur
 | `OPENAI_PROMPT` | No | shared alt-text prompt | Prompt sent with the image. |
 | `HF_API_KEY` | No | none | Registers `huggingface`. `HF_TOKEN` is accepted as an alias. |
 | `HF_BASE_URL` | No | `https://router.huggingface.co/v1` | Hugging Face router base URL. |
-| `HF_MODEL` | No | `Qwen/Qwen2.5-VL-7B-Instruct:cheapest` | Default Hugging Face multimodal model selector. |
+| `HF_MODEL` | No | `Qwen/Qwen3-VL-8B-Instruct:novita` | Default low-cost Hugging Face image-to-text route. |
 | `HF_MAX_TOKENS` | No | `160` | Max completion tokens for `huggingface`. |
 | `HF_PROMPT` | No | shared alt-text prompt | Prompt sent with the image. |
 | `OPENROUTER_API_KEY` | No | none | Registers `openrouter`. |
 | `OPENROUTER_BASE_URL` | No | `https://openrouter.ai/api/v1` | OpenRouter base URL. |
-| `OPENROUTER_MODEL` | No | `openrouter/auto` | Default OpenRouter model routing target. |
+| `OPENROUTER_MODEL` | No | `openrouter/free` | Default zero-cost OpenRouter routing target for image captions. |
 | `OPENROUTER_MAX_TOKENS` | No | `160` | Max completion tokens for `openrouter`. |
 | `OPENROUTER_PROMPT` | No | shared alt-text prompt | Prompt sent with the image. |
 | `OPENROUTER_HTTP_REFERER` | No | unset | Optional OpenRouter attribution header. |

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Notes:
 - CI runs `postman:smoke` on pull requests and `postman:harness` on `main` / `production` pushes.
 - Deploy verification runs `postman:deploy` on `production` pushes so hosted smoke checks stay inside the Newman contract layer.
 - Deploy verification also reads `PRODUCTION_API_AUTH_ENABLED` and `PRODUCTION_DEPLOY_VALIDATION_API_TOKEN` from the GitHub Actions environment so hosted protected-endpoint checks can verify the expected Render `API_AUTH_ENABLED` / `API_AUTH_TOKENS` state.
-- Live mode uses a single `LIVE_PROVIDER_SCOPE` enum: `auto`, `azure`, `replicate`, or `all`.
-- `LIVE_PROVIDER_SCOPE=auto` prefers Azure when Azure credentials are configured and otherwise falls back to Replicate when a Replicate token exists.
+- Live mode uses a single `LIVE_PROVIDER_SCOPE` enum: `auto`, `azure`, `replicate`, `huggingface`, `openrouter`, or `all`.
+- `LIVE_PROVIDER_SCOPE=auto` keeps the live-provider preference order: Azure, then Replicate, then Hugging Face, then OpenRouter.
 - Live-provider runs upload Newman artifacts and append request, assertion, failure, and response-time metrics to the GitHub Actions step summary.
 - Local harness runs accept self-signed development TLS.
 - The deterministic harness uses a local Azure stub and can boot with a dummy Replicate token or Azure-only configuration.

--- a/postman/collections/alt-text-generator.postman_collection.json
+++ b/postman/collections/alt-text-generator.postman_collection.json
@@ -1997,7 +1997,7 @@
       "name": "90 Live Provider Validation",
       "item": [
         {
-          "name": "Live clip single image",
+          "name": "Live provider single image",
           "request": {
             "method": "GET",
             "header": [
@@ -2011,7 +2011,7 @@
               },
               {
                 "key": "X-Max-Response-Time-Ms",
-                "value": "15000"
+                "value": "30000"
               }
             ],
             "url": {
@@ -2032,7 +2032,7 @@
                 },
                 {
                   "key": "model",
-                  "value": "clip"
+                  "value": "{{model}}"
                 }
               ]
             }
@@ -2065,7 +2065,7 @@
           ]
         },
         {
-          "name": "Live clip page descriptions",
+          "name": "Live provider page descriptions",
           "request": {
             "method": "GET",
             "header": [
@@ -2079,7 +2079,7 @@
               },
               {
                 "key": "X-Max-Response-Time-Ms",
-                "value": "15000"
+                "value": "30000"
               }
             ],
             "url": {
@@ -2100,7 +2100,7 @@
                 },
                 {
                   "key": "model",
-                  "value": "clip"
+                  "value": "{{model}}"
                 }
               ]
             }
@@ -2120,7 +2120,7 @@
                   "",
                   "pm.test('response includes page metadata', function () {",
                   "  pm.expect(body.pageUrl).to.eql(pm.environment.get('livePageUrl'));",
-                  "  pm.expect(body.model).to.eql('clip');",
+                  "  pm.expect(body.model).to.eql(pm.environment.get('model'));",
                   "  pm.expect(body.totalImages).to.be.a('number');",
                   "  pm.expect(body.uniqueImages).to.be.a('number');",
                   "  pm.expect(body.descriptions).to.be.an('array');",

--- a/scripts/postman/live-provider-scope.js
+++ b/scripts/postman/live-provider-scope.js
@@ -23,12 +23,10 @@ const resolveConfiguredProviderScopes = ({
     return configuredProviderScopes;
   }
 
-  return getLiveValidationProviders()
-    .filter((provider) => (
-      (provider.liveValidation.scopeKey === 'azure' && hasAzureProvider)
-      || (provider.liveValidation.scopeKey === 'replicate' && hasReplicateProvider)
-    ))
-    .map((provider) => provider.liveValidation.scopeKey);
+  return [
+    ...(hasAzureProvider ? ['azure'] : []),
+    ...(hasReplicateProvider ? ['replicate'] : []),
+  ];
 };
 
 const buildAllRequirementMessage = () => {
@@ -55,7 +53,7 @@ const buildAllRequirementMessage = () => {
  *
  * @param {string|undefined|null} value
  * @param {{ label?: string, fallback?: string }} [options]
- * @returns {'auto'|'azure'|'replicate'|'all'}
+ * @returns {'auto'|'azure'|'replicate'|'huggingface'|'openrouter'|'all'}
  */
 function normalizeProviderScope(
   value,
@@ -104,8 +102,7 @@ function detectAvailableProviders(env = process.env) {
 /**
  * Resolves the final live-provider scope to execute.
  *
- * `auto` prefers Azure when Azure credentials are configured, otherwise it
- * falls back to Replicate when that token exists.
+ * `auto` prefers the configured provider with the lowest `autoPriority`.
  *
  * @param {{
  *   requestedScope?: string|undefined,
@@ -114,7 +111,7 @@ function detectAvailableProviders(env = process.env) {
  *   hasAzureProvider?: boolean|undefined,
  *   hasReplicateProvider?: boolean|undefined,
  * }} options
- * @returns {'azure'|'replicate'|'all'}
+ * @returns {'azure'|'replicate'|'huggingface'|'openrouter'|'all'}
  */
 function resolveProviderScope({
   requestedScope,
@@ -176,7 +173,7 @@ function resolveProviderScope({
 /**
  * Expands a resolved scope into provider booleans.
  *
- * @param {'azure'|'replicate'|'all'} scope
+ * @param {'azure'|'replicate'|'huggingface'|'openrouter'|'all'} scope
  * @returns {{
  *   selectedProviderScopes: string[],
  *   runAzure: boolean,
@@ -201,19 +198,41 @@ function getSelectedProviders(scope) {
   };
 }
 
-function getSelectedProviderFolders(scope) {
+/**
+ * Builds live-validation execution plans for the resolved provider scope.
+ *
+ * @param {'azure'|'replicate'|'huggingface'|'openrouter'|'all'} scope
+ * @returns {{ folderName: string, envVars: string[], scopeKey: string }[]}
+ */
+function getSelectedProviderPlans(scope) {
   const { selectedProviderScopes } = getSelectedProviders(scope);
 
   return selectedProviderScopes.map((selectedScope) => {
     const provider = getLiveProviderByScope(selectedScope);
-    return provider.liveValidation.folderName;
+
+    if (!provider) {
+      throw new Error(`Resolved live provider scope is invalid: ${scope}`);
+    }
+
+    return {
+      folderName: provider.liveValidation.folderName,
+      envVars: provider.liveValidation.requestEnvVars || [],
+      scopeKey: selectedScope,
+    };
   });
+}
+
+function getSelectedProviderFolders(scope) {
+  return Array.from(
+    new Set(getSelectedProviderPlans(scope).map((providerPlan) => providerPlan.folderName)),
+  );
 }
 
 module.exports = {
   VALID_PROVIDER_SCOPES: Array.from(VALID_PROVIDER_SCOPES),
   detectAvailableProviders,
   getSelectedProviderFolders,
+  getSelectedProviderPlans,
   getSelectedProviders,
   normalizeProviderScope,
   resolveProviderScope,

--- a/scripts/run-postman-harness.js
+++ b/scripts/run-postman-harness.js
@@ -17,7 +17,7 @@ const {
 } = require('./postman/collection-utils');
 const {
   detectAvailableProviders,
-  getSelectedProviderFolders,
+  getSelectedProviderPlans,
   getSelectedProviders,
   resolveProviderScope,
 } = require('./postman/live-provider-scope');
@@ -159,6 +159,8 @@ function spawnLogged(label, command, args, env = {}) {
  *   replicateApiToken?: string | null,
  *   azureApiEndpoint?: string | null,
  *   azureSubscriptionKey?: string | null,
+ *   hfApiKey?: string | null,
+ *   openrouterApiKey?: string | null,
  *   apiAuthTokens?: string | null,
  * }} options
  * @returns {Record<string, string>}
@@ -169,6 +171,8 @@ function buildAppServerEnv({
   replicateApiToken = null,
   azureApiEndpoint = null,
   azureSubscriptionKey = null,
+  hfApiKey = null,
+  openrouterApiKey = null,
   apiAuthTokens = null,
 }) {
   const env = {
@@ -192,6 +196,14 @@ function buildAppServerEnv({
 
   if (azureSubscriptionKey) {
     env.ACV_SUBSCRIPTION_KEY = azureSubscriptionKey;
+  }
+
+  if (hfApiKey) {
+    env.HF_API_KEY = hfApiKey;
+  }
+
+  if (openrouterApiKey) {
+    env.OPENROUTER_API_KEY = openrouterApiKey;
   }
 
   if (apiAuthTokens) {
@@ -358,10 +370,16 @@ async function main() {
     : null;
   const selectedLiveProviders = liveProviderScope
     ? getSelectedProviders(liveProviderScope)
-    : { runAzure: false, runReplicate: false };
+    : { selectedProviderScopes: [], runAzure: false, runReplicate: false };
+  const selectedLiveProviderPlans = liveProviderScope
+    ? getSelectedProviderPlans(liveProviderScope)
+    : [];
+  const selectedLiveProviderScopeSet = new Set(selectedLiveProviders.selectedProviderScopes);
   let appReplicateApiToken = 'test-token';
   let appAzureApiEndpoint = `http://${HOST}:${FIXTURE_PORT}/vision/v3.2/describe`;
   let appAzureSubscriptionKey = 'stub-key';
+  let appHfApiKey = null;
+  let appOpenRouterApiKey = null;
 
   if (liveModeEnabled) {
     appReplicateApiToken = selectedLiveProviders.runReplicate
@@ -372,6 +390,12 @@ async function main() {
       : null;
     appAzureSubscriptionKey = selectedLiveProviders.runAzure
       ? liveAzureSubscriptionKey
+      : null;
+    appHfApiKey = selectedLiveProviderScopeSet.has('huggingface')
+      ? process.env.HF_API_KEY || process.env.HF_TOKEN
+      : null;
+    appOpenRouterApiKey = selectedLiveProviderScopeSet.has('openrouter')
+      ? process.env.OPENROUTER_API_KEY
       : null;
   }
   const managedChildren = new Set();
@@ -408,6 +432,8 @@ async function main() {
       replicateApiToken: appReplicateApiToken,
       azureApiEndpoint: appAzureApiEndpoint,
       azureSubscriptionKey: appAzureSubscriptionKey,
+      hfApiKey: appHfApiKey,
+      openrouterApiKey: appOpenRouterApiKey,
     }),
   );
   managedChildren.add(appServer);
@@ -537,9 +563,11 @@ async function main() {
     }
 
     if (liveModeEnabled) {
-      const liveFolders = getSelectedProviderFolders(liveProviderScope);
+      const liveFolders = Array.from(
+        new Set(selectedLiveProviderPlans.map((providerPlan) => providerPlan.folderName)),
+      );
 
-      if (liveFolders.length === 0) {
+      if (selectedLiveProviderPlans.length === 0) {
         throw new Error(`Live mode enabled but provider scope "${liveProviderScope}" selected no folders`);
       }
 
@@ -548,14 +576,21 @@ async function main() {
         liveFolders,
         'live mode',
       );
-      await runNewman(
-        'live-provider',
-        liveFolders,
-        {
-          allureResultsDir,
-          envVars: localNewmanEnvVars,
-          extraArgs: ['--insecure'],
-        },
+
+      await selectedLiveProviderPlans.reduce(
+        (runPromise, providerPlan) => runPromise.then(() => runNewman(
+          `live-provider-${providerPlan.scopeKey}`,
+          [providerPlan.folderName],
+          {
+            allureResultsDir,
+            envVars: [
+              ...localNewmanEnvVars,
+              ...providerPlan.envVars,
+            ],
+            extraArgs: ['--insecure'],
+          },
+        )),
+        Promise.resolve(),
       );
     }
   } finally {

--- a/src/providers/definitions/buildOpenAiCompatibleProvider.js
+++ b/src/providers/definitions/buildOpenAiCompatibleProvider.js
@@ -24,6 +24,7 @@ const buildOpenAiCompatibleProvider = ({
   defaultModel,
   maxTokensEnvName,
   promptEnvName,
+  liveValidation = null,
   additionalEnvSchema = () => ({}),
   buildAdditionalConfig = () => ({}),
   buildHeaders = () => ({}),
@@ -86,6 +87,7 @@ const buildOpenAiCompatibleProvider = ({
     providerName: displayName,
     requestOptions,
   }),
+  liveValidation,
 });
 
 module.exports = {

--- a/src/providers/definitions/clip.js
+++ b/src/providers/definitions/clip.js
@@ -39,6 +39,7 @@ module.exports = {
     scopeKey: 'replicate',
     autoPriority: 20,
     folderName: '90 Live Provider Validation',
+    requestEnvVars: ['model=clip'],
     scopeRequirement: 'REPLICATE_API_TOKEN',
     allRequirement: 'REPLICATE_API_TOKEN',
   },

--- a/src/providers/definitions/huggingface.js
+++ b/src/providers/definitions/huggingface.js
@@ -8,7 +8,15 @@ module.exports = buildOpenAiCompatibleProvider({
   baseUrlEnvName: 'HF_BASE_URL',
   defaultBaseUrl: 'https://router.huggingface.co/v1',
   modelEnvName: 'HF_MODEL',
-  defaultModel: 'Qwen/Qwen2.5-VL-7B-Instruct:cheapest',
+  defaultModel: 'Qwen/Qwen3-VL-8B-Instruct:novita',
   maxTokensEnvName: 'HF_MAX_TOKENS',
   promptEnvName: 'HF_PROMPT',
+  liveValidation: {
+    scopeKey: 'huggingface',
+    autoPriority: 30,
+    folderName: '90 Live Provider Validation',
+    requestEnvVars: ['model=huggingface'],
+    scopeRequirement: 'HF_API_KEY or HF_TOKEN',
+    allRequirement: 'HF_API_KEY or HF_TOKEN',
+  },
 });

--- a/src/providers/definitions/openrouter.js
+++ b/src/providers/definitions/openrouter.js
@@ -8,9 +8,17 @@ module.exports = buildOpenAiCompatibleProvider({
   baseUrlEnvName: 'OPENROUTER_BASE_URL',
   defaultBaseUrl: 'https://openrouter.ai/api/v1',
   modelEnvName: 'OPENROUTER_MODEL',
-  defaultModel: 'openrouter/auto',
+  defaultModel: 'openrouter/free',
   maxTokensEnvName: 'OPENROUTER_MAX_TOKENS',
   promptEnvName: 'OPENROUTER_PROMPT',
+  liveValidation: {
+    scopeKey: 'openrouter',
+    autoPriority: 40,
+    folderName: '90 Live Provider Validation',
+    requestEnvVars: ['model=openrouter'],
+    scopeRequirement: 'OPENROUTER_API_KEY',
+    allRequirement: 'OPENROUTER_API_KEY',
+  },
   additionalEnvSchema: (Joi) => ({
     OPENROUTER_HTTP_REFERER: Joi.string().uri().optional(),
     OPENROUTER_TITLE: Joi.string().optional(),

--- a/tests/unit/config/providerCatalog.test.js
+++ b/tests/unit/config/providerCatalog.test.js
@@ -60,7 +60,7 @@ describe('Unit | Config | Provider Catalog', () => {
       huggingface: {
         apiKey: 'hf-key',
         baseUrl: 'https://router.huggingface.co/v1',
-        model: 'Qwen/Qwen2.5-VL-7B-Instruct:cheapest',
+        model: 'Qwen/Qwen3-VL-8B-Instruct:novita',
         maxTokens: 160,
         prompt: expect.any(String),
         headers: {},
@@ -76,7 +76,7 @@ describe('Unit | Config | Provider Catalog', () => {
       openrouter: {
         apiKey: 'openrouter-key',
         baseUrl: 'https://openrouter.ai/api/v1',
-        model: 'openrouter/auto',
+        model: 'openrouter/free',
         maxTokens: 160,
         prompt: expect.any(String),
         headers: {
@@ -163,8 +163,13 @@ describe('Unit | Config | Provider Catalog', () => {
       'together',
     ]);
     expect(getLiveValidationProviders().map((provider) => provider.liveValidation.scopeKey))
-      .toEqual(['replicate', 'azure']);
-    expect(getAvailableLiveProviderScopes()).toEqual(['replicate', 'azure']);
+      .toEqual(['replicate', 'azure', 'huggingface', 'openrouter']);
+    expect(getAvailableLiveProviderScopes()).toEqual([
+      'replicate',
+      'azure',
+      'huggingface',
+      'openrouter',
+    ]);
     expect(getLiveProviderByScope('azure').displayName).toBe('Azure Computer Vision');
   });
 });

--- a/tests/unit/providers/definitions/buildOpenAiCompatibleProvider.test.js
+++ b/tests/unit/providers/definitions/buildOpenAiCompatibleProvider.test.js
@@ -17,6 +17,13 @@ describe('Unit | Providers | Definitions | Build OpenAI Compatible Provider', ()
     defaultModel: 'demo-model',
     maxTokensEnvName: 'DEMO_MAX_TOKENS',
     promptEnvName: 'DEMO_PROMPT',
+    liveValidation: {
+      scopeKey: 'demo',
+      autoPriority: 50,
+      folderName: '90 Live Provider Validation',
+      scopeRequirement: 'DEMO_API_KEY',
+      allRequirement: 'DEMO_API_KEY',
+    },
     additionalEnvSchema: (schemaBuilder) => ({
       DEMO_HEADER: schemaBuilder.string().optional(),
     }),
@@ -92,5 +99,17 @@ describe('Unit | Providers | Definitions | Build OpenAI Compatible Provider', ()
     expect(runtime.providerKey).toBe('demo');
     expect(runtime.apiClient).toBe(providerClient);
     expect(runtime.httpClient).toBe(httpClient);
+  });
+
+  it('preserves live validation metadata on the provider definition', () => {
+    const provider = buildProvider();
+
+    expect(provider.liveValidation).toEqual({
+      scopeKey: 'demo',
+      autoPriority: 50,
+      folderName: '90 Live Provider Validation',
+      scopeRequirement: 'DEMO_API_KEY',
+      allRequirement: 'DEMO_API_KEY',
+    });
   });
 });

--- a/tests/unit/scripts/github/resolveLiveProviderScope.test.js
+++ b/tests/unit/scripts/github/resolveLiveProviderScope.test.js
@@ -26,6 +26,8 @@ describe('Unit | Scripts | GitHub | Resolve Live Provider Scope', () => {
         REPLICATE_API_TOKEN: 'replicate-token',
         ACV_API_ENDPOINT: 'https://azure.example.com',
         ACV_SUBSCRIPTION_KEY: 'azure-key',
+        HF_API_KEY: 'hf-key',
+        OPENROUTER_API_KEY: 'openrouter-key',
       })).toBe('all');
     });
 
@@ -36,6 +38,17 @@ describe('Unit | Scripts | GitHub | Resolve Live Provider Scope', () => {
         ACV_API_ENDPOINT: 'https://azure.example.com',
         ACV_SUBSCRIPTION_KEY: 'azure-key',
       })).toBe('azure');
+    });
+
+    it('resolves api-key multimodal providers when they are explicitly requested', () => {
+      expect(resolveScopeFromEnv({
+        INPUT_PROVIDER_SCOPE: 'openrouter',
+        OPENROUTER_API_KEY: 'openrouter-key',
+      })).toBe('openrouter');
+      expect(resolveScopeFromEnv({
+        INPUT_PROVIDER_SCOPE: 'huggingface',
+        HF_API_KEY: 'hf-key',
+      })).toBe('huggingface');
     });
   });
 

--- a/tests/unit/scripts/postman/liveProviderScope.test.js
+++ b/tests/unit/scripts/postman/liveProviderScope.test.js
@@ -1,6 +1,7 @@
 const {
   detectAvailableProviders,
   getSelectedProviderFolders,
+  getSelectedProviderPlans,
   getSelectedProviders,
   normalizeProviderScope,
   resolveProviderScope,
@@ -19,7 +20,7 @@ describe('Unit | Scripts | Postman | Live Provider Scope', () => {
 
     it('rejects unsupported scope values', () => {
       expect(() => normalizeProviderScope('both')).toThrow(
-        'provider scope must be one of: auto, azure, replicate, all',
+        'provider scope must be one of: auto, azure, replicate, huggingface, openrouter, all',
       );
     });
   });
@@ -37,6 +38,17 @@ describe('Unit | Scripts | Postman | Live Provider Scope', () => {
         configuredProviderScopes: ['replicate', 'azure'],
         hasAzureProvider: true,
         hasReplicateProvider: true,
+      });
+    });
+
+    it('detects api-key-backed multimodal providers', () => {
+      expect(detectAvailableProviders({
+        HF_API_KEY: 'hf-key',
+        OPENROUTER_API_KEY: 'openrouter-key',
+      })).toEqual({
+        configuredProviderScopes: ['huggingface', 'openrouter'],
+        hasAzureProvider: false,
+        hasReplicateProvider: false,
       });
     });
 
@@ -64,7 +76,7 @@ describe('Unit | Scripts | Postman | Live Provider Scope', () => {
       expect(resolveProviderScope({
         requestedScope: 'auto',
         configuredScope: 'all',
-        configuredProviderScopes: ['replicate', 'azure'],
+        configuredProviderScopes: ['replicate', 'azure', 'huggingface', 'openrouter'],
       })).toBe('all');
     });
 
@@ -74,6 +86,14 @@ describe('Unit | Scripts | Postman | Live Provider Scope', () => {
         configuredScope: 'auto',
         configuredProviderScopes: ['replicate'],
       })).toBe('replicate');
+    });
+
+    it('falls back to huggingface before openrouter in auto mode', () => {
+      expect(resolveProviderScope({
+        requestedScope: 'auto',
+        configuredScope: 'auto',
+        configuredProviderScopes: ['openrouter', 'huggingface'],
+      })).toBe('huggingface');
     });
 
     it('rejects azure scope without azure credentials', () => {
@@ -92,7 +112,7 @@ describe('Unit | Scripts | Postman | Live Provider Scope', () => {
         configuredScope: 'auto',
         configuredProviderScopes: ['azure'],
       })).toThrow(
-        'provider_scope=all requires Azure credentials and REPLICATE_API_TOKEN',
+        'provider_scope=all requires Azure credentials, REPLICATE_API_TOKEN, HF_API_KEY or HF_TOKEN, OPENROUTER_API_KEY',
       );
     });
   });
@@ -100,7 +120,7 @@ describe('Unit | Scripts | Postman | Live Provider Scope', () => {
   describe('getSelectedProviders', () => {
     it('maps all to both providers', () => {
       expect(getSelectedProviders('all')).toEqual({
-        selectedProviderScopes: ['replicate', 'azure'],
+        selectedProviderScopes: ['replicate', 'azure', 'huggingface', 'openrouter'],
         runAzure: true,
         runReplicate: true,
       });
@@ -112,6 +132,18 @@ describe('Unit | Scripts | Postman | Live Provider Scope', () => {
         runAzure: true,
         runReplicate: false,
       });
+    });
+  });
+
+  describe('getSelectedProviderPlans', () => {
+    it('maps generic providers to the shared live folder with request env vars', () => {
+      expect(getSelectedProviderPlans('huggingface')).toEqual([
+        {
+          folderName: '90 Live Provider Validation',
+          envVars: ['model=huggingface'],
+          scopeKey: 'huggingface',
+        },
+      ]);
     });
   });
 


### PR DESCRIPTION
## Summary
- switch Hugging Face to a cheaper image-captioning default and OpenRouter to a free vision router
- extend live provider validation so GitHub can exercise the huggingface and openrouter providers with the existing secrets
- update docs, Newman live coverage, and provider metadata for the new live scopes