### PR TITLE
Patch undici for production security audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "selfsigned": "^5.5.0",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^4.6.2",
-        "undici": "^6.23.0"
+        "undici": "^6.24.0"
       },
       "devDependencies": {
         "allure-commandline": "^2.37.0",
@@ -9315,9 +9315,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
+      "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "selfsigned": "^5.5.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^4.6.2",
-    "undici": "^6.23.0"
+    "undici": "^6.24.0"
   },
   "devDependencies": {
     "allure-commandline": "^2.37.0",


### PR DESCRIPTION
## Summary
- bump `undici` from `^6.23.0` to `^6.24.0` to clear current production advisories
- refresh the lockfile on top of the merged provider-validation remediation

## Validation
- npm audit --omit=dev --json
- npm run lint
- npm test -- --runInBand
- npm run postman:smoke
- npm ci --dry-run
