### PR TITLE
Raise provider integration Newman timeout

### DIFF
--- a/scripts/postman/harness-timeouts.js
+++ b/scripts/postman/harness-timeouts.js
@@ -1,0 +1,20 @@
+const DEFAULT_NEWMAN_TIMEOUT_REQUEST_MS = 10000;
+const PROVIDER_INTEGRATION_NEWMAN_TIMEOUT_REQUEST_MS = 45000;
+
+/**
+ * Resolves the Newman request timeout for the current harness mode.
+ *
+ * @param {{ providerIntegrationModeEnabled?: boolean }} [options]
+ * @returns {number}
+ */
+function resolveNewmanTimeoutRequestMs({ providerIntegrationModeEnabled = false } = {}) {
+  return providerIntegrationModeEnabled
+    ? PROVIDER_INTEGRATION_NEWMAN_TIMEOUT_REQUEST_MS
+    : DEFAULT_NEWMAN_TIMEOUT_REQUEST_MS;
+}
+
+module.exports = {
+  DEFAULT_NEWMAN_TIMEOUT_REQUEST_MS,
+  PROVIDER_INTEGRATION_NEWMAN_TIMEOUT_REQUEST_MS,
+  resolveNewmanTimeoutRequestMs,
+};

--- a/scripts/run-postman-harness.js
+++ b/scripts/run-postman-harness.js
@@ -28,6 +28,10 @@ const {
 const {
   buildPublicProviderValidationFixtureUrls,
 } = require('./postman/provider-validation-public-fixtures');
+const {
+  DEFAULT_NEWMAN_TIMEOUT_REQUEST_MS,
+  resolveNewmanTimeoutRequestMs,
+} = require('./postman/harness-timeouts');
 
 const ROOT = path.resolve(__dirname, '..');
 const COLLECTION_PATH = path.join(
@@ -245,6 +249,7 @@ function buildAppServerEnv({
  *   envPath?: string,
  *   envVars?: string[],
  *   extraArgs?: string[],
+ *   timeoutRequestMs?: number,
  * }} options
  * @returns {Promise<void>}
  */
@@ -256,6 +261,7 @@ function runNewman(
     envPath = ENV_PATH,
     envVars = [],
     extraArgs = [],
+    timeoutRequestMs = DEFAULT_NEWMAN_TIMEOUT_REQUEST_MS,
   } = {},
 ) {
   const folderArgs = folders.flatMap((folder) => ['--folder', folder]);
@@ -304,7 +310,7 @@ function runNewman(
     'maxResponseTimeMs=1500',
     ...envVars.flatMap((envVar) => ['--env-var', envVar]),
     '--timeout-request',
-    '10000',
+    String(timeoutRequestMs),
     '--timeout-script',
     '10000',
     ...buildNewmanReporterArgs({
@@ -641,6 +647,9 @@ async function main() {
               ...providerPlan.envVars,
             ],
             extraArgs: ['--insecure'],
+            timeoutRequestMs: resolveNewmanTimeoutRequestMs({
+              providerIntegrationModeEnabled,
+            }),
           },
         )),
         Promise.resolve(),

--- a/tests/unit/runPostmanHarness.test.js
+++ b/tests/unit/runPostmanHarness.test.js
@@ -4,8 +4,14 @@ const {
   buildNewmanReporterArgs,
   resolveAllureResultsDir,
 } = require('../../scripts/postman/newman-reporting');
+const { resolveNewmanTimeoutRequestMs } = require('../../scripts/postman/harness-timeouts');
 
 describe('Unit | Postman Harness Reporting', () => {
+  it('uses the longer Newman request timeout in provider-integration mode', () => {
+    expect(resolveNewmanTimeoutRequestMs()).toBe(10000);
+    expect(resolveNewmanTimeoutRequestMs({ providerIntegrationModeEnabled: true })).toBe(45000);
+  });
+
   it('keeps the existing CLI, JSON, and JUnit reporters by default', () => {
     const args = buildNewmanReporterArgs({
       label: 'smoke',


### PR DESCRIPTION
## Summary
- move the provider-integration Newman timeout policy into a dedicated helper module
- increase provider-integration request timeouts to 45s so the local harness can tolerate real provider latency
- cover the timeout policy with a focused unit test
