### PR TITLE
Disable unfunded Replicate from live validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ TLS_PORT=8443
 
 # Configure at least one provider before booting the app.
 # Replicate enables the `clip` model.
+# REPLICATE_ENABLED=false
 # REPLICATE_API_TOKEN=replace-me
 # Azure enables the `azure` model.
 # ACV_API_ENDPOINT=https://example.cognitiveservices.azure.com/computervision/imageanalysis:analyze?api-version=2024-02-01

--- a/.github/workflows/live-provider-validation.yml
+++ b/.github/workflows/live-provider-validation.yml
@@ -64,6 +64,7 @@ jobs:
           VALIDATION_SUMMARY_TITLE: Live Provider Validation
           INPUT_PROVIDER_SCOPE: ${{ inputs.provider_scope }}
           LIVE_PROVIDER_SCOPE: ${{ vars.LIVE_PROVIDER_SCOPE }}
+          REPLICATE_ENABLED: ${{ vars.REPLICATE_ENABLED }}
           REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
           ACV_API_ENDPOINT: ${{ secrets.ACV_API_ENDPOINT }}
           ACV_SUBSCRIPTION_KEY: ${{ secrets.ACV_SUBSCRIPTION_KEY }}
@@ -79,6 +80,7 @@ jobs:
           PRODUCTION_API_AUTH_ENABLED: ${{ vars.PRODUCTION_API_AUTH_ENABLED }}
           PRODUCTION_DEPLOY_VALIDATION_API_TOKEN: ${{ secrets.PRODUCTION_DEPLOY_VALIDATION_API_TOKEN }}
           LIVE_PROVIDER_SCOPE: ${{ env.LIVE_PROVIDER_SCOPE }}
+          REPLICATE_ENABLED: ${{ vars.REPLICATE_ENABLED }}
           REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
           ACV_API_ENDPOINT: ${{ secrets.ACV_API_ENDPOINT }}
           ACV_SUBSCRIPTION_KEY: ${{ secrets.ACV_SUBSCRIPTION_KEY }}

--- a/.github/workflows/provider-integration-validation.yml
+++ b/.github/workflows/provider-integration-validation.yml
@@ -43,6 +43,7 @@ jobs:
           VALIDATION_SUMMARY_TITLE: Provider Integration Validation
           INPUT_PROVIDER_SCOPE: ${{ inputs.provider_scope }}
           LIVE_PROVIDER_SCOPE: ${{ vars.LIVE_PROVIDER_SCOPE }}
+          REPLICATE_ENABLED: ${{ vars.REPLICATE_ENABLED }}
           REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
           ACV_API_ENDPOINT: ${{ secrets.ACV_API_ENDPOINT }}
           ACV_SUBSCRIPTION_KEY: ${{ secrets.ACV_SUBSCRIPTION_KEY }}
@@ -55,6 +56,7 @@ jobs:
         run: npm run postman:provider-integration
         env:
           LIVE_PROVIDER_SCOPE: ${{ env.LIVE_PROVIDER_SCOPE }}
+          REPLICATE_ENABLED: ${{ vars.REPLICATE_ENABLED }}
           REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
           ACV_API_ENDPOINT: ${{ secrets.ACV_API_ENDPOINT }}
           ACV_SUBSCRIPTION_KEY: ${{ secrets.ACV_SUBSCRIPTION_KEY }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -93,6 +93,7 @@ The repository uses a small workflow set with separate responsibilities:
   - runs `npm run postman:live -- --base-url <host>`
   - reuses `PRODUCTION_DEPLOY_VALIDATION_API_TOKEN` when `PRODUCTION_API_AUTH_ENABLED=true`
   - uses the `prod-validation` GitHub Actions variable `LIVE_PROVIDER_SCOPE` with `auto`, `azure`, `replicate`, `huggingface`, `openai`, `openrouter`, or `all`
+  - `provider_scope=all` expands to every provider configured in the `prod-validation` environment
   - requires GitHub Actions secrets, not Render env vars
   - requires `REPLICATE_API_TOKEN` only when the resolved scope includes Replicate
   - requires `ACV_API_ENDPOINT` plus `ACV_SUBSCRIPTION_KEY` only when the resolved scope includes Azure
@@ -307,6 +308,7 @@ Notes:
 | --- | --- | --- | --- |
 | `NODE_ENV` | No | `development` | Valid values: `development`, `production`, `test`. |
 | `REPLICATE_API_TOKEN` | No | none | Required only to register the `clip` provider and for real Replicate-backed descriptions. |
+| `REPLICATE_ENABLED` | No | derived from `REPLICATE_API_TOKEN` | Set to `false` to keep Replicate credentials present but disable the `clip` provider and its validation scope. |
 | `PAGE_DESCRIPTION_CONCURRENCY` | No | `3` | Max concurrent provider calls during one page-description request. |
 | `API_AUTH_ENABLED` | No | derived from `API_AUTH_TOKENS` | Explicitly enables or disables API auth. Defaults to `true` when `API_AUTH_TOKENS` contains at least one token, otherwise `false`. |
 | `API_AUTH_TOKENS` | No | unset | Optional comma-separated API tokens. When API auth is enabled, scraper and description endpoints require either `Authorization: Bearer <token>` or `X-API-Key: <token>`. |
@@ -355,6 +357,7 @@ Development TLS behavior:
 
 | Variable | Required | Default | Description |
 | --- | --- | --- | --- |
+| `REPLICATE_ENABLED` | No | enabled when `REPLICATE_API_TOKEN` is present | Set to `false` to remove `clip` from runtime registration and provider-validation scope resolution without deleting the token. |
 | `REPLICATE_API_ENDPOINT` | No | Replicate SDK default | Override for stubs, proxies, or alternate environments. |
 | `REPLICATE_USER_AGENT` | No | `alt-text-generator/1.0.0` | Replicate client user agent. |
 | `REPLICATE_MODEL_OWNER` | No | `rmokady` | Replicate model owner. |

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Notes:
 - Deploy verification also reads `PRODUCTION_API_AUTH_ENABLED` and `PRODUCTION_DEPLOY_VALIDATION_API_TOKEN` from the GitHub Actions environment so hosted protected-endpoint checks can verify the expected Render `API_AUTH_ENABLED` / `API_AUTH_TOKENS` state.
 - Provider-validation workflows use a single `LIVE_PROVIDER_SCOPE` enum: `auto`, `azure`, `replicate`, `huggingface`, `openai`, `openrouter`, or `all`.
 - `LIVE_PROVIDER_SCOPE=auto` keeps the provider-validation preference order: Azure, then Replicate, then Hugging Face, then OpenRouter, then OpenAI.
+- `provider_scope=all` runs every provider that is configured for that environment; it does not require every supported provider to be enabled everywhere.
 - Provider integration resolves public provider-validation fixtures from this repository and pins them to `GITHUB_SHA` in GitHub Actions when available.
 - Outside GitHub Actions, set `PROVIDER_VALIDATION_PUBLIC_REF=<pushed-sha-or-ref>` if you need provider-integration runs to use a branch-specific fixture revision before it lands on `main`.
 - Hosted live-provider validation derives public validation fixtures from the target `baseUrl` and refuses localhost/private-network targets.
@@ -147,6 +148,7 @@ Required at startup:
   - or `ACV_API_ENDPOINT` plus `ACV_SUBSCRIPTION_KEY` to register `azure`
   - or `OLLAMA_MODEL` / `OLLAMA_BASE_URL` to register `ollama`
   - or `OPENAI_API_KEY`, `HF_API_KEY` / `HF_TOKEN`, `OPENROUTER_API_KEY`, or `TOGETHER_API_KEY`
+- Set `REPLICATE_ENABLED=false` when you need to keep a Replicate token configured but temporarily remove `clip` from the runtime and validation scope.
 
 Required for live Azure descriptions:
 

--- a/scripts/postman/provider-validation-scope.js
+++ b/scripts/postman/provider-validation-scope.js
@@ -50,6 +50,18 @@ const buildAllRequirementMessage = () => {
   return requirements.join(', ');
 };
 
+const resolveSelectedProviderScopes = (scope, configuredProviderScopes = null) => {
+  if (scope !== 'all') {
+    return [scope];
+  }
+
+  if (Array.isArray(configuredProviderScopes) && configuredProviderScopes.length > 0) {
+    return configuredProviderScopes.slice();
+  }
+
+  return getAvailableProviderValidationScopes();
+};
+
 /**
  * Normalizes a provider-scope string.
  *
@@ -152,13 +164,14 @@ function resolveProviderScope({
     );
   }
 
-  if (
-    desiredScope === 'all'
-    && resolvedProviderScopes.length !== getAvailableProviderValidationScopes().length
-  ) {
-    throw new Error(
-      `provider_scope=all requires ${buildAllRequirementMessage()}`,
-    );
+  if (desiredScope === 'all') {
+    if (resolvedProviderScopes.length === 0) {
+      throw new Error(
+        `provider validation requires ${buildAllRequirementMessage()}`,
+      );
+    }
+
+    return desiredScope;
   }
 
   if (desiredScope !== 'all' && !configuredProviderScopeSet.has(desiredScope)) {
@@ -182,10 +195,8 @@ function resolveProviderScope({
  *   runReplicate: boolean,
  * }}
  */
-function getSelectedProviders(scope) {
-  const selectedProviderScopes = scope === 'all'
-    ? getAvailableProviderValidationScopes()
-    : [scope];
+function getSelectedProviders(scope, { configuredProviderScopes } = {}) {
+  const selectedProviderScopes = resolveSelectedProviderScopes(scope, configuredProviderScopes);
 
   selectedProviderScopes.forEach((selectedScope) => {
     if (!getProviderValidationByScope(selectedScope)) {
@@ -207,8 +218,11 @@ function getSelectedProviders(scope) {
  * @param {{ mode?: 'live'|'provider-integration' }} [options]
  * @returns {{ folderName: string, envVars: string[], scopeKey: string }[]}
  */
-function getSelectedProviderPlans(scope, { mode = 'live' } = {}) {
-  const { selectedProviderScopes } = getSelectedProviders(scope);
+function getSelectedProviderPlans(scope, {
+  configuredProviderScopes,
+  mode = 'live',
+} = {}) {
+  const { selectedProviderScopes } = getSelectedProviders(scope, { configuredProviderScopes });
 
   return selectedProviderScopes.map((selectedScope) => {
     const provider = getProviderValidationByScope(selectedScope);

--- a/scripts/run-postman-harness.js
+++ b/scripts/run-postman-harness.js
@@ -405,10 +405,15 @@ async function main() {
     })
     : null;
   const selectedProviderValidation = providerValidationScope
-    ? getSelectedProviders(providerValidationScope)
+    ? getSelectedProviders(providerValidationScope, {
+      configuredProviderScopes: availableLiveProviders.configuredProviderScopes,
+    })
     : { selectedProviderScopes: [], runAzure: false, runReplicate: false };
   const selectedProviderPlans = providerValidationScope
-    ? getSelectedProviderPlans(providerValidationScope, { mode: 'provider-integration' })
+    ? getSelectedProviderPlans(providerValidationScope, {
+      configuredProviderScopes: availableLiveProviders.configuredProviderScopes,
+      mode: 'provider-integration',
+    })
     : [];
   const selectedProviderScopeSet = new Set(selectedProviderValidation.selectedProviderScopes);
   let appReplicateApiToken = 'test-token';

--- a/scripts/run-postman-live.js
+++ b/scripts/run-postman-live.js
@@ -311,7 +311,9 @@ async function main() {
     );
   }
 
-  const providerPlans = getSelectedProviderPlans(providerScope);
+  const providerPlans = getSelectedProviderPlans(providerScope, {
+    configuredProviderScopes: availableProviders.configuredProviderScopes,
+  });
   const collection = readCollection(COLLECTION_PATH);
   const availableFolders = listTopLevelFolderNames(collection);
   const selectedFolders = Array.from(

--- a/src/providers/definitions/clip.js
+++ b/src/providers/definitions/clip.js
@@ -1,6 +1,7 @@
 const Replicate = require('replicate');
 
 const ReplicateDescriberService = require('../../services/ReplicateDescriberService');
+const { isExplicitlyDisabled } = require('./helpers');
 
 const buildReplicateClient = (providerConfig, fetch) => new Replicate({
   auth: providerConfig.apiToken,
@@ -15,6 +16,7 @@ module.exports = {
   displayName: 'Replicate CLIP',
   startupHint: 'REPLICATE_API_TOKEN to enable clip',
   buildEnvSchema: (Joi) => ({
+    REPLICATE_ENABLED: Joi.string().valid('true', 'false').optional(),
     REPLICATE_API_TOKEN: Joi.string().optional(),
     REPLICATE_API_ENDPOINT: Joi.string().uri().optional(),
     REPLICATE_USER_AGENT: Joi.string().optional(),
@@ -23,6 +25,7 @@ module.exports = {
     REPLICATE_MODEL_VERSION: Joi.string().optional(),
   }),
   buildConfig: (env) => ({
+    enabled: !isExplicitlyDisabled('REPLICATE_ENABLED', env) && Boolean(env.REPLICATE_API_TOKEN),
     apiToken: env.REPLICATE_API_TOKEN,
     apiEndpoint: env.REPLICATE_API_ENDPOINT,
     userAgent: env.REPLICATE_USER_AGENT || 'alt-text-generator/1.0.0',
@@ -32,8 +35,12 @@ module.exports = {
       env.REPLICATE_MODEL_VERSION
       || '9a34a6339872a03f45236f114321fb51fc7aa8269d38ae0ce5334969981e4cd8',
   }),
-  isConfiguredInEnv: (env = {}) => Boolean(env.REPLICATE_API_TOKEN),
-  isConfiguredInConfig: (config = {}) => Boolean(config.replicate?.apiToken),
+  isConfiguredInEnv: (env = {}) => (
+    !isExplicitlyDisabled('REPLICATE_ENABLED', env) && Boolean(env.REPLICATE_API_TOKEN)
+  ),
+  isConfiguredInConfig: (config = {}) => (
+    config.replicate?.enabled !== false && Boolean(config.replicate?.apiToken)
+  ),
   validateEnv: () => [],
   providerValidation: {
     scopeKey: 'replicate',

--- a/src/providers/definitions/helpers.js
+++ b/src/providers/definitions/helpers.js
@@ -7,6 +7,24 @@ const toPositiveIntegerOrFallback = (value, fallback) => {
 
 const hasAnyEnvValue = (env = {}, keys = []) => keys.some((key) => Boolean(env[key]));
 
+const toOptionalBooleanString = (value) => {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  if (value === true || value === 'true') {
+    return true;
+  }
+
+  if (value === false || value === 'false') {
+    return false;
+  }
+
+  return undefined;
+};
+
+const isExplicitlyDisabled = (envName, env = {}) => toOptionalBooleanString(env[envName]) === false;
+
 const validateApiKeyBackedProviderEnv = ({
   env = {},
   apiKeyEnvNames = [],
@@ -25,6 +43,8 @@ const validateApiKeyBackedProviderEnv = ({
 module.exports = {
   DEFAULT_ALT_TEXT_PROMPT,
   hasAnyEnvValue,
+  isExplicitlyDisabled,
+  toOptionalBooleanString,
   toPositiveIntegerOrFallback,
   validateApiKeyBackedProviderEnv,
 };

--- a/tests/unit/config/providerCatalog.test.js
+++ b/tests/unit/config/providerCatalog.test.js
@@ -15,6 +15,7 @@ const {
 describe('Unit | Config | Provider Catalog', () => {
   it('builds provider config sections with documented defaults and explicit overrides', () => {
     const sections = buildProviderConfigSections({
+      REPLICATE_ENABLED: 'true',
       REPLICATE_API_TOKEN: 'replicate-token',
       REPLICATE_API_ENDPOINT: 'https://replicate.example.com',
       REPLICATE_USER_AGENT: 'alt-text-generator/test',
@@ -37,6 +38,7 @@ describe('Unit | Config | Provider Catalog', () => {
 
     expect(sections).toEqual({
       replicate: {
+        enabled: true,
         apiToken: 'replicate-token',
         apiEndpoint: 'https://replicate.example.com',
         userAgent: 'alt-text-generator/test',
@@ -102,6 +104,7 @@ describe('Unit | Config | Provider Catalog', () => {
     const schema = buildProviderEnvSchema(Joi);
 
     expect(schema).toHaveProperty('REPLICATE_API_TOKEN');
+    expect(schema).toHaveProperty('REPLICATE_ENABLED');
     expect(schema).toHaveProperty('ACV_API_ENDPOINT');
     expect(schema).toHaveProperty('OPENAI_API_KEY');
     expect(schema).toHaveProperty('HF_API_KEY');
@@ -173,5 +176,27 @@ describe('Unit | Config | Provider Catalog', () => {
       'openrouter',
     ]);
     expect(getProviderValidationByScope('azure').displayName).toBe('Azure Computer Vision');
+  });
+
+  it('treats REPLICATE_ENABLED=false as a hard disable for clip', () => {
+    const sections = buildProviderConfigSections({
+      REPLICATE_ENABLED: 'false',
+      REPLICATE_API_TOKEN: 'replicate-token',
+    });
+
+    expect(sections.replicate).toMatchObject({
+      enabled: false,
+      apiToken: 'replicate-token',
+    });
+    expect(getConfiguredProvidersFromEnv({
+      REPLICATE_ENABLED: 'false',
+      REPLICATE_API_TOKEN: 'replicate-token',
+    })).toEqual([]);
+    expect(getConfiguredProvidersFromConfig({
+      replicate: {
+        enabled: false,
+        apiToken: 'replicate-token',
+      },
+    })).toEqual([]);
   });
 });

--- a/tests/unit/createApp.test.js
+++ b/tests/unit/createApp.test.js
@@ -227,4 +227,32 @@ describe('Unit | Application Composition', () => {
 
     expect(services.imageDescriberFactory.getAvailableModels()).toEqual([]);
   });
+
+  it('does not register clip when Replicate is explicitly disabled', () => {
+    const config = {
+      replicate: {
+        enabled: false,
+        apiToken: 'test-token',
+        apiEndpoint: 'https://replicate.example.com',
+        userAgent: 'alt-text-generator/test',
+        modelOwner: 'owner',
+        modelName: 'model',
+        modelVersion: 'version',
+      },
+      scraper: {
+        requestTimeoutMs: 1500,
+        maxRedirects: 4,
+        maxContentLengthBytes: 2048,
+      },
+    };
+
+    const { services } = createApp({
+      appLogger: createAppLogger(),
+      requestLogger: createRequestLogger(),
+      httpClient: { get: jest.fn(), post: jest.fn() },
+      config,
+    });
+
+    expect(services.imageDescriberFactory.getAvailableModels()).toEqual([]);
+  });
 });

--- a/tests/unit/scripts/github/resolveProviderValidationScope.test.js
+++ b/tests/unit/scripts/github/resolveProviderValidationScope.test.js
@@ -32,6 +32,16 @@ describe('Unit | Scripts | GitHub | Resolve Provider Validation Scope', () => {
       })).toBe('all');
     });
 
+    it('treats disabled replicate credentials as unavailable when resolving auto', () => {
+      expect(resolveScopeFromEnv({
+        INPUT_PROVIDER_SCOPE: 'auto',
+        LIVE_PROVIDER_SCOPE: 'auto',
+        REPLICATE_ENABLED: 'false',
+        REPLICATE_API_TOKEN: 'replicate-token',
+        OPENAI_API_KEY: 'openai-key',
+      })).toBe('openai');
+    });
+
     it('falls back to azure when auto is requested and both providers are configured', () => {
       expect(resolveScopeFromEnv({
         INPUT_PROVIDER_SCOPE: 'auto',

--- a/tests/unit/scripts/postman/providerValidationScope.test.js
+++ b/tests/unit/scripts/postman/providerValidationScope.test.js
@@ -41,6 +41,18 @@ describe('Unit | Scripts | Postman | Provider Validation Scope', () => {
       });
     });
 
+    it('excludes disabled replicate credentials from the configured scope list', () => {
+      expect(detectAvailableProviders({
+        REPLICATE_ENABLED: 'false',
+        REPLICATE_API_TOKEN: 'replicate-token',
+        OPENAI_API_KEY: 'openai-key',
+      })).toEqual({
+        configuredProviderScopes: ['openai'],
+        hasAzureProvider: false,
+        hasReplicateProvider: false,
+      });
+    });
+
     it('detects api-key-backed multimodal providers', () => {
       expect(detectAvailableProviders({
         HF_API_KEY: 'hf-key',
@@ -107,23 +119,33 @@ describe('Unit | Scripts | Postman | Provider Validation Scope', () => {
       );
     });
 
-    it('rejects all scope when only one provider is configured', () => {
-      expect(() => resolveProviderScope({
+    it('expands all to the configured providers only', () => {
+      expect(resolveProviderScope({
         requestedScope: 'all',
         configuredScope: 'auto',
         configuredProviderScopes: ['azure'],
+      })).toBe('all');
+    });
+
+    it('rejects all scope when no provider is configured', () => {
+      expect(() => resolveProviderScope({
+        requestedScope: 'all',
+        configuredScope: 'auto',
+        configuredProviderScopes: [],
       })).toThrow(
-        'provider_scope=all requires Azure credentials, REPLICATE_API_TOKEN, HF_API_KEY or HF_TOKEN, OPENROUTER_API_KEY, OPENAI_API_KEY',
+        'provider validation requires Azure credentials, REPLICATE_API_TOKEN, HF_API_KEY or HF_TOKEN, OPENROUTER_API_KEY, OPENAI_API_KEY',
       );
     });
   });
 
   describe('getSelectedProviders', () => {
-    it('maps all to both providers', () => {
-      expect(getSelectedProviders('all')).toEqual({
-        selectedProviderScopes: ['replicate', 'azure', 'huggingface', 'openai', 'openrouter'],
+    it('maps all to the configured providers', () => {
+      expect(getSelectedProviders('all', {
+        configuredProviderScopes: ['azure', 'openai'],
+      })).toEqual({
+        selectedProviderScopes: ['azure', 'openai'],
         runAzure: true,
-        runReplicate: true,
+        runReplicate: false,
       });
     });
 
@@ -160,13 +182,34 @@ describe('Unit | Scripts | Postman | Provider Validation Scope', () => {
         },
       ]);
     });
+
+    it('expands all using only configured provider plans', () => {
+      expect(getSelectedProviderPlans('all', {
+        configuredProviderScopes: ['azure', 'openrouter'],
+      })).toEqual([
+        {
+          folderName: '91 Azure Provider Validation',
+          envVars: [],
+          scopeKey: 'azure',
+        },
+        {
+          folderName: '90 Provider Validation',
+          envVars: [
+            'model=openrouter',
+          ],
+          scopeKey: 'openrouter',
+        },
+      ]);
+    });
   });
 
   describe('getSelectedProviderFolders', () => {
-    it('maps the all scope to every live provider folder', () => {
-      expect(getSelectedProviderFolders('all')).toEqual([
-        '90 Provider Validation',
+    it('maps the all scope to the configured live provider folders', () => {
+      expect(getSelectedProviderFolders('all', {
+        configuredProviderScopes: ['azure', 'openrouter'],
+      })).toEqual([
         '91 Azure Provider Validation',
+        '90 Provider Validation',
       ]);
     });
   });


### PR DESCRIPTION
## Summary
- add an explicit `REPLICATE_ENABLED=false` kill switch so `clip` can be disabled without deleting secrets
- make `provider_scope=all` expand to the providers configured in the current environment
- pass the Replicate enablement flag through the provider-validation workflows and document the behavior