### PR TITLE
Use public fixtures for provider integration

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -105,6 +105,8 @@ The repository uses a small workflow set with separate responsibilities:
   - runs `npm run postman:provider-integration`
   - uses the same `LIVE_PROVIDER_SCOPE` enum as hosted live validation
   - boots the local app and local fixture server, then exercises real provider credentials where available
+  - uses repo-owned public provider-validation fixtures, pinned to `GITHUB_SHA` in GitHub Actions when available
+  - for local ad hoc runs before merge, `PROVIDER_VALIDATION_PUBLIC_REF=<pushed-sha-or-ref>` pins the public fixture revision explicitly
   - never targets the deployed Render service and should be interpreted as local provider-integration coverage only
 - `Deploy Verification` in `.github/workflows/deploy-verification.yml`
   - runs automatically on `production` pushes

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Notes:
 - `postman:smoke` is the fast deterministic gate.
 - `postman:harness` runs the full deterministic suite, including protected-endpoint auth coverage, and writes JSON and JUnit reports under `reports/newman/`.
 - CI also emits `reports/jest/junit.xml` from the canonical Node 20 Jest lane and publishes one combined GitHub test report that joins Jest and Newman results.
-- `postman:provider-integration` is the local provider-integration harness: it boots the app locally, uses deterministic fixtures when appropriate, and validates real provider credentials plus request/response wiring without claiming hosted coverage.
+- `postman:provider-integration` is the local provider-integration harness: it boots the app locally, uses deterministic local fixtures for the core contract suite, and uses repo-owned public provider-validation fixtures for real vendor coverage without claiming hosted coverage.
 - `postman:live` is optional and reserved for explicit hosted live-provider validation against a deployed base URL.
 - `postman:deploy` runs the hosted production-smoke folder from the same Postman collection against a supplied base URL.
 - Before Newman starts, `postman:deploy` waits for consecutive stable health/auth probes so zero-downtime rollout overlap does not create deploy-smoke false negatives.
@@ -95,6 +95,8 @@ Notes:
 - Deploy verification also reads `PRODUCTION_API_AUTH_ENABLED` and `PRODUCTION_DEPLOY_VALIDATION_API_TOKEN` from the GitHub Actions environment so hosted protected-endpoint checks can verify the expected Render `API_AUTH_ENABLED` / `API_AUTH_TOKENS` state.
 - Provider-validation workflows use a single `LIVE_PROVIDER_SCOPE` enum: `auto`, `azure`, `replicate`, `huggingface`, `openai`, `openrouter`, or `all`.
 - `LIVE_PROVIDER_SCOPE=auto` keeps the provider-validation preference order: Azure, then Replicate, then Hugging Face, then OpenRouter, then OpenAI.
+- Provider integration resolves public provider-validation fixtures from this repository and pins them to `GITHUB_SHA` in GitHub Actions when available.
+- Outside GitHub Actions, set `PROVIDER_VALIDATION_PUBLIC_REF=<pushed-sha-or-ref>` if you need provider-integration runs to use a branch-specific fixture revision before it lands on `main`.
 - Hosted live-provider validation derives public validation fixtures from the target `baseUrl` and refuses localhost/private-network targets.
 - Provider-validation runs upload Newman artifacts and append request, assertion, failure, and response-time metrics to the GitHub Actions step summary.
 - Local harness runs accept self-signed development TLS.

--- a/postman/environments/alt-text-generator.local.fixture.postman_environment.json
+++ b/postman/environments/alt-text-generator.local.fixture.postman_environment.json
@@ -94,25 +94,25 @@
     },
     {
       "key": "providerValidationImageUrl",
-      "value": "https://upload.wikimedia.org/wikipedia/commons/3/3f/Fronalpstock_big.jpg",
+      "value": "https://raw.githubusercontent.com/jsugg/alt-text-generator/main/.github/assets/alt-text-generator.png",
       "type": "default",
       "enabled": true
     },
     {
       "key": "providerValidationPageUrl",
-      "value": "https://developer.chrome.com/",
+      "value": "https://raw.githubusercontent.com/jsugg/alt-text-generator/main/provider-validation/public/page.html",
       "type": "default",
       "enabled": true
     },
     {
       "key": "providerValidationAzureImageUrl",
-      "value": "https://developer.chrome.com/static/images/ai-homepage-card.png",
+      "value": "https://raw.githubusercontent.com/jsugg/alt-text-generator/main/.github/assets/alt-text-generator.png",
       "type": "default",
       "enabled": true
     },
     {
       "key": "providerValidationAzurePageUrl",
-      "value": "https://developer.chrome.com/",
+      "value": "https://raw.githubusercontent.com/jsugg/alt-text-generator/main/provider-validation/public/page.html",
       "type": "default",
       "enabled": true
     }

--- a/provider-validation/public/page.html
+++ b/provider-validation/public/page.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Alt Text Provider Validation Fixture</title>
+  </head>
+  <body>
+    <h1>Alt Text Provider Validation Fixture</h1>
+    <img src="../../.github/assets/alt-text-generator.png" alt="" />
+    <img src="../../.github/assets/alt-text-generator.png?variant=duplicate" alt="" />
+  </body>
+</html>

--- a/scripts/postman/provider-validation-public-fixtures.js
+++ b/scripts/postman/provider-validation-public-fixtures.js
@@ -1,0 +1,135 @@
+const DEFAULT_PUBLIC_FIXTURE_REPOSITORY = 'jsugg/alt-text-generator';
+const DEFAULT_PUBLIC_FIXTURE_REF = 'main';
+const DEFAULT_PUBLIC_FIXTURE_IMAGE_PATH = '.github/assets/alt-text-generator.png';
+const DEFAULT_PUBLIC_FIXTURE_PAGE_PATH = 'provider-validation/public/page.html';
+
+const REPO_SLUG_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+/**
+ * @param {string} value
+ * @param {string} label
+ * @returns {string}
+ */
+function normalizeRequiredValue(value, label) {
+  if (typeof value !== 'string') {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+
+  const normalizedValue = value.trim();
+  if (!normalizedValue) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+
+  return normalizedValue;
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function normalizeRepositorySlug(value) {
+  const repository = normalizeRequiredValue(value, 'provider validation public repository');
+
+  if (!REPO_SLUG_PATTERN.test(repository)) {
+    throw new Error(
+      'provider validation public repository must use the "<owner>/<repo>" format',
+    );
+  }
+
+  return repository;
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function normalizeRepositoryRef(value) {
+  return normalizeRequiredValue(value, 'provider validation public ref');
+}
+
+/**
+ * @param {{
+ *   repository?: string | undefined,
+ *   ref?: string | undefined,
+ * }} [options]
+ * @returns {{ repository: string, ref: string }}
+ */
+function resolvePublicFixtureRepositoryContext(options = {}) {
+  const repository = normalizeRepositorySlug(
+    options.repository
+      || process.env.PROVIDER_VALIDATION_PUBLIC_REPOSITORY
+      || process.env.GITHUB_REPOSITORY
+      || DEFAULT_PUBLIC_FIXTURE_REPOSITORY,
+  );
+  const ref = normalizeRepositoryRef(
+    options.ref
+      || process.env.PROVIDER_VALIDATION_PUBLIC_REF
+      || process.env.GITHUB_SHA
+      || DEFAULT_PUBLIC_FIXTURE_REF,
+  );
+
+  return { repository, ref };
+}
+
+/**
+ * @param {{ repository: string, ref: string, relativePath: string }} params
+ * @returns {string}
+ */
+function buildRawGitHubUrl({ repository, ref, relativePath }) {
+  const normalizedRelativePath = normalizeRequiredValue(
+    relativePath,
+    'provider validation relative path',
+  );
+  const encodedPath = normalizedRelativePath
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+
+  return `https://raw.githubusercontent.com/${repository}/${encodeURIComponent(ref)}/${encodedPath}`;
+}
+
+/**
+ * @param {{
+ *   repository?: string | undefined,
+ *   ref?: string | undefined,
+ * }} [options]
+ * @returns {{
+ *   providerValidationAzureImageUrl: string,
+ *   providerValidationAzurePageUrl: string,
+ *   providerValidationImageUrl: string,
+ *   providerValidationPageUrl: string,
+ * }}
+ */
+function buildPublicProviderValidationFixtureUrls(options = {}) {
+  const { repository, ref } = resolvePublicFixtureRepositoryContext(options);
+
+  const providerValidationImageUrl = buildRawGitHubUrl({
+    repository,
+    ref,
+    relativePath: DEFAULT_PUBLIC_FIXTURE_IMAGE_PATH,
+  });
+  const providerValidationPageUrl = buildRawGitHubUrl({
+    repository,
+    ref,
+    relativePath: DEFAULT_PUBLIC_FIXTURE_PAGE_PATH,
+  });
+
+  return {
+    providerValidationImageUrl,
+    providerValidationPageUrl,
+    providerValidationAzureImageUrl: providerValidationImageUrl,
+    providerValidationAzurePageUrl: providerValidationPageUrl,
+  };
+}
+
+module.exports = {
+  DEFAULT_PUBLIC_FIXTURE_IMAGE_PATH,
+  DEFAULT_PUBLIC_FIXTURE_PAGE_PATH,
+  DEFAULT_PUBLIC_FIXTURE_REF,
+  DEFAULT_PUBLIC_FIXTURE_REPOSITORY,
+  buildPublicProviderValidationFixtureUrls,
+  buildRawGitHubUrl,
+  normalizeRepositoryRef,
+  normalizeRepositorySlug,
+  resolvePublicFixtureRepositoryContext,
+};

--- a/scripts/run-postman-harness.js
+++ b/scripts/run-postman-harness.js
@@ -25,6 +25,9 @@ const {
   buildNewmanReporterArgs,
   resolveAllureResultsDir,
 } = require('./postman/newman-reporting');
+const {
+  buildPublicProviderValidationFixtureUrls,
+} = require('./postman/provider-validation-public-fixtures');
 
 const ROOT = path.resolve(__dirname, '..');
 const COLLECTION_PATH = path.join(
@@ -256,6 +259,7 @@ function runNewman(
   } = {},
 ) {
   const folderArgs = folders.flatMap((folder) => ['--folder', folder]);
+  const publicProviderValidationFixtures = buildPublicProviderValidationFixtureUrls();
 
   const args = [
     '--no-install',
@@ -287,13 +291,13 @@ function runNewman(
     '--env-var',
     `expectedSwaggerServerUrl=https://localhost:${APP_HTTPS_PORT}`,
     '--env-var',
-    'providerValidationImageUrl=https://upload.wikimedia.org/wikipedia/commons/3/3f/Fronalpstock_big.jpg',
+    `providerValidationImageUrl=${publicProviderValidationFixtures.providerValidationImageUrl}`,
     '--env-var',
-    'providerValidationPageUrl=https://developer.chrome.com/',
+    `providerValidationPageUrl=${publicProviderValidationFixtures.providerValidationPageUrl}`,
     '--env-var',
-    'providerValidationAzureImageUrl=https://developer.chrome.com/static/images/ai-homepage-card.png',
+    `providerValidationAzureImageUrl=${publicProviderValidationFixtures.providerValidationAzureImageUrl}`,
     '--env-var',
-    'providerValidationAzurePageUrl=https://developer.chrome.com/',
+    `providerValidationAzurePageUrl=${publicProviderValidationFixtures.providerValidationAzurePageUrl}`,
     '--env-var',
     'model=azure',
     '--env-var',

--- a/src/providers/definitions/azure.js
+++ b/src/providers/definitions/azure.js
@@ -41,10 +41,6 @@ module.exports = {
     scopeKey: 'azure',
     autoPriority: 10,
     folderName: '91 Azure Provider Validation',
-    providerIntegrationEnvVars: [
-      'providerValidationAzureImageUrl=http://127.0.0.1:19090/assets/a.png',
-      'providerValidationAzurePageUrl=http://127.0.0.1:19090/fixtures/page-with-images',
-    ],
     scopeRequirement: 'ACV_API_ENDPOINT and ACV_SUBSCRIPTION_KEY',
     allRequirement: 'Azure credentials',
   },

--- a/src/providers/definitions/huggingface.js
+++ b/src/providers/definitions/huggingface.js
@@ -18,10 +18,6 @@ module.exports = buildOpenAiCompatibleProvider({
     requestEnvVars: [
       'model=huggingface',
     ],
-    providerIntegrationEnvVars: [
-      'providerValidationImageUrl=http://127.0.0.1:19090/assets/a.png',
-      'providerValidationPageUrl=http://127.0.0.1:19090/fixtures/page-with-images',
-    ],
     scopeRequirement: 'HF_API_KEY or HF_TOKEN',
     allRequirement: 'HF_API_KEY or HF_TOKEN',
   },

--- a/src/providers/definitions/openai.js
+++ b/src/providers/definitions/openai.js
@@ -16,10 +16,6 @@ module.exports = buildOpenAiCompatibleProvider({
     autoPriority: 50,
     folderName: '90 Provider Validation',
     requestEnvVars: ['model=openai'],
-    providerIntegrationEnvVars: [
-      'providerValidationImageUrl=http://127.0.0.1:19090/assets/a.png',
-      'providerValidationPageUrl=http://127.0.0.1:19090/fixtures/page-with-images',
-    ],
     scopeRequirement: 'OPENAI_API_KEY',
     allRequirement: 'OPENAI_API_KEY',
   },

--- a/src/providers/definitions/openrouter.js
+++ b/src/providers/definitions/openrouter.js
@@ -18,10 +18,6 @@ module.exports = buildOpenAiCompatibleProvider({
     requestEnvVars: [
       'model=openrouter',
     ],
-    providerIntegrationEnvVars: [
-      'providerValidationImageUrl=http://127.0.0.1:19090/assets/a.png',
-      'providerValidationPageUrl=http://127.0.0.1:19090/fixtures/page-with-images',
-    ],
     scopeRequirement: 'OPENROUTER_API_KEY',
     allRequirement: 'OPENROUTER_API_KEY',
   },

--- a/tests/unit/scripts/postman/providerValidationPublicFixtures.test.js
+++ b/tests/unit/scripts/postman/providerValidationPublicFixtures.test.js
@@ -1,0 +1,53 @@
+const {
+  DEFAULT_PUBLIC_FIXTURE_IMAGE_PATH,
+  DEFAULT_PUBLIC_FIXTURE_PAGE_PATH,
+  buildPublicProviderValidationFixtureUrls,
+  buildRawGitHubUrl,
+  resolvePublicFixtureRepositoryContext,
+} = require('../../../../scripts/postman/provider-validation-public-fixtures');
+
+describe('Unit | Scripts | Postman | Provider Validation Public Fixtures', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('builds raw GitHub urls for the default repository and ref', () => {
+    expect(buildPublicProviderValidationFixtureUrls()).toEqual({
+      providerValidationImageUrl: `https://raw.githubusercontent.com/jsugg/alt-text-generator/main/${encodeURIComponent(DEFAULT_PUBLIC_FIXTURE_IMAGE_PATH).replace(/%2F/g, '/')}`,
+      providerValidationPageUrl: `https://raw.githubusercontent.com/jsugg/alt-text-generator/main/${encodeURIComponent(DEFAULT_PUBLIC_FIXTURE_PAGE_PATH).replace(/%2F/g, '/')}`,
+      providerValidationAzureImageUrl: `https://raw.githubusercontent.com/jsugg/alt-text-generator/main/${encodeURIComponent(DEFAULT_PUBLIC_FIXTURE_IMAGE_PATH).replace(/%2F/g, '/')}`,
+      providerValidationAzurePageUrl: `https://raw.githubusercontent.com/jsugg/alt-text-generator/main/${encodeURIComponent(DEFAULT_PUBLIC_FIXTURE_PAGE_PATH).replace(/%2F/g, '/')}`,
+    });
+  });
+
+  it('prefers GitHub repository context when it is available', () => {
+    process.env.GITHUB_REPOSITORY = 'octo/example';
+    process.env.GITHUB_SHA = '0123456789abcdef';
+
+    expect(resolvePublicFixtureRepositoryContext()).toEqual({
+      repository: 'octo/example',
+      ref: '0123456789abcdef',
+    });
+  });
+
+  it('rejects invalid repository slugs', () => {
+    expect(() => resolvePublicFixtureRepositoryContext({
+      repository: 'not a slug',
+      ref: 'main',
+    })).toThrow(
+      'provider validation public repository must use the "<owner>/<repo>" format',
+    );
+  });
+
+  it('encodes raw GitHub paths without altering path separators', () => {
+    expect(buildRawGitHubUrl({
+      repository: 'octo/example',
+      ref: 'abc123',
+      relativePath: 'a folder/file #1.png',
+    })).toBe(
+      'https://raw.githubusercontent.com/octo/example/abc123/a%20folder/file%20%231.png',
+    );
+  });
+});

--- a/tests/unit/scripts/postman/providerValidationPublicFixtures.test.js
+++ b/tests/unit/scripts/postman/providerValidationPublicFixtures.test.js
@@ -14,7 +14,10 @@ describe('Unit | Scripts | Postman | Provider Validation Public Fixtures', () =>
   });
 
   it('builds raw GitHub urls for the default repository and ref', () => {
-    expect(buildPublicProviderValidationFixtureUrls()).toEqual({
+    expect(buildPublicProviderValidationFixtureUrls({
+      repository: 'jsugg/alt-text-generator',
+      ref: 'main',
+    })).toEqual({
       providerValidationImageUrl: `https://raw.githubusercontent.com/jsugg/alt-text-generator/main/${encodeURIComponent(DEFAULT_PUBLIC_FIXTURE_IMAGE_PATH).replace(/%2F/g, '/')}`,
       providerValidationPageUrl: `https://raw.githubusercontent.com/jsugg/alt-text-generator/main/${encodeURIComponent(DEFAULT_PUBLIC_FIXTURE_PAGE_PATH).replace(/%2F/g, '/')}`,
       providerValidationAzureImageUrl: `https://raw.githubusercontent.com/jsugg/alt-text-generator/main/${encodeURIComponent(DEFAULT_PUBLIC_FIXTURE_IMAGE_PATH).replace(/%2F/g, '/')}`,

--- a/tests/unit/scripts/postman/providerValidationScope.test.js
+++ b/tests/unit/scripts/postman/providerValidationScope.test.js
@@ -149,14 +149,12 @@ describe('Unit | Scripts | Postman | Provider Validation Scope', () => {
       ]);
     });
 
-    it('adds provider-integration overrides only in provider-integration mode', () => {
+    it('keeps provider-specific request env vars in provider-integration mode', () => {
       expect(getSelectedProviderPlans('openai', { mode: 'provider-integration' })).toEqual([
         {
           folderName: '90 Provider Validation',
           envVars: [
             'model=openai',
-            'providerValidationImageUrl=http://127.0.0.1:19090/assets/a.png',
-            'providerValidationPageUrl=http://127.0.0.1:19090/fixtures/page-with-images',
           ],
           scopeKey: 'openai',
         },


### PR DESCRIPTION
## Summary
- switch provider-integration validation to repo-owned public fixtures instead of localhost overrides
- add a fixture URL resolver that pins to GITHUB_SHA in Actions when available
- document the hosted-live vs local-integration split and branch pinning override

## Validation
- npm run lint
- npm test -- --runInBand
- npm run postman:smoke
- npm ci --dry-run
- LIVE_PROVIDER_SCOPE=openai PROVIDER_VALIDATION_PUBLIC_REF=5c204bff1575a16b62710a1d0a222a699d07e337 npm run postman:provider-integration (now reaches OpenAI with public URLs; local shell key is unauthorized, so final provider validation is delegated to GitHub env secrets)
