### PR TITLE
fix: fetch pages state branch before syncing

### DIFF
--- a/scripts/github/sync-pages-state-branch.js
+++ b/scripts/github/sync-pages-state-branch.js
@@ -137,6 +137,24 @@ function remoteBranchRef(branch) {
  *   branch: string,
  *   repoDir: string,
  * }} options
+ * @returns {void}
+ */
+function fetchRemoteBranch({
+  branch,
+  repoDir,
+}) {
+  runGit({
+    allowFailure: true,
+    args: ['fetch', 'origin', `${branch}:${remoteBranchRef(branch)}`],
+    cwd: repoDir,
+  });
+}
+
+/**
+ * @param {{
+ *   branch: string,
+ *   repoDir: string,
+ * }} options
  * @returns {boolean}
  */
 function hasRemoteBranch({
@@ -222,6 +240,10 @@ async function syncPagesStateBranch({
   siteDir,
 }) {
   const worktreeDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'sync-pages-state-branch-'));
+  fetchRemoteBranch({
+    branch,
+    repoDir,
+  });
   const remoteBranchExists = hasRemoteBranch({
     branch,
     repoDir,
@@ -322,6 +344,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  fetchRemoteBranch,
   hasRemoteBranch,
   hasStagedChanges,
   parseArgs,

--- a/tests/unit/scripts/github/syncPagesStateBranch.test.js
+++ b/tests/unit/scripts/github/syncPagesStateBranch.test.js
@@ -4,6 +4,7 @@ const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 
 const {
+  fetchRemoteBranch,
   hasRemoteBranch,
   hasStagedChanges,
   parseArgs,
@@ -205,6 +206,65 @@ describe('Unit | Scripts | GitHub | Sync Pages State Branch', () => {
       expect(thirdSync.changed).toBe(true);
 
       runGit(publishedCloneDir, ['pull', '--ff-only']);
+      await expect(fs.readFile(path.join(publishedCloneDir, 'index.html'), 'utf8')).resolves.toBe('second-report');
+    } finally {
+      await fs.rm(rootDir, {
+        force: true,
+        recursive: true,
+      });
+    }
+  });
+
+  it('fetches and updates an existing remote state branch that is not present locally yet', async () => {
+    const {
+      repoDir,
+      rootDir,
+      siteDir,
+    } = await createRemoteRepo();
+
+    try {
+      await writeFile(path.join(siteDir, 'index.html'), 'first-report');
+      await writeFile(path.join(siteDir, '.nojekyll'), '');
+
+      await syncPagesStateBranch({
+        branch: 'gh-pages',
+        commitMessage: 'docs: sync first report',
+        repoDir,
+        siteDir,
+      });
+
+      const freshCloneDir = path.join(rootDir, 'fresh-clone');
+      runGit(rootDir, ['clone', path.join(rootDir, 'remote.git'), freshCloneDir]);
+      runGit(freshCloneDir, ['update-ref', '-d', 'refs/remotes/origin/gh-pages']);
+
+      expect(hasRemoteBranch({
+        branch: 'gh-pages',
+        repoDir: freshCloneDir,
+      })).toBe(false);
+
+      fetchRemoteBranch({
+        branch: 'gh-pages',
+        repoDir: freshCloneDir,
+      });
+
+      expect(hasRemoteBranch({
+        branch: 'gh-pages',
+        repoDir: freshCloneDir,
+      })).toBe(true);
+
+      await writeFile(path.join(siteDir, 'index.html'), 'second-report');
+
+      const syncResult = await syncPagesStateBranch({
+        branch: 'gh-pages',
+        commitMessage: 'docs: sync second report',
+        repoDir: freshCloneDir,
+        siteDir,
+      });
+
+      expect(syncResult.changed).toBe(true);
+
+      const publishedCloneDir = path.join(rootDir, 'published-state');
+      runGit(rootDir, ['clone', '--branch', 'gh-pages', path.join(rootDir, 'remote.git'), publishedCloneDir]);
       await expect(fs.readFile(path.join(publishedCloneDir, 'index.html'), 'utf8')).resolves.toBe('second-report');
     } finally {
       await fs.rm(rootDir, {


### PR DESCRIPTION
## Summary
- fetch `gh-pages` before checking whether the persistent Pages state branch exists
- avoid the non-fast-forward publish failure in clones that do not yet have `origin/gh-pages` locally
- add a regression test for that exact publish workflow scenario

## Validation
- `npm run lint`
- `npm test -- --runInBand`
- `ruby scripts/github/validate-workflow-yaml.rb`