### PR TITLE
Redact sensitive auth headers from logs

### DIFF
--- a/src/infrastructure/logger.js
+++ b/src/infrastructure/logger.js
@@ -3,6 +3,31 @@ const pino = require('pino');
 const pinoHttp = require('pino-http');
 const config = require('../../config');
 
+const REDACTED_HEADER_VALUE = '[Redacted]';
+const SENSITIVE_LOGGED_HEADERS = new Set([
+  'authorization',
+  'cookie',
+  'ocp-apim-subscription-key',
+  'proxy-authorization',
+  'set-cookie',
+  'x-api-key',
+]);
+
+const redactLoggedHeaders = (headers) => {
+  if (!headers || typeof headers !== 'object') {
+    return headers;
+  }
+
+  return Object.fromEntries(
+    Object.entries(headers).map(([name, value]) => [
+      name,
+      SENSITIVE_LOGGED_HEADERS.has(name.toLowerCase())
+        ? REDACTED_HEADER_VALUE
+        : value,
+    ]),
+  );
+};
+
 const serializeLoggedError = (error) => {
   const serialized = pinoHttp.stdSerializers.err(error);
   const serializedCause = error?.cause ? serializeLoggedError(error.cause) : undefined;
@@ -18,6 +43,32 @@ const serializeLoggedError = (error) => {
     ...(serialized.code ? { code: serialized.code } : {}),
     ...(serialized.signal ? { signal: serialized.signal } : {}),
     ...(serializedCause ? { cause: serializedCause } : {}),
+  };
+};
+
+const serializeLoggedRequest = (request) => {
+  const serialized = pinoHttp.stdSerializers.req(request);
+
+  if (!serialized || typeof serialized !== 'object') {
+    return serialized;
+  }
+
+  return {
+    ...serialized,
+    ...(serialized.headers ? { headers: redactLoggedHeaders(serialized.headers) } : {}),
+  };
+};
+
+const serializeLoggedResponse = (response) => {
+  const serialized = pinoHttp.stdSerializers.res(response);
+
+  if (!serialized || typeof serialized !== 'object') {
+    return serialized;
+  }
+
+  return {
+    ...serialized,
+    ...(serialized.headers ? { headers: redactLoggedHeaders(serialized.headers) } : {}),
   };
 };
 
@@ -40,10 +91,10 @@ const createRequestLogger = (appLogger) => pinoHttp({
   },
   serializers: {
     err: serializeLoggedError,
-    req: pinoHttp.stdSerializers.req,
-    res: pinoHttp.stdSerializers.res,
+    req: serializeLoggedRequest,
+    res: serializeLoggedResponse,
   },
-  wrapSerializers: true,
+  wrapSerializers: false,
   customLogLevel: (req, res, err) => {
     if (res.statusCode >= 400 && res.statusCode < 500) return 'warn';
     if (res.statusCode >= 500 || err) return 'error';

--- a/tests/unit/infrastructure/logger.test.js
+++ b/tests/unit/infrastructure/logger.test.js
@@ -19,8 +19,16 @@ const mockStdSerializers = {
       }
       : undefined,
   })),
-  req: Symbol('req'),
-  res: Symbol('res'),
+  req: jest.fn((request) => ({
+    id: request.id,
+    method: request.method,
+    headers: request.headers,
+    url: request.url,
+  })),
+  res: jest.fn((response) => ({
+    statusCode: response.statusCode,
+    headers: response.headers,
+  })),
 };
 
 const mockPino = jest.fn();
@@ -130,17 +138,71 @@ describe('Unit | Infrastructure | Logger', () => {
       logger: mockChildLogger,
       serializers: expect.objectContaining({
         err: expect.any(Function),
-        req: mockStdSerializers.req,
-        res: mockStdSerializers.res,
+        req: expect.any(Function),
+        res: expect.any(Function),
       }),
-      wrapSerializers: true,
+      wrapSerializers: false,
     }));
     expect(requestLoggerOptions.logger).toBe(mockChildLogger);
-    expect(requestLoggerOptions.serializers.req).toBe(mockStdSerializers.req);
-    expect(requestLoggerOptions.serializers.res).toBe(mockStdSerializers.res);
+    expect(requestLoggerOptions.serializers.req).toEqual(expect.any(Function));
+    expect(requestLoggerOptions.serializers.res).toEqual(expect.any(Function));
     expect(requestLoggerOptions.serializers.err).toEqual(expect.any(Function));
     expect(loggerModule.requestLogger).toBe(mockRequestLogger);
     expect(loggerModule.serverLogger).toBe(mockRequestLogger);
+  });
+
+  it('redacts sensitive request and response headers before logging', () => {
+    const { requestLoggerOptions } = loadLoggerModule({
+      env: {
+        NODE_ENV: 'production',
+      },
+    });
+
+    const serializedRequest = requestLoggerOptions.serializers.req({
+      id: 'req-123',
+      method: 'GET',
+      url: '/api/v1/accessibility/description',
+      headers: {
+        authorization: 'Bearer super-secret',
+        'x-api-key': 'deploy-validation-test-token-1',
+        'ocp-apim-subscription-key': 'azure-key',
+        cookie: 'session=secret',
+        accept: 'application/json',
+      },
+    });
+    const serializedResponse = requestLoggerOptions.serializers.res({
+      statusCode: 200,
+      headers: {
+        'set-cookie': ['session=secret'],
+        'content-type': 'application/json',
+      },
+    });
+
+    expect(mockStdSerializers.req).toHaveBeenCalledWith(expect.objectContaining({
+      method: 'GET',
+    }));
+    expect(mockStdSerializers.res).toHaveBeenCalledWith(expect.objectContaining({
+      statusCode: 200,
+    }));
+    expect(serializedRequest).toEqual({
+      id: 'req-123',
+      method: 'GET',
+      url: '/api/v1/accessibility/description',
+      headers: {
+        authorization: '[Redacted]',
+        'x-api-key': '[Redacted]',
+        'ocp-apim-subscription-key': '[Redacted]',
+        cookie: '[Redacted]',
+        accept: 'application/json',
+      },
+    });
+    expect(serializedResponse).toEqual({
+      statusCode: 200,
+      headers: {
+        'set-cookie': '[Redacted]',
+        'content-type': 'application/json',
+      },
+    });
   });
 
   it('sanitizes serialized errors before they reach the logger output', () => {


### PR DESCRIPTION
## Summary
- redact sensitive request and response auth headers before they are emitted by the pino HTTP logger
- keep the existing error sanitization and request logging flow intact
- add regression coverage for redacted request and response metadata

## Validation
- npm run lint
- npm ci --dry-run
- NODE_ENV=test REPLICATE_API_TOKEN=test-token npm test -- --runInBand