### PR TITLE
Stabilize low-cost provider release gates

### DIFF
--- a/.github/workflows/post-deploy-verification.yml
+++ b/.github/workflows/post-deploy-verification.yml
@@ -23,8 +23,8 @@ on:
         type: choice
         options:
           - auto
+          - huggingface
           - openai
-          - openrouter
           - all
 
 permissions:
@@ -60,16 +60,18 @@ jobs:
           VALIDATION_SUMMARY_TITLE: Post Deploy Verification
           INPUT_PROVIDER_SCOPE: ${{ github.event_name == 'workflow_dispatch' && inputs.provider_scope || 'all' }}
           LIVE_PROVIDER_SCOPE: ${{ github.event_name == 'workflow_dispatch' && inputs.provider_scope || 'all' }}
+          HF_API_KEY: ${{ secrets.HF_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: node scripts/github/resolve-provider-validation-scope.js
 
       - name: Run post-deploy Newman verification
         run: npm run postman:post-deploy -- --base-url "${BASE_URL}"
         env:
           LIVE_PROVIDER_SCOPE: ${{ env.LIVE_PROVIDER_SCOPE }}
+          HF_API_KEY: ${{ secrets.HF_API_KEY }}
+          HF_MODEL: Qwen/Qwen3-VL-30B-A3B-Instruct:fastest
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENAI_MODEL: gpt-4.1-nano
           PROVIDER_VALIDATION_PUBLIC_REF: production
 
       - name: Write deploy summary

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -30,18 +30,18 @@ jobs:
           VALIDATION_SUMMARY_TITLE: Pre Production Provider Validation
           INPUT_PROVIDER_SCOPE: all
           LIVE_PROVIDER_SCOPE: all
+          HF_API_KEY: ${{ secrets.HF_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: node scripts/github/resolve-provider-validation-scope.js
 
       - name: Run pre-production provider validation
         run: npm run postman:pre-production-provider
         env:
           LIVE_PROVIDER_SCOPE: ${{ env.LIVE_PROVIDER_SCOPE }}
+          HF_API_KEY: ${{ secrets.HF_API_KEY }}
+          HF_MODEL: Qwen/Qwen3-VL-30B-A3B-Instruct:fastest
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: gpt-4.1-nano
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          OPENROUTER_MODEL: google/gemma-3-4b-it:free
           PROVIDER_VALIDATION_PUBLIC_REF: ${{ github.sha }}
 
       - name: Upload pre-production provider artifacts

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -181,6 +181,7 @@ Modes:
   - appends raw Allure result files to `reports/allure-results/`
 - `npm run postman:pre-production-provider`
   - low-cost real-provider validation against the local app
+  - uses the Hugging Face plus OpenAI subset when both providers are configured
   - reuses repo-controlled public provider-validation fixtures so results can be compared directly with post-deploy validation
 - `npm run postman:live-provider`
   - production description-service validation
@@ -189,7 +190,7 @@ Modes:
   - supports `azure`, `replicate`, `huggingface`, `openai`, `openrouter`, or `all` through `LIVE_PROVIDER_SCOPE`
 - `npm run postman:post-deploy -- --base-url https://wcag.qcraft.com.br`
   - post-deploy smoke verification
-  - runs the post-deploy folders plus a low-cost live-provider subset and writes `post-deploy*.json` / `post-deploy*.xml`
+  - runs the post-deploy folders plus the same low-cost Hugging Face plus OpenAI subset and writes `post-deploy*.json` / `post-deploy*.xml`
 
 Contribution standards for folder naming, tier placement, and assertion policy are documented in [docs/postman-standards.md](./docs/postman-standards.md).
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Notes:
 - `postman:smoke` is the fast deterministic gate.
 - `postman:full` runs the full local provider-integration suite, including protected-endpoint auth coverage, mocked provider-validation coverage, and JSON/JUnit reports under `reports/newman/`.
 - CI also emits `reports/jest/junit.xml` from the canonical Node 20 Jest lane and publishes one combined GitHub test report that joins Jest and Newman results.
-- `postman:pre-production-provider` boots the app locally and runs the low-cost real-provider validation set used immediately before promotion.
+- `postman:pre-production-provider` boots the app locally and runs the low-cost real-provider validation set used immediately before promotion, currently Hugging Face plus OpenAI when both are configured.
 - `postman:live-provider` is the production description-service validation command for deployed-app plus live-provider checks against a supplied base URL.
 - `postman:post-deploy` runs post-deploy smoke plus the same low-cost real-provider validation set against a supplied base URL.
 - Before Newman starts, `postman:live-provider` and `postman:post-deploy` wait for consecutive stable health/auth probes so zero-downtime rollout overlap does not create false negatives.
@@ -98,7 +98,7 @@ Notes:
 - `LIVE_PROVIDER_SCOPE=auto` keeps the provider-validation preference order: Azure, then Replicate, then Hugging Face, then OpenRouter, then OpenAI.
 - `provider_scope=all` runs every provider that is configured for that environment; it does not require every supported provider to be enabled everywhere.
 - Local provider integration is fully mocked and never spends live provider credits.
-- Pre-production, post-deploy, and production live-provider checks all use repo-controlled public provider-validation fixtures so local and deployed real-provider validations compare the same inputs.
+- Pre-production and post-deploy use the low-cost Hugging Face plus OpenAI subset, while production live-provider validation can still run every configured provider against the same repo-controlled public provider-validation fixtures.
 - `postman:smoke` and `postman:full` use the local Postman environment; `postman:live-provider` and `postman:post-deploy` use the live Postman environment.
 - Outside GitHub Actions, set `PROVIDER_VALIDATION_PUBLIC_REF=<pushed-sha-or-ref>` if you need live-provider runs to use a branch-specific fixture revision before it lands on `main`.
 - Production live-provider validation refuses localhost/private-network targets.

--- a/scripts/postman/provider-validation-scope.js
+++ b/scripts/postman/provider-validation-scope.js
@@ -15,6 +15,10 @@ const VALID_PROVIDER_SCOPES = new Set([
     .map((provider) => provider.providerValidation.scopeKey),
   'all',
 ]);
+const LOW_COST_PROVIDER_VALIDATION_SCOPES = Object.freeze([
+  'huggingface',
+  'openai',
+]);
 
 const resolveConfiguredProviderScopes = ({
   configuredProviderScopes,
@@ -105,9 +109,18 @@ function normalizeProviderScope(
  *   hasReplicateProvider: boolean,
  * }}
  */
-function detectAvailableProviders(env = process.env) {
+function detectAvailableProviders(env = process.env, { allowedProviderScopes = null } = {}) {
+  const allowedProviderScopeSet = Array.isArray(allowedProviderScopes)
+    ? new Set(allowedProviderScopes)
+    : null;
   const configuredProviderScopes = getProviderValidationProviders()
-    .filter((provider) => provider.isConfiguredInEnv(env))
+    .filter((provider) => (
+      provider.isConfiguredInEnv(env)
+      && (
+        allowedProviderScopeSet === null
+        || allowedProviderScopeSet.has(provider.providerValidation.scopeKey)
+      )
+    ))
     .map((provider) => provider.providerValidation.scopeKey);
 
   return {
@@ -257,6 +270,7 @@ function getSelectedProviderFolders(scope, options) {
 }
 
 module.exports = {
+  LOW_COST_PROVIDER_VALIDATION_SCOPES,
   VALID_PROVIDER_SCOPES: Array.from(VALID_PROVIDER_SCOPES),
   detectAvailableProviders,
   getSelectedProviderFolders,

--- a/scripts/run-postman-deploy.js
+++ b/scripts/run-postman-deploy.js
@@ -13,6 +13,7 @@ const {
   readCollection,
 } = require('./postman/collection-utils');
 const {
+  LOW_COST_PROVIDER_VALIDATION_SCOPES,
   detectAvailableProviders,
   getSelectedProviderPlans,
   resolveProviderScope,
@@ -167,7 +168,9 @@ function parseArgs(argv) {
  * }}
  */
 function resolvePostDeployProviderPlans(env = process.env) {
-  const availableProviders = detectAvailableProviders(env);
+  const availableProviders = detectAvailableProviders(env, {
+    allowedProviderScopes: LOW_COST_PROVIDER_VALIDATION_SCOPES,
+  });
   const providerScope = resolveProviderScope({
     requestedScope: env.LIVE_PROVIDER_SCOPE,
     configuredScope: env.LIVE_PROVIDER_SCOPE,

--- a/scripts/run-postman-harness.js
+++ b/scripts/run-postman-harness.js
@@ -16,6 +16,7 @@ const {
   readCollection,
 } = require('./postman/collection-utils');
 const {
+  LOW_COST_PROVIDER_VALIDATION_SCOPES,
   getSelectedProviderPlans,
   resolveProviderScope,
   detectAvailableProviders,
@@ -463,7 +464,9 @@ async function main() {
   });
   const publicProviderValidationFixtures = buildPublicProviderValidationFixtureUrls();
   const availableLiveProviders = realProviderModeEnabled
-    ? detectAvailableProviders(process.env)
+    ? detectAvailableProviders(process.env, {
+      allowedProviderScopes: LOW_COST_PROVIDER_VALIDATION_SCOPES,
+    })
     : { configuredProviderScopes: LOCAL_PROVIDER_VALIDATION_SCOPES.slice() };
   const configuredProviderScopes = fullModeEnabled
     ? LOCAL_PROVIDER_VALIDATION_SCOPES.slice()

--- a/tests/unit/scripts/postman/providerValidationScope.test.js
+++ b/tests/unit/scripts/postman/providerValidationScope.test.js
@@ -1,4 +1,5 @@
 const {
+  LOW_COST_PROVIDER_VALIDATION_SCOPES,
   detectAvailableProviders,
   getSelectedProviderFolders,
   getSelectedProviderPlans,
@@ -26,6 +27,20 @@ describe('Unit | Scripts | Postman | Provider Validation Scope', () => {
   });
 
   describe('detectAvailableProviders', () => {
+    it('can restrict detection to an allowed provider subset', () => {
+      expect(detectAvailableProviders({
+        HF_API_KEY: 'hf-key',
+        OPENAI_API_KEY: 'openai-key',
+        OPENROUTER_API_KEY: 'openrouter-key',
+      }, {
+        allowedProviderScopes: LOW_COST_PROVIDER_VALIDATION_SCOPES,
+      })).toEqual({
+        configuredProviderScopes: ['huggingface', 'openai'],
+        hasAzureProvider: false,
+        hasReplicateProvider: false,
+      });
+    });
+
     it('detects replicate and azure independently', () => {
       expect(detectAvailableProviders({
         replicateApiToken: 'replicate-token',

--- a/tests/unit/scripts/runPostmanDeploy.test.js
+++ b/tests/unit/scripts/runPostmanDeploy.test.js
@@ -364,14 +364,15 @@ describe('Unit | Scripts | Run Postman Deploy', () => {
     it('keeps the post-deploy provider subset on low-cost providers only', () => {
       expect(resolvePostDeployProviderPlans({
         LIVE_PROVIDER_SCOPE: 'all',
+        HF_API_KEY: 'hf-key',
         OPENAI_API_KEY: 'openai-key',
         OPENROUTER_API_KEY: 'openrouter-key',
       })).toEqual({
         providerPlans: [
           {
-            envVars: ['model=openrouter'],
+            envVars: ['model=huggingface'],
             folderName: '90 Provider Validation',
-            scopeKey: 'openrouter',
+            scopeKey: 'huggingface',
           },
           {
             envVars: ['model=openai'],
@@ -403,6 +404,35 @@ describe('Unit | Scripts | Run Postman Deploy', () => {
       expect(workflow).toContain('npm run postman:post-deploy -- --base-url "$'
         + '{BASE_URL}"');
       expect(workflow).not.toContain('postman:deploy');
+    });
+
+    it('pins release validation workflows to Hugging Face plus OpenAI', () => {
+      const postDeployWorkflow = fs.readFileSync(
+        path.join(ROOT, '.github/workflows/post-deploy-verification.yml'),
+        'utf8',
+      );
+      const promoteWorkflow = fs.readFileSync(
+        path.join(ROOT, '.github/workflows/promote-to-production.yml'),
+        'utf8',
+      );
+
+      expect(postDeployWorkflow).toContain('HF_API_KEY: $'
+        + '{{ secrets.HF_API_KEY }}');
+      expect(postDeployWorkflow).toContain('HF_MODEL: Qwen/Qwen3-VL-30B-A3B-Instruct:fastest');
+      expect(postDeployWorkflow).toContain('OPENAI_API_KEY: $'
+        + '{{ secrets.OPENAI_API_KEY }}');
+      expect(postDeployWorkflow).toContain('OPENAI_MODEL: gpt-4.1-nano');
+      expect(postDeployWorkflow).not.toContain('OPENROUTER_API_KEY');
+      expect(postDeployWorkflow).not.toContain('OPENROUTER_MODEL');
+
+      expect(promoteWorkflow).toContain('HF_API_KEY: $'
+        + '{{ secrets.HF_API_KEY }}');
+      expect(promoteWorkflow).toContain('HF_MODEL: Qwen/Qwen3-VL-30B-A3B-Instruct:fastest');
+      expect(promoteWorkflow).toContain('OPENAI_API_KEY: $'
+        + '{{ secrets.OPENAI_API_KEY }}');
+      expect(promoteWorkflow).toContain('OPENAI_MODEL: gpt-4.1-nano');
+      expect(promoteWorkflow).not.toContain('OPENROUTER_API_KEY');
+      expect(promoteWorkflow).not.toContain('OPENROUTER_MODEL');
     });
   });
 });


### PR DESCRIPTION
## Summary
- pin the pre-production and post-deploy low-cost release gates to Hugging Face plus OpenAI
- keep OpenRouter in the manual/weekly all-provider production validation flow only
- add regression coverage so release workflows cannot drift back to the throttled free-route path

## Validation
- npm test -- --runInBand
- npm run lint
- npm run postman:full
- npm ci --dry-run