### PR TITLE
fix: preserve PR allure reports on main publish

### DIFF
--- a/.github/workflows/allure-pages-publish.yml
+++ b/.github/workflows/allure-pages-publish.yml
@@ -39,6 +39,7 @@ jobs:
         id: source-run
         env:
           DISPATCH_RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.run_id || '' }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: >-
           node scripts/github/resolve-pages-source-run.js
           --github-output "${GITHUB_OUTPUT}"

--- a/scripts/github/compose-pages-site.js
+++ b/scripts/github/compose-pages-site.js
@@ -3,6 +3,8 @@
 const fs = require('node:fs/promises');
 const path = require('node:path');
 
+const PRESERVED_ROOT_ENTRIES = ['pr'];
+
 /**
  * @param {string[]} argv
  * @returns {{
@@ -105,6 +107,25 @@ async function copyDirectory(sourceDir, destinationDir) {
     force: true,
     recursive: true,
   });
+}
+
+/**
+ * @param {{
+ *   destinationDir: string,
+ *   entryNames: string[],
+ *   sourceDir: string,
+ * }} options
+ * @returns {Promise<void>}
+ */
+async function copyNamedEntries({
+  destinationDir,
+  entryNames,
+  sourceDir,
+}) {
+  await Promise.all(entryNames.map((entryName) => copyDirectory(
+    path.join(sourceDir, entryName),
+    path.join(destinationDir, entryName),
+  )));
 }
 
 /**
@@ -259,13 +280,22 @@ async function composePagesSite({
   });
   await fs.mkdir(outputDir, { recursive: true });
 
-  await copyDirectory(existingSiteDir, outputDir);
-  await fs.rm(targetDir, {
-    force: true,
-    recursive: true,
-  });
-  await fs.mkdir(path.dirname(targetDir), { recursive: true });
-  await copyDirectory(reportDir, targetDir);
+  if (normalizedPublishPath) {
+    await copyDirectory(existingSiteDir, outputDir);
+    await fs.rm(targetDir, {
+      force: true,
+      recursive: true,
+    });
+    await fs.mkdir(path.dirname(targetDir), { recursive: true });
+    await copyDirectory(reportDir, targetDir);
+  } else {
+    await copyDirectory(reportDir, outputDir);
+    await copyNamedEntries({
+      destinationDir: outputDir,
+      entryNames: PRESERVED_ROOT_ENTRIES,
+      sourceDir: existingSiteDir,
+    });
+  }
 
   await fs.writeFile(path.join(outputDir, '.nojekyll'), '', 'utf8');
   if (normalizedPublishPath) {

--- a/tests/unit/scripts/github/allurePagesPublishWorkflow.test.js
+++ b/tests/unit/scripts/github/allurePagesPublishWorkflow.test.js
@@ -16,6 +16,7 @@ describe('Unit | Workflows | Allure Pages Publish', () => {
     expect(workflowContents).toContain('name: allure-pages-metadata');
     expect(workflowContents).toContain('name: Resolve source workflow run');
     expect(workflowContents).toContain('node scripts/github/resolve-pages-source-run.js');
+    expect(workflowContents).toMatch(/GITHUB_TOKEN: \$\{\{ github\.token \}\}/u);
     expect(workflowContents).toContain('node scripts/github/read-pages-metadata.js');
     expect(workflowContents).toContain('node scripts/github/sync-pages-state-branch.js');
     expect(workflowContents).toMatch(/run-id: \$\{\{ steps\.source-run\.outputs\.run_id \}\}/u);

--- a/tests/unit/scripts/github/allurePagesWorkflow.test.js
+++ b/tests/unit/scripts/github/allurePagesWorkflow.test.js
@@ -32,5 +32,6 @@ describe('Unit | Workflows | CI Allure Pages', () => {
     expect(workflowContents).toContain('needs.allure-pages.result == \'success\'');
     expect(workflowContents).toContain('github.event.pull_request.head.repo.full_name == github.repository');
     expect(workflowContents).toContain('node scripts/github/dispatch-pages-publish.js');
+    expect(workflowContents).toContain('--ref "main"');
   });
 });

--- a/tests/unit/scripts/github/composePagesSite.test.js
+++ b/tests/unit/scripts/github/composePagesSite.test.js
@@ -88,6 +88,7 @@ describe('Unit | Scripts | GitHub | Compose Pages Site', () => {
 
     await writeFile(path.join(existingSiteDir, 'index.html'), 'old-main');
     await writeFile(path.join(existingSiteDir, 'history', 'old.json'), '{"history":true}');
+    await writeFile(path.join(existingSiteDir, 'pr', '111', 'index.html'), 'existing-pr');
     await writeFile(path.join(reportDir, 'index.html'), 'new-main');
     await writeFile(path.join(reportDir, 'data', 'widgets.json'), '{"widgets":true}');
 
@@ -100,6 +101,9 @@ describe('Unit | Scripts | GitHub | Compose Pages Site', () => {
 
     await expect(fs.readFile(path.join(outputDir, 'index.html'), 'utf8')).resolves.toBe('new-main');
     await expect(fs.readFile(path.join(outputDir, 'data', 'widgets.json'), 'utf8')).resolves.toBe('{"widgets":true}');
+    await expect(fs.readFile(path.join(outputDir, 'pr', '111', 'index.html'), 'utf8')).resolves.toBe('existing-pr');
+    await expect(fs.readFile(path.join(outputDir, 'pr', 'index.html'), 'utf8')).resolves.toContain('PR #111');
+    await expect(fs.access(path.join(outputDir, 'history', 'old.json'))).rejects.toThrow();
     await expect(fs.readFile(path.join(outputDir, '.nojekyll'), 'utf8')).resolves.toBe('');
     expect(result.publishPath).toBe('');
     expect(result.targetDir).toBe(outputDir);


### PR DESCRIPTION
## Summary
- preserve previously published PR Allure reports when republishing the root main report
- keep root report replacement strict so stale main-report files are still removed
- add a regression test covering the main-publish-after-PR-report scenario

## Validation
- npm run lint
- npm run postman:smoke
- GITHUB_API_URL=https://api.github.com GITHUB_REPOSITORY=jsugg/alt-text-generator GITHUB_TOKEN=test-token npm test -- --runInBand