### PR TITLE
Clarify hosted provider validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,7 +73,7 @@ TLS_PORT=8443
 # Optional OpenAI provider settings.
 # OPENAI_API_KEY=
 # OPENAI_BASE_URL=https://api.openai.com/v1
-# OPENAI_MODEL=gpt-4.1-mini
+# OPENAI_MODEL=gpt-4.1-nano
 # OPENAI_MAX_TOKENS=160
 # OPENAI_PROMPT=Write concise alt text for this image.
 

--- a/.github/workflows/live-provider-validation.yml
+++ b/.github/workflows/live-provider-validation.yml
@@ -1,4 +1,4 @@
-name: Live Provider Validation
+name: Hosted Provider Validation
 
 on:
   workflow_dispatch:
@@ -9,7 +9,7 @@ on:
         default: 'https://wcag.qcraft.com.br'
         type: string
       provider_scope:
-        description: Select the live provider scope. Use auto to defer to the prod-validation LIVE_PROVIDER_SCOPE variable.
+        description: Select the hosted provider scope. Use auto to defer to the prod-validation LIVE_PROVIDER_SCOPE variable.
         required: false
         default: auto
         type: choice
@@ -39,14 +39,14 @@ jobs:
       - name: Write summary
         run: |
           {
-            echo "## Live Provider Validation"
+            echo "## Hosted Provider Validation"
             echo
             echo "- Scheduled run skipped because ENABLE_SCHEDULED_LIVE_PROVIDER_VALIDATION is not set to true."
           } >> "$GITHUB_STEP_SUMMARY"
 
   live-provider:
     if: github.event_name != 'schedule' || vars.ENABLE_SCHEDULED_LIVE_PROVIDER_VALIDATION == 'true'
-    name: live-provider
+    name: hosted-provider
     runs-on: ubuntu-latest
     environment: prod-validation
     timeout-minutes: 20
@@ -61,7 +61,7 @@ jobs:
 
       - name: Resolve provider scope
         env:
-          VALIDATION_SUMMARY_TITLE: Live Provider Validation
+          VALIDATION_SUMMARY_TITLE: Hosted Provider Validation
           INPUT_PROVIDER_SCOPE: ${{ inputs.provider_scope }}
           LIVE_PROVIDER_SCOPE: ${{ vars.LIVE_PROVIDER_SCOPE }}
           REPLICATE_ENABLED: ${{ vars.REPLICATE_ENABLED }}
@@ -73,8 +73,8 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: node scripts/github/resolve-provider-validation-scope.js
 
-      - name: Run live provider validation
-        run: npm run postman:live -- --base-url "${BASE_URL}"
+      - name: Run hosted provider validation
+        run: npm run postman:hosted-provider -- --base-url "${BASE_URL}"
         env:
           BASE_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.base_url || 'https://wcag.qcraft.com.br' }}
           PRODUCTION_API_AUTH_ENABLED: ${{ vars.PRODUCTION_API_AUTH_ENABLED }}
@@ -88,11 +88,11 @@ jobs:
           HF_API_KEY: ${{ secrets.HF_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
 
-      - name: Upload live validation artifacts
+      - name: Upload hosted validation artifacts
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: live-provider-artifacts
+          name: hosted-provider-artifacts
           path: reports/newman/
           if-no-files-found: ignore
           retention-days: 7
@@ -101,4 +101,4 @@ jobs:
         if: always()
         run: bash scripts/github/write-provider-validation-summary.sh "$GITHUB_STEP_SUMMARY"
         env:
-          VALIDATION_SUMMARY_TITLE: Live Provider Validation
+          VALIDATION_SUMMARY_TITLE: Hosted Provider Validation

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -88,9 +88,9 @@ The repository uses a small workflow set with separate responsibilities:
   - runs on a weekly schedule and by manual dispatch
   - executes `npm audit --omit=dev --audit-level=high`
   - uploads audit artifacts and fails when high or critical production dependency findings exist
-- `Live Provider Validation` in `.github/workflows/live-provider-validation.yml`
+- `Hosted Provider Validation` in `.github/workflows/live-provider-validation.yml`
   - manual only
-  - runs `npm run postman:live -- --base-url <host>`
+  - runs `npm run postman:hosted-provider -- --base-url <host>`
   - reuses `PRODUCTION_DEPLOY_VALIDATION_API_TOKEN` when `PRODUCTION_API_AUTH_ENABLED=true`
   - uses the `prod-validation` GitHub Actions variable `LIVE_PROVIDER_SCOPE` with `auto`, `azure`, `replicate`, `huggingface`, `openai`, `openrouter`, or `all`
   - `provider_scope=all` expands to every provider configured in the `prod-validation` environment
@@ -184,11 +184,12 @@ Modes:
   - optional local provider-integration validation
   - uses the local app plus fixture server
   - supports provider-scoped validation with real credentials without claiming hosted coverage
-- `npm run postman:live`
-  - optional live-provider validation
+- `npm run postman:hosted-provider`
+  - optional hosted provider validation
   - targets a deployed base URL and waits for rollout stabilization before starting Newman
   - uses repo-controlled public provider-validation fixtures served from the target deployment
   - supports `azure`, `replicate`, `huggingface`, `openai`, `openrouter`, or `all` through `LIVE_PROVIDER_SCOPE`
+  - `npm run postman:live` remains as a backward-compatible alias
 - `npm run postman:deploy -- --base-url https://wcag.qcraft.com.br`
   - hosted deploy smoke verification
   - runs only the deploy folder from the shared Postman collection and writes `deploy.json` / `deploy.xml`
@@ -391,7 +392,7 @@ At least one provider must be configured at startup: `REPLICATE_API_TOKEN`, Azur
 | --- | --- | --- | --- |
 | `OPENAI_API_KEY` | No | none | Registers `openai`. |
 | `OPENAI_BASE_URL` | No | `https://api.openai.com/v1` | Override for proxies or compatible gateways. |
-| `OPENAI_MODEL` | No | `gpt-4.1-mini` | Default OpenAI multimodal model. |
+| `OPENAI_MODEL` | No | `gpt-4.1-nano` | Default OpenAI multimodal model. |
 | `OPENAI_MAX_TOKENS` | No | `160` | Max completion tokens for `openai`. |
 | `OPENAI_PROMPT` | No | shared alt-text prompt | Prompt sent with the image. |
 | `HF_API_KEY` | No | none | Registers `huggingface`. `HF_TOKEN` is accepted as an alias. |

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Commands:
 npm run postman:smoke
 npm run postman:harness
 npm run postman:provider-integration
-npm run postman:live -- --base-url https://wcag.qcraft.com.br
+npm run postman:hosted-provider -- --base-url https://wcag.qcraft.com.br
 npm run postman:deploy -- --base-url https://wcag.qcraft.com.br
 ```
 
@@ -87,10 +87,11 @@ Notes:
 - `postman:harness` runs the full deterministic suite, including protected-endpoint auth coverage, and writes JSON and JUnit reports under `reports/newman/`.
 - CI also emits `reports/jest/junit.xml` from the canonical Node 20 Jest lane and publishes one combined GitHub test report that joins Jest and Newman results.
 - `postman:provider-integration` is the local provider-integration harness: it boots the app locally, uses deterministic local fixtures for the core contract suite, and uses repo-owned public provider-validation fixtures for real vendor coverage without claiming hosted coverage.
-- `postman:live` is optional and reserved for explicit hosted live-provider validation against a deployed base URL.
+- `postman:hosted-provider` is the canonical hosted provider-validation command for explicit deployed-service validation against a supplied base URL.
+- `postman:live` remains as a backward-compatible alias for `postman:hosted-provider`.
 - `postman:deploy` runs the hosted production-smoke folder from the same Postman collection against a supplied base URL.
 - Before Newman starts, `postman:deploy` waits for consecutive stable health/auth probes so zero-downtime rollout overlap does not create deploy-smoke false negatives.
-- When production auth is enabled, `postman:live` reuses `PRODUCTION_DEPLOY_VALIDATION_API_TOKEN` for provider-validation requests.
+- When production auth is enabled, `postman:hosted-provider` reuses `PRODUCTION_DEPLOY_VALIDATION_API_TOKEN` for provider-validation requests.
 - CI runs `postman:smoke` on pull requests and `postman:harness` on `main` / `production` pushes.
 - Deploy verification runs `postman:deploy` on `production` pushes so hosted smoke checks stay inside the Newman contract layer.
 - Deploy verification also reads `PRODUCTION_API_AUTH_ENABLED` and `PRODUCTION_DEPLOY_VALIDATION_API_TOKEN` from the GitHub Actions environment so hosted protected-endpoint checks can verify the expected Render `API_AUTH_ENABLED` / `API_AUTH_TOKENS` state.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "postman:smoke": "node scripts/run-postman-harness.js smoke",
     "postman:harness": "node scripts/run-postman-harness.js full",
     "postman:provider-integration": "node scripts/run-postman-harness.js provider-integration",
+    "postman:hosted-provider": "node scripts/run-postman-live.js",
     "postman:live": "node scripts/run-postman-live.js",
     "postman:deploy": "node scripts/run-postman-deploy.js",
     "report:allure": "npm run allure:clean && npm run test:allure && npm run postman:harness:allure && npm run allure:generate",

--- a/scripts/run-postman-harness.js
+++ b/scripts/run-postman-harness.js
@@ -396,7 +396,7 @@ async function main() {
   }
   if (mode === 'live') {
     throw new Error(
-      'The live mode moved to scripts/run-postman-live.js. Use npm run postman:live '
+      'The live mode moved to scripts/run-postman-live.js. Use npm run postman:hosted-provider '
       + 'for hosted validation or node scripts/run-postman-harness.js provider-integration '
       + 'for the local provider-integration harness.',
     );

--- a/src/providers/definitions/openai.js
+++ b/src/providers/definitions/openai.js
@@ -8,7 +8,7 @@ module.exports = buildOpenAiCompatibleProvider({
   baseUrlEnvName: 'OPENAI_BASE_URL',
   defaultBaseUrl: 'https://api.openai.com/v1',
   modelEnvName: 'OPENAI_MODEL',
-  defaultModel: 'gpt-4.1-mini',
+  defaultModel: 'gpt-4.1-nano',
   maxTokensEnvName: 'OPENAI_MAX_TOKENS',
   promptEnvName: 'OPENAI_PROMPT',
   providerValidation: {

--- a/tests/unit/config/providerCatalog.test.js
+++ b/tests/unit/config/providerCatalog.test.js
@@ -27,7 +27,7 @@ describe('Unit | Config | Provider Catalog', () => {
       ACV_LANGUAGE: 'pt-BR',
       ACV_MAX_CANDIDATES: '7',
       OPENAI_API_KEY: 'openai-key',
-      OPENAI_MODEL: 'gpt-4.1-mini',
+      OPENAI_MODEL: 'gpt-4.1-nano',
       HF_API_KEY: 'hf-key',
       OLLAMA_MODEL: 'llama3.2-vision',
       OPENROUTER_API_KEY: 'openrouter-key',
@@ -70,7 +70,7 @@ describe('Unit | Config | Provider Catalog', () => {
       openai: {
         apiKey: 'openai-key',
         baseUrl: 'https://api.openai.com/v1',
-        model: 'gpt-4.1-mini',
+        model: 'gpt-4.1-nano',
         maxTokens: 160,
         prompt: expect.any(String),
         headers: {},
@@ -151,7 +151,7 @@ describe('Unit | Config | Provider Catalog', () => {
       ACV_SUBSCRIPTION_KEY: 'azure-key',
     })).toEqual([]);
     expect(validateProviderEnv({
-      OPENAI_MODEL: 'gpt-4.1-mini',
+      OPENAI_MODEL: 'gpt-4.1-nano',
     })[0]).toMatch(/OPENAI_API_KEY/);
     expect(validateProviderEnv({
       OPENROUTER_TITLE: 'Alt Text 4 All',

--- a/tests/unit/utils/validateEnvVars.test.js
+++ b/tests/unit/utils/validateEnvVars.test.js
@@ -299,7 +299,7 @@ describe('Unit | Utils | Validate Env Vars', () => {
   it('rejects OpenAI overrides without an API key', () => {
     const validateEnvVars = loadValidator({
       overrides: {
-        OPENAI_MODEL: 'gpt-4.1-mini',
+        OPENAI_MODEL: 'gpt-4.1-nano',
       },
       remove: ['REPLICATE_API_TOKEN', 'ACV_API_ENDPOINT', 'ACV_SUBSCRIPTION_KEY', 'OPENAI_API_KEY'],
     });


### PR DESCRIPTION
## Summary
- rename the hosted provider-validation workflow and docs so the deployed-service suite is explicit
- add a canonical \ command while keeping \ as a compatibility alias
- switch the default OpenAI vision model to \ for lower-cost image captioning

## Validation
- npm run lint
- npm test -- --runInBand
- npm run postman:smoke
- npm ci --dry-run