### PR TITLE
Enable Together provider validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,7 +97,7 @@ TLS_PORT=8443
 # Optional Together provider settings.
 # TOGETHER_API_KEY=
 # TOGETHER_BASE_URL=https://api.together.xyz/v1
-# TOGETHER_MODEL=meta-llama/Llama-4-Scout-17B-16E-Instruct
+# TOGETHER_MODEL=Qwen/Qwen3-VL-8B-Instruct
 # TOGETHER_MAX_TOKENS=160
 # TOGETHER_PROMPT=Write concise alt text for this image.
 

--- a/.github/workflows/live-provider-validation.yml
+++ b/.github/workflows/live-provider-validation.yml
@@ -20,6 +20,7 @@ on:
           - huggingface
           - openai
           - openrouter
+          - together
           - all
   schedule:
     - cron: '23 8 * * 1'
@@ -71,6 +72,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           HF_API_KEY: ${{ secrets.HF_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
           PROVIDER_VALIDATION_PUBLIC_REF: production
         run: node scripts/github/resolve-provider-validation-scope.js
 
@@ -88,6 +90,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           HF_API_KEY: ${{ secrets.HF_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
 
       - name: Upload production description service artifacts
         if: always()

--- a/.github/workflows/post-deploy-verification.yml
+++ b/.github/workflows/post-deploy-verification.yml
@@ -25,6 +25,8 @@ on:
           - auto
           - huggingface
           - openai
+          - openrouter
+          - together
           - all
 
 permissions:
@@ -62,6 +64,8 @@ jobs:
           LIVE_PROVIDER_SCOPE: ${{ github.event_name == 'workflow_dispatch' && inputs.provider_scope || 'all' }}
           HF_API_KEY: ${{ secrets.HF_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
         run: node scripts/github/resolve-provider-validation-scope.js
 
       - name: Run post-deploy Newman verification
@@ -72,6 +76,9 @@ jobs:
           HF_MODEL: Qwen/Qwen3-VL-30B-A3B-Instruct:fastest
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: gpt-4.1-nano
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENAI_MODEL: gpt-4.1-nano
+          TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
           PROVIDER_VALIDATION_PUBLIC_REF: production
 
       - name: Write deploy summary

--- a/.github/workflows/post-deploy-verification.yml
+++ b/.github/workflows/post-deploy-verification.yml
@@ -25,7 +25,6 @@ on:
           - auto
           - huggingface
           - openai
-          - openrouter
           - together
           - all
 
@@ -64,7 +63,6 @@ jobs:
           LIVE_PROVIDER_SCOPE: ${{ github.event_name == 'workflow_dispatch' && inputs.provider_scope || 'all' }}
           HF_API_KEY: ${{ secrets.HF_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
         run: node scripts/github/resolve-provider-validation-scope.js
 
@@ -75,8 +73,6 @@ jobs:
           HF_API_KEY: ${{ secrets.HF_API_KEY }}
           HF_MODEL: Qwen/Qwen3-VL-30B-A3B-Instruct:fastest
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_MODEL: gpt-4.1-nano
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OPENAI_MODEL: gpt-4.1-nano
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
           PROVIDER_VALIDATION_PUBLIC_REF: production

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -32,6 +32,8 @@ jobs:
           LIVE_PROVIDER_SCOPE: all
           HF_API_KEY: ${{ secrets.HF_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
         run: node scripts/github/resolve-provider-validation-scope.js
 
       - name: Run pre-production provider validation
@@ -42,6 +44,9 @@ jobs:
           HF_MODEL: Qwen/Qwen3-VL-30B-A3B-Instruct:fastest
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: gpt-4.1-nano
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENROUTER_MODEL: google/gemma-3-4b-it:free
+          TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
           PROVIDER_VALIDATION_PUBLIC_REF: ${{ github.sha }}
 
       - name: Upload pre-production provider artifacts

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -32,7 +32,6 @@ jobs:
           LIVE_PROVIDER_SCOPE: all
           HF_API_KEY: ${{ secrets.HF_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
         run: node scripts/github/resolve-provider-validation-scope.js
 
@@ -44,8 +43,6 @@ jobs:
           HF_MODEL: Qwen/Qwen3-VL-30B-A3B-Instruct:fastest
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: gpt-4.1-nano
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          OPENROUTER_MODEL: google/gemma-3-4b-it:free
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
           PROVIDER_VALIDATION_PUBLIC_REF: ${{ github.sha }}
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -181,7 +181,7 @@ Modes:
   - appends raw Allure result files to `reports/allure-results/`
 - `npm run postman:pre-production-provider`
   - low-cost real-provider validation against the local app
-  - uses the Hugging Face plus OpenAI subset when both providers are configured
+  - uses the Hugging Face, OpenAI, and Together subset when configured
   - reuses repo-controlled public provider-validation fixtures so results can be compared directly with post-deploy validation
 - `npm run postman:live-provider`
   - production description-service validation
@@ -190,7 +190,7 @@ Modes:
   - supports `azure`, `replicate`, `huggingface`, `openai`, `openrouter`, or `all` through `LIVE_PROVIDER_SCOPE`
 - `npm run postman:post-deploy -- --base-url https://wcag.qcraft.com.br`
   - post-deploy smoke verification
-  - runs the post-deploy folders plus the same low-cost Hugging Face plus OpenAI subset and writes `post-deploy*.json` / `post-deploy*.xml`
+  - runs the post-deploy folders plus the same low-cost Hugging Face, OpenAI, and Together subset and writes `post-deploy*.json` / `post-deploy*.xml`
 
 Contribution standards for folder naming, tier placement, and assertion policy are documented in [docs/postman-standards.md](./docs/postman-standards.md).
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -411,9 +411,9 @@ At least one provider must be configured at startup: `REPLICATE_API_TOKEN`, Azur
 | `OPENROUTER_PROMPT` | No | shared alt-text prompt | Prompt sent with the image. |
 | `OPENROUTER_HTTP_REFERER` | No | unset | Optional OpenRouter attribution header. |
 | `OPENROUTER_TITLE` | No | unset | Optional OpenRouter application title header. |
-| `TOGETHER_API_KEY` | No | none | Registers `together`. |
+| `TOGETHER_API_KEY` | No | none | Together AI API key. Registers `together`. |
 | `TOGETHER_BASE_URL` | No | `https://api.together.xyz/v1` | Together AI base URL. |
-| `TOGETHER_MODEL` | No | `meta-llama/Llama-4-Scout-17B-16E-Instruct` | Default Together multimodal model. |
+| `TOGETHER_MODEL` | No | `Qwen/Qwen3-VL-8B-Instruct` | Default Together multimodal model. |
 | `TOGETHER_MAX_TOKENS` | No | `160` | Max completion tokens for `together`. |
 | `TOGETHER_PROMPT` | No | shared alt-text prompt | Prompt sent with the image. |
 

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ Notes:
 - CI runs `postman:smoke` on pull requests and `postman:full` on `main` / `production` pushes.
 - Post-deploy verification runs `postman:post-deploy` on `production` pushes so smoke and low-cost provider checks stay inside the Newman contract layer.
 - Post-deploy verification also reads `PRODUCTION_API_AUTH_ENABLED` and `PRODUCTION_DEPLOY_VALIDATION_API_TOKEN` from the GitHub Actions environment so protected-endpoint checks match the deployed Render `API_AUTH_ENABLED` / `API_AUTH_TOKENS` state.
-- Provider-validation workflows use a single `LIVE_PROVIDER_SCOPE` enum: `auto`, `azure`, `replicate`, `huggingface`, `openai`, `openrouter`, or `all`.
-- `LIVE_PROVIDER_SCOPE=auto` keeps the provider-validation preference order: Azure, then Replicate, then Hugging Face, then OpenRouter, then OpenAI.
+- Provider-validation workflows use a single `LIVE_PROVIDER_SCOPE` enum: `auto`, `azure`, `replicate`, `huggingface`, `openai`, `openrouter`, `together`, or `all`.
+- `LIVE_PROVIDER_SCOPE=auto` keeps the provider-validation preference order: Azure, then Replicate, then Hugging Face, then OpenRouter, then OpenAI, then Together AI.
 - `provider_scope=all` runs every provider that is configured for that environment; it does not require every supported provider to be enabled everywhere.
 - Local provider integration is fully mocked and never spends live provider credits.
 - Pre-production and post-deploy use the low-cost Hugging Face plus OpenAI subset, while production live-provider validation can still run every configured provider against the same repo-controlled public provider-validation fixtures.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Notes:
 - `postman:smoke` is the fast deterministic gate.
 - `postman:full` runs the full local provider-integration suite, including protected-endpoint auth coverage, mocked provider-validation coverage, and JSON/JUnit reports under `reports/newman/`.
 - CI also emits `reports/jest/junit.xml` from the canonical Node 20 Jest lane and publishes one combined GitHub test report that joins Jest and Newman results.
-- `postman:pre-production-provider` boots the app locally and runs the low-cost real-provider validation set used immediately before promotion, currently Hugging Face plus OpenAI when both are configured.
+- `postman:pre-production-provider` boots the app locally and runs the low-cost real-provider validation set used immediately before promotion, currently Hugging Face, OpenAI, and Together when configured.
 - `postman:live-provider` is the production description-service validation command for deployed-app plus live-provider checks against a supplied base URL.
 - `postman:post-deploy` runs post-deploy smoke plus the same low-cost real-provider validation set against a supplied base URL.
 - Before Newman starts, `postman:live-provider` and `postman:post-deploy` wait for consecutive stable health/auth probes so zero-downtime rollout overlap does not create false negatives.
@@ -98,7 +98,7 @@ Notes:
 - `LIVE_PROVIDER_SCOPE=auto` keeps the provider-validation preference order: Azure, then Replicate, then Hugging Face, then OpenRouter, then OpenAI, then Together AI.
 - `provider_scope=all` runs every provider that is configured for that environment; it does not require every supported provider to be enabled everywhere.
 - Local provider integration is fully mocked and never spends live provider credits.
-- Pre-production and post-deploy use the low-cost Hugging Face plus OpenAI subset, while production live-provider validation can still run every configured provider against the same repo-controlled public provider-validation fixtures.
+- Pre-production and post-deploy use the low-cost Hugging Face, OpenAI, and Together subset, while production live-provider validation can still run every configured provider against the same repo-controlled public provider-validation fixtures.
 - `postman:smoke` and `postman:full` use the local Postman environment; `postman:live-provider` and `postman:post-deploy` use the live Postman environment.
 - Outside GitHub Actions, set `PROVIDER_VALIDATION_PUBLIC_REF=<pushed-sha-or-ref>` if you need live-provider runs to use a branch-specific fixture revision before it lands on `main`.
 - Production live-provider validation refuses localhost/private-network targets.

--- a/docs/openapi.base.json
+++ b/docs/openapi.base.json
@@ -93,6 +93,15 @@
             "required": true,
             "schema": {
               "type": "string",
+              "enum": [
+                "clip",
+                "azure",
+                "ollama",
+                "huggingface",
+                "openai",
+                "openrouter",
+                "together"
+              ],
               "example": "clip"
             }
           }
@@ -184,6 +193,15 @@
             "required": true,
             "schema": {
               "type": "string",
+              "enum": [
+                "clip",
+                "azure",
+                "ollama",
+                "huggingface",
+                "openai",
+                "openrouter",
+                "together"
+              ],
               "example": "clip"
             }
           }

--- a/scripts/github/resolve-provider-validation-scope.js
+++ b/scripts/github/resolve-provider-validation-scope.js
@@ -39,7 +39,7 @@ function appendSummary(summaryFile, lines) {
  * Resolves the provider-validation scope from the current environment.
  *
  * @param {NodeJS.ProcessEnv} env
- * @returns {'azure'|'replicate'|'huggingface'|'openai'|'openrouter'|'all'}
+ * @returns {'azure'|'replicate'|'huggingface'|'openai'|'openrouter'|'together'|'all'}
  */
 function resolveScopeFromEnv(env = process.env) {
   const availableProviders = detectAvailableProviders(env);

--- a/scripts/postman/provider-validation-scope.js
+++ b/scripts/postman/provider-validation-scope.js
@@ -75,7 +75,7 @@ const resolveSelectedProviderScopes = (scope, configuredProviderScopes = null) =
  *
  * @param {string|undefined|null} value
  * @param {{ label?: string, fallback?: string }} [options]
- * @returns {'auto'|'azure'|'replicate'|'huggingface'|'openai'|'openrouter'|'all'}
+ * @returns {'auto'|'azure'|'replicate'|'huggingface'|'openai'|'openrouter'|'together'|'all'}
  */
 function normalizeProviderScope(
   value,
@@ -142,7 +142,7 @@ function detectAvailableProviders(env = process.env, { allowedProviderScopes = n
  *   hasAzureProvider?: boolean|undefined,
  *   hasReplicateProvider?: boolean|undefined,
  * }} options
- * @returns {'azure'|'replicate'|'huggingface'|'openai'|'openrouter'|'all'}
+ * @returns {'azure'|'replicate'|'huggingface'|'openai'|'openrouter'|'together'|'all'}
  */
 function resolveProviderScope({
   requestedScope,
@@ -205,7 +205,7 @@ function resolveProviderScope({
 /**
  * Expands a resolved scope into provider booleans.
  *
- * @param {'azure'|'replicate'|'huggingface'|'openai'|'openrouter'|'all'} scope
+ * @param {'azure'|'replicate'|'huggingface'|'openai'|'openrouter'|'together'|'all'} scope
  * @returns {{
  *   selectedProviderScopes: string[],
  *   runAzure: boolean,
@@ -231,7 +231,7 @@ function getSelectedProviders(scope, { configuredProviderScopes } = {}) {
 /**
  * Builds provider-validation execution plans for the resolved provider scope.
  *
- * @param {'azure'|'replicate'|'huggingface'|'openai'|'openrouter'|'all'} scope
+ * @param {'azure'|'replicate'|'huggingface'|'openai'|'openrouter'|'together'|'all'} scope
  * @param {{ mode?: 'live'|'provider-integration' }} [options]
  * @returns {{ folderName: string, envVars: string[], scopeKey: string }[]}
  */

--- a/scripts/postman/provider-validation-scope.js
+++ b/scripts/postman/provider-validation-scope.js
@@ -18,6 +18,7 @@ const VALID_PROVIDER_SCOPES = new Set([
 const LOW_COST_PROVIDER_VALIDATION_SCOPES = Object.freeze([
   'huggingface',
   'openai',
+  'together',
 ]);
 
 const resolveConfiguredProviderScopes = ({

--- a/src/api/v1/controllers/descriptionController.js
+++ b/src/api/v1/controllers/descriptionController.js
@@ -50,6 +50,14 @@ class DescriptionController {
    *         required: true
    *         schema:
    *           type: string
+   *           enum:
+   *             - clip
+   *             - azure
+   *             - ollama
+   *             - huggingface
+   *             - openai
+   *             - openrouter
+   *             - together
    *           example: clip
    *     responses:
    *       200:
@@ -158,6 +166,14 @@ class DescriptionController {
    *         required: true
    *         schema:
    *           type: string
+   *           enum:
+   *             - clip
+   *             - azure
+   *             - ollama
+   *             - huggingface
+   *             - openai
+   *             - openrouter
+   *             - together
    *           example: clip
    *     responses:
    *       200:

--- a/src/providers/definitions/together.js
+++ b/src/providers/definitions/together.js
@@ -8,7 +8,17 @@ module.exports = buildOpenAiCompatibleProvider({
   baseUrlEnvName: 'TOGETHER_BASE_URL',
   defaultBaseUrl: 'https://api.together.xyz/v1',
   modelEnvName: 'TOGETHER_MODEL',
-  defaultModel: 'meta-llama/Llama-4-Scout-17B-16E-Instruct',
+  defaultModel: 'Qwen/Qwen3-VL-8B-Instruct',
   maxTokensEnvName: 'TOGETHER_MAX_TOKENS',
   promptEnvName: 'TOGETHER_PROMPT',
+  providerValidation: {
+    scopeKey: 'together',
+    autoPriority: 60,
+    folderName: '90 Provider Validation',
+    requestEnvVars: [
+      'model=together',
+    ],
+    scopeRequirement: 'TOGETHER_API_KEY',
+    allRequirement: 'TOGETHER_API_KEY',
+  },
 });

--- a/tests/unit/config/providerCatalog.test.js
+++ b/tests/unit/config/providerCatalog.test.js
@@ -89,7 +89,7 @@ describe('Unit | Config | Provider Catalog', () => {
       together: {
         apiKey: 'together-key',
         baseUrl: 'https://api.together.xyz/v1',
-        model: 'meta-llama/Llama-4-Scout-17B-16E-Instruct',
+        model: 'Qwen/Qwen3-VL-8B-Instruct',
         maxTokens: 160,
         prompt: expect.any(String),
         headers: {},
@@ -156,6 +156,9 @@ describe('Unit | Config | Provider Catalog', () => {
     expect(validateProviderEnv({
       OPENROUTER_TITLE: 'Alt Text 4 All',
     })[0]).toMatch(/OPENROUTER_API_KEY/);
+    expect(validateProviderEnv({
+      TOGETHER_MODEL: 'Qwen/Qwen3-VL-8B-Instruct',
+    })[0]).toMatch(/TOGETHER_API_KEY/);
     expect(getProviderCatalog().map((provider) => provider.key)).toEqual([
       'clip',
       'azure',
@@ -167,13 +170,14 @@ describe('Unit | Config | Provider Catalog', () => {
     ]);
     expect(
       getProviderValidationProviders().map((provider) => provider.providerValidation.scopeKey),
-    ).toEqual(['replicate', 'azure', 'huggingface', 'openai', 'openrouter']);
+    ).toEqual(['replicate', 'azure', 'huggingface', 'openai', 'openrouter', 'together']);
     expect(getAvailableProviderValidationScopes()).toEqual([
       'replicate',
       'azure',
       'huggingface',
       'openai',
       'openrouter',
+      'together',
     ]);
     expect(getProviderValidationByScope('azure').displayName).toBe('Azure Computer Vision');
   });

--- a/tests/unit/config/swagger.test.js
+++ b/tests/unit/config/swagger.test.js
@@ -90,8 +90,10 @@ describe('Unit | Config | Swagger', () => {
     const descriptionImageSource = descriptionParameters.find(
       (parameter) => parameter.name === 'image_source',
     );
+    const descriptionModel = descriptionParameters.find((parameter) => parameter.name === 'model');
     const pageParameters = swaggerSpec.paths['/api/accessibility/descriptions'].get.parameters;
     const pageUrl = pageParameters.find((parameter) => parameter.name === 'url');
+    const pageModel = pageParameters.find((parameter) => parameter.name === 'model');
     const scraperParameters = swaggerSpec.paths['/api/scraper/images'].get.parameters;
     const scraperUrl = scraperParameters.find((parameter) => parameter.name === 'url');
     const responseImageExample = swaggerSpec.paths['/api/accessibility/description']
@@ -106,6 +108,16 @@ describe('Unit | Config | Swagger', () => {
     );
     expect(pageUrl.schema.example).toBe('https%3A%2F%2Fdeveloper.chrome.com%2F');
     expect(scraperUrl.schema.example).toBe('https%3A%2F%2Fdeveloper.chrome.com%2F');
+    expect(descriptionModel.schema.enum).toEqual([
+      'clip',
+      'azure',
+      'ollama',
+      'huggingface',
+      'openai',
+      'openrouter',
+      'together',
+    ]);
+    expect(pageModel.schema.enum).toEqual(descriptionModel.schema.enum);
     expect(responseImageExample).toBe(
       'https://developer.chrome.com/static/images/ai-homepage-card.png',
     );

--- a/tests/unit/scripts/github/resolveProviderValidationScope.test.js
+++ b/tests/unit/scripts/github/resolveProviderValidationScope.test.js
@@ -29,6 +29,7 @@ describe('Unit | Scripts | GitHub | Resolve Provider Validation Scope', () => {
         HF_API_KEY: 'hf-key',
         OPENAI_API_KEY: 'openai-key',
         OPENROUTER_API_KEY: 'openrouter-key',
+        TOGETHER_API_KEY: 'together-key',
       })).toBe('all');
     });
 
@@ -64,6 +65,10 @@ describe('Unit | Scripts | GitHub | Resolve Provider Validation Scope', () => {
         INPUT_PROVIDER_SCOPE: 'huggingface',
         HF_API_KEY: 'hf-key',
       })).toBe('huggingface');
+      expect(resolveScopeFromEnv({
+        INPUT_PROVIDER_SCOPE: 'together',
+        TOGETHER_API_KEY: 'together-key',
+      })).toBe('together');
     });
   });
 

--- a/tests/unit/scripts/postman/providerValidationScope.test.js
+++ b/tests/unit/scripts/postman/providerValidationScope.test.js
@@ -21,7 +21,7 @@ describe('Unit | Scripts | Postman | Provider Validation Scope', () => {
 
     it('rejects unsupported scope values', () => {
       expect(() => normalizeProviderScope('both')).toThrow(
-        'provider scope must be one of: auto, azure, replicate, huggingface, openrouter, openai, all',
+        'provider scope must be one of: auto, azure, replicate, huggingface, openrouter, openai, together, all',
       );
     });
   });
@@ -73,8 +73,9 @@ describe('Unit | Scripts | Postman | Provider Validation Scope', () => {
         HF_API_KEY: 'hf-key',
         OPENAI_API_KEY: 'openai-key',
         OPENROUTER_API_KEY: 'openrouter-key',
+        TOGETHER_API_KEY: 'together-key',
       })).toEqual({
-        configuredProviderScopes: ['huggingface', 'openai', 'openrouter'],
+        configuredProviderScopes: ['huggingface', 'openai', 'openrouter', 'together'],
         hasAzureProvider: false,
         hasReplicateProvider: false,
       });
@@ -120,7 +121,7 @@ describe('Unit | Scripts | Postman | Provider Validation Scope', () => {
       expect(resolveProviderScope({
         requestedScope: 'auto',
         configuredScope: 'auto',
-        configuredProviderScopes: ['openrouter', 'openai', 'huggingface'],
+        configuredProviderScopes: ['openrouter', 'openai', 'huggingface', 'together'],
       })).toBe('huggingface');
     });
 
@@ -148,7 +149,7 @@ describe('Unit | Scripts | Postman | Provider Validation Scope', () => {
         configuredScope: 'auto',
         configuredProviderScopes: [],
       })).toThrow(
-        'provider validation requires Azure credentials, REPLICATE_API_TOKEN, HF_API_KEY or HF_TOKEN, OPENROUTER_API_KEY, OPENAI_API_KEY',
+        'provider validation requires Azure credentials, REPLICATE_API_TOKEN, HF_API_KEY or HF_TOKEN, OPENROUTER_API_KEY, OPENAI_API_KEY, TOGETHER_API_KEY',
       );
     });
   });
@@ -198,9 +199,21 @@ describe('Unit | Scripts | Postman | Provider Validation Scope', () => {
       ]);
     });
 
+    it('maps together to the shared neutral folder with production env vars', () => {
+      expect(getSelectedProviderPlans('together')).toEqual([
+        {
+          folderName: '90 Provider Validation',
+          envVars: [
+            'model=together',
+          ],
+          scopeKey: 'together',
+        },
+      ]);
+    });
+
     it('expands all using only configured provider plans', () => {
       expect(getSelectedProviderPlans('all', {
-        configuredProviderScopes: ['azure', 'openrouter'],
+        configuredProviderScopes: ['azure', 'openrouter', 'together'],
       })).toEqual([
         {
           folderName: '91 Azure Provider Validation',
@@ -214,6 +227,13 @@ describe('Unit | Scripts | Postman | Provider Validation Scope', () => {
           ],
           scopeKey: 'openrouter',
         },
+        {
+          folderName: '90 Provider Validation',
+          envVars: [
+            'model=together',
+          ],
+          scopeKey: 'together',
+        },
       ]);
     });
   });
@@ -221,7 +241,7 @@ describe('Unit | Scripts | Postman | Provider Validation Scope', () => {
   describe('getSelectedProviderFolders', () => {
     it('maps the all scope to the configured live provider folders', () => {
       expect(getSelectedProviderFolders('all', {
-        configuredProviderScopes: ['azure', 'openrouter'],
+        configuredProviderScopes: ['azure', 'openrouter', 'together'],
       })).toEqual([
         '91 Azure Provider Validation',
         '90 Provider Validation',

--- a/tests/unit/scripts/runPostmanDeploy.test.js
+++ b/tests/unit/scripts/runPostmanDeploy.test.js
@@ -412,7 +412,7 @@ describe('Unit | Scripts | Run Postman Deploy', () => {
       expect(workflow).not.toContain('postman:deploy');
     });
 
-    it('pins release validation workflows to Hugging Face plus OpenAI', () => {
+    it('pins release validation workflows to Hugging Face, OpenAI, and Together', () => {
       const postDeployWorkflow = fs.readFileSync(
         path.join(ROOT, '.github/workflows/post-deploy-verification.yml'),
         'utf8',
@@ -428,6 +428,8 @@ describe('Unit | Scripts | Run Postman Deploy', () => {
       expect(postDeployWorkflow).toContain('OPENAI_API_KEY: $'
         + '{{ secrets.OPENAI_API_KEY }}');
       expect(postDeployWorkflow).toContain('OPENAI_MODEL: gpt-4.1-nano');
+      expect(postDeployWorkflow).toContain('TOGETHER_API_KEY: $'
+        + '{{ secrets.TOGETHER_API_KEY }}');
       expect(postDeployWorkflow).not.toContain('OPENROUTER_API_KEY');
       expect(postDeployWorkflow).not.toContain('OPENROUTER_MODEL');
 
@@ -437,6 +439,8 @@ describe('Unit | Scripts | Run Postman Deploy', () => {
       expect(promoteWorkflow).toContain('OPENAI_API_KEY: $'
         + '{{ secrets.OPENAI_API_KEY }}');
       expect(promoteWorkflow).toContain('OPENAI_MODEL: gpt-4.1-nano');
+      expect(promoteWorkflow).toContain('TOGETHER_API_KEY: $'
+        + '{{ secrets.TOGETHER_API_KEY }}');
       expect(promoteWorkflow).not.toContain('OPENROUTER_API_KEY');
       expect(promoteWorkflow).not.toContain('OPENROUTER_MODEL');
     });

--- a/tests/unit/scripts/runPostmanDeploy.test.js
+++ b/tests/unit/scripts/runPostmanDeploy.test.js
@@ -367,6 +367,7 @@ describe('Unit | Scripts | Run Postman Deploy', () => {
         HF_API_KEY: 'hf-key',
         OPENAI_API_KEY: 'openai-key',
         OPENROUTER_API_KEY: 'openrouter-key',
+        TOGETHER_API_KEY: 'together-key',
       })).toEqual({
         providerPlans: [
           {
@@ -378,6 +379,11 @@ describe('Unit | Scripts | Run Postman Deploy', () => {
             envVars: ['model=openai'],
             folderName: '90 Provider Validation',
             scopeKey: 'openai',
+          },
+          {
+            envVars: ['model=together'],
+            folderName: '90 Provider Validation',
+            scopeKey: 'together',
           },
         ],
         providerScope: 'all',

--- a/tests/unit/utils/validateEnvVars.test.js
+++ b/tests/unit/utils/validateEnvVars.test.js
@@ -110,6 +110,17 @@ describe('Unit | Utils | Validate Env Vars', () => {
     expect(() => validateEnvVars()).not.toThrow();
   });
 
+  it('accepts a Together-only provider configuration', () => {
+    const validateEnvVars = loadValidator({
+      overrides: {
+        TOGETHER_API_KEY: 'together-key',
+      },
+      remove: ['REPLICATE_API_TOKEN', 'ACV_API_ENDPOINT', 'ACV_SUBSCRIPTION_KEY'],
+    });
+
+    expect(() => validateEnvVars()).not.toThrow();
+  });
+
   it('rejects startup when no provider is configured', () => {
     const validateEnvVars = loadValidator({
       remove: ['REPLICATE_API_TOKEN', 'ACV_API_ENDPOINT', 'ACV_SUBSCRIPTION_KEY'],


### PR DESCRIPTION
## Summary
- enable the Together provider on TOGETHER_API_KEY only and switch the default model to Qwen/Qwen3-VL-8B-Instruct
- add Together to provider-validation scope handling, live validation workflows, and the curated low-cost release gate subset
- tighten Swagger model docs and regenerate the committed OpenAPI artifact

## Verification
- npm run lint
- npm ci --dry-run
- NODE_ENV=test REPLICATE_API_TOKEN=test-token npm test -- --runInBand