### PR TITLE
Reuse deploy auth in live provider validation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -91,6 +91,7 @@ The repository uses a small workflow set with separate responsibilities:
 - `Live Provider Validation` in `.github/workflows/live-provider-validation.yml`
   - manual only
   - runs `npm run postman:live -- --base-url <host>`
+  - reuses `PRODUCTION_DEPLOY_VALIDATION_API_TOKEN` when `PRODUCTION_API_AUTH_ENABLED=true`
   - uses the `prod-validation` GitHub Actions variable `LIVE_PROVIDER_SCOPE` with `auto`, `azure`, `replicate`, `huggingface`, `openai`, `openrouter`, or `all`
   - requires GitHub Actions secrets, not Render env vars
   - requires `REPLICATE_API_TOKEN` only when the resolved scope includes Replicate

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Notes:
 - `postman:live` is optional and reserved for explicit hosted live-provider validation against a deployed base URL.
 - `postman:deploy` runs the hosted production-smoke folder from the same Postman collection against a supplied base URL.
 - Before Newman starts, `postman:deploy` waits for consecutive stable health/auth probes so zero-downtime rollout overlap does not create deploy-smoke false negatives.
+- When production auth is enabled, `postman:live` reuses `PRODUCTION_DEPLOY_VALIDATION_API_TOKEN` for provider-validation requests.
 - CI runs `postman:smoke` on pull requests and `postman:harness` on `main` / `production` pushes.
 - Deploy verification runs `postman:deploy` on `production` pushes so hosted smoke checks stay inside the Newman contract layer.
 - Deploy verification also reads `PRODUCTION_API_AUTH_ENABLED` and `PRODUCTION_DEPLOY_VALIDATION_API_TOKEN` from the GitHub Actions environment so hosted protected-endpoint checks can verify the expected Render `API_AUTH_ENABLED` / `API_AUTH_TOKENS` state.

--- a/postman/collections/alt-text-generator.postman_collection.json
+++ b/postman/collections/alt-text-generator.postman_collection.json
@@ -2012,6 +2012,10 @@
               {
                 "key": "X-Max-Response-Time-Ms",
                 "value": "30000"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{deployValidationApiToken}}"
               }
             ],
             "url": {
@@ -2080,6 +2084,10 @@
               {
                 "key": "X-Max-Response-Time-Ms",
                 "value": "30000"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{deployValidationApiToken}}"
               }
             ],
             "url": {
@@ -2164,6 +2172,10 @@
               {
                 "key": "X-Max-Response-Time-Ms",
                 "value": "15000"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{deployValidationApiToken}}"
               }
             ],
             "url": {
@@ -2232,6 +2244,10 @@
               {
                 "key": "X-Max-Response-Time-Ms",
                 "value": "15000"
+              },
+              {
+                "key": "Authorization",
+                "value": "Bearer {{deployValidationApiToken}}"
               }
             ],
             "url": {

--- a/postman/environments/alt-text-generator.local.fixture.postman_environment.json
+++ b/postman/environments/alt-text-generator.local.fixture.postman_environment.json
@@ -93,6 +93,12 @@
       "enabled": true
     },
     {
+      "key": "deployValidationApiToken",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
       "key": "providerValidationImageUrl",
       "value": "https://raw.githubusercontent.com/jsugg/alt-text-generator/main/.github/assets/alt-text-generator.png",
       "type": "default",

--- a/scripts/run-postman-live.js
+++ b/scripts/run-postman-live.js
@@ -145,9 +145,19 @@ function parseArgs(argv) {
 
 /**
  * @param {string} baseUrl
+ * @param {{
+ *   deployValidationApiToken?: string,
+ *   productionApiAuthEnabled?: 'true'|'false',
+ * }} [authConfig]
  * @returns {Record<string, string>}
  */
-function buildLiveProviderEnvVars(baseUrl) {
+function buildLiveProviderEnvVars(
+  baseUrl,
+  {
+    deployValidationApiToken = '',
+    productionApiAuthEnabled = 'false',
+  } = {},
+) {
   const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
   const providerValidationPageUrl = new URL('/provider-validation/page', `${normalizedBaseUrl}/`).toString();
   const providerValidationImageUrl = new URL(
@@ -166,7 +176,9 @@ function buildLiveProviderEnvVars(baseUrl) {
 
   return {
     baseUrl: normalizedBaseUrl,
+    deployValidationApiToken,
     expectedSwaggerServerUrl: normalizedBaseUrl,
+    productionApiAuthEnabled,
     providerValidationImageUrl,
     providerValidationPageUrl,
     providerValidationAzureImageUrl: providerValidationImageUrl,
@@ -179,6 +191,10 @@ function buildLiveProviderEnvVars(baseUrl) {
  * @param {string} baseUrl
  * @param {{
  *   allureResultsDir?: string | null,
+ *   authConfig?: {
+ *     deployValidationApiToken?: string,
+ *     productionApiAuthEnabled?: 'true'|'false',
+ *   } | null,
  *   folders: string[],
  *   label: string,
  *   providerEnvVars?: string[],
@@ -189,13 +205,14 @@ function buildLiveProviderNewmanArgs(
   baseUrl,
   {
     allureResultsDir = null,
+    authConfig = null,
     folders,
     label,
     providerEnvVars = [],
   },
 ) {
   const folderArgs = folders.flatMap((folder) => ['--folder', folder]);
-  const envVarArgs = Object.entries(buildLiveProviderEnvVars(baseUrl))
+  const envVarArgs = Object.entries(buildLiveProviderEnvVars(baseUrl, authConfig ?? undefined))
     .flatMap(([key, value]) => ['--env-var', `${key}=${value}`]);
 
   return [
@@ -224,6 +241,10 @@ function buildLiveProviderNewmanArgs(
  * @param {string} baseUrl
  * @param {{
  *   allureResultsDir?: string | null,
+ *   authConfig?: {
+ *     deployValidationApiToken?: string,
+ *     productionApiAuthEnabled?: 'true'|'false',
+ *   } | null,
  *   folders: string[],
  *   label: string,
  *   providerEnvVars?: string[],
@@ -234,6 +255,7 @@ function runNewman(
   baseUrl,
   {
     allureResultsDir = null,
+    authConfig = null,
     folders,
     label,
     providerEnvVars = [],
@@ -241,6 +263,7 @@ function runNewman(
 ) {
   const args = buildLiveProviderNewmanArgs(baseUrl, {
     allureResultsDir,
+    authConfig,
     folders,
     label,
     providerEnvVars,
@@ -280,6 +303,14 @@ async function main() {
     configuredScope: process.env.LIVE_PROVIDER_SCOPE,
     configuredProviderScopes: availableProviders.configuredProviderScopes,
   });
+
+  if (authConfig.productionApiAuthEnabled === 'true' && !authConfig.deployValidationApiToken) {
+    throw new Error(
+      'Hosted live-provider validation requires PRODUCTION_DEPLOY_VALIDATION_API_TOKEN '
+      + 'when PRODUCTION_API_AUTH_ENABLED=true.',
+    );
+  }
+
   const providerPlans = getSelectedProviderPlans(providerScope);
   const collection = readCollection(COLLECTION_PATH);
   const availableFolders = listTopLevelFolderNames(collection);
@@ -302,7 +333,7 @@ async function main() {
     await fs.mkdir(allureResultsDir, { recursive: true });
   }
 
-  buildLiveProviderEnvVars(normalizedBaseUrl);
+  buildLiveProviderEnvVars(normalizedBaseUrl, authConfig);
   await waitForStableDeploy(normalizedBaseUrl, authConfig);
 
   await providerPlans.reduce(
@@ -310,6 +341,7 @@ async function main() {
       normalizedBaseUrl,
       {
         allureResultsDir,
+        authConfig,
         folders: [providerPlan.folderName],
         label: `live-provider-${providerPlan.scopeKey}`,
         providerEnvVars: providerPlan.envVars,

--- a/tests/unit/scripts/runPostmanLive.test.js
+++ b/tests/unit/scripts/runPostmanLive.test.js
@@ -51,9 +51,14 @@ describe('Unit | Scripts | Run Postman Live', () => {
 
   describe('buildLiveProviderEnvVars', () => {
     it('derives stable provider-validation fixtures from the hosted base URL', () => {
-      expect(buildLiveProviderEnvVars('https://wcag.qcraft.com.br/')).toEqual({
+      expect(buildLiveProviderEnvVars('https://wcag.qcraft.com.br/', {
+        deployValidationApiToken: 'deploy-token',
+        productionApiAuthEnabled: 'true',
+      })).toEqual({
         baseUrl: 'https://wcag.qcraft.com.br',
+        deployValidationApiToken: 'deploy-token',
         expectedSwaggerServerUrl: 'https://wcag.qcraft.com.br',
+        productionApiAuthEnabled: 'true',
         providerValidationImageUrl: 'https://wcag.qcraft.com.br/provider-validation/assets/a.png',
         providerValidationPageUrl: 'https://wcag.qcraft.com.br/provider-validation/page',
         providerValidationAzureImageUrl: 'https://wcag.qcraft.com.br/provider-validation/assets/a.png',
@@ -66,12 +71,20 @@ describe('Unit | Scripts | Run Postman Live', () => {
   describe('buildLiveProviderNewmanArgs', () => {
     it('includes derived provider validation vars and requested folders', () => {
       expect(buildLiveProviderNewmanArgs('https://wcag.qcraft.com.br', {
+        authConfig: {
+          deployValidationApiToken: 'deploy-token',
+          productionApiAuthEnabled: 'true',
+        },
         folders: ['90 Provider Validation'],
         label: 'live-provider-openai',
         providerEnvVars: ['model=openai'],
       })).toEqual(expect.arrayContaining([
         '--env-var',
         'baseUrl=https://wcag.qcraft.com.br',
+        '--env-var',
+        'deployValidationApiToken=deploy-token',
+        '--env-var',
+        'productionApiAuthEnabled=true',
         '--env-var',
         'providerValidationImageUrl=https://wcag.qcraft.com.br/provider-validation/assets/a.png',
         '--env-var',


### PR DESCRIPTION
## Summary
- pass deploy auth env vars through the hosted live provider runner
- send the deploy validation bearer token on provider-validation requests
- document the auth requirement for hosted live provider validation

## Validation
- npm run lint
- npm test -- --runInBand
- npm run postman:smoke
