### PR TITLE
Allow HTML provider fixtures served as text/plain

### DIFF
--- a/scripts/postman/provider-validation-fixture-probe.js
+++ b/scripts/postman/provider-validation-fixture-probe.js
@@ -7,6 +7,11 @@ const PROVIDER_VALIDATION_FIXTURE_EXPECTATIONS = Object.freeze({
   providerValidationPageUrl: 'text/html',
 });
 
+const ACCEPTABLE_HTML_CONTENT_TYPES = Object.freeze([
+  'text/html',
+  'text/plain',
+]);
+
 /**
  * @param {string} value
  * @returns {string}
@@ -30,10 +35,15 @@ async function assertFixtureResponse(response, key, url, expectedPrefix) {
   }
 
   const contentType = normalizeContentType(response.headers.get('content-type') || '');
-  if (!contentType.startsWith(expectedPrefix)) {
+  const acceptsHtmlFixture = expectedPrefix === 'text/html'
+    && ACCEPTABLE_HTML_CONTENT_TYPES.includes(contentType);
+  if (!acceptsHtmlFixture && !contentType.startsWith(expectedPrefix)) {
+    const expectedDescription = expectedPrefix === 'text/html'
+      ? 'text/html* or text/plain*'
+      : `${expectedPrefix}*`;
     throw new Error(
       `${key} returned content-type "${contentType || 'unknown'}" from ${url}; `
-        + `expected ${expectedPrefix}*`,
+        + `expected ${expectedDescription}`,
     );
   }
 

--- a/tests/unit/scripts/postman/providerValidationFixtureProbe.test.js
+++ b/tests/unit/scripts/postman/providerValidationFixtureProbe.test.js
@@ -33,6 +33,18 @@ const createHtmlResponse = (body = '<html><body><img src="/a.png" alt="" /></bod
   text: jest.fn().mockResolvedValue(body),
 });
 
+const createPlainTextHtmlResponse = (
+  body = '<html><body><img src="/a.png" alt="" /></body></html>',
+) => ({
+  ok: true,
+  status: 200,
+  statusText: 'OK',
+  headers: createHeaders({
+    'content-type': 'text/plain; charset=utf-8',
+  }),
+  text: jest.fn().mockResolvedValue(body),
+});
+
 describe('Unit | Scripts | Postman | Provider Validation Fixture Probe', () => {
   it('normalizes content types without charset noise', () => {
     expect(normalizeContentType('text/html; charset=utf-8')).toBe('text/html');
@@ -72,6 +84,24 @@ describe('Unit | Scripts | Postman | Provider Validation Fixture Probe', () => {
       fetchFn,
       writeLog: jest.fn(),
     })).rejects.toThrow('https://example.test/page.html does not look like an HTML fixture page');
+  });
+
+  it('accepts HTML fixture pages served as text/plain when the body is valid HTML', async () => {
+    const fetchFn = jest.fn(async (url) => (
+      url.endsWith('.html')
+        ? createPlainTextHtmlResponse()
+        : createImageResponse()
+    ));
+
+    await expect(assertProviderValidationFixturesReachable({
+      providerValidationImageUrl: 'https://example.test/assets/a.png',
+      providerValidationPageUrl: 'https://example.test/page.html',
+      providerValidationAzureImageUrl: 'https://example.test/assets/a.png',
+      providerValidationAzurePageUrl: 'https://example.test/page.html',
+    }, {
+      fetchFn,
+      writeLog: jest.fn(),
+    })).resolves.toBeUndefined();
   });
 
   it('fails when an image fixture returns the wrong content type', async () => {


### PR DESCRIPTION
## Summary
- accept provider validation HTML fixtures when GitHub Raw serves them as text/plain
- keep the HTML body integrity check so non-HTML fixtures still fail
- add regression coverage for the text/plain HTML case

## Validation
- npm run lint
- NODE_ENV=test REPLICATE_API_TOKEN=test-token npm test -- --runInBand
- npm ci --dry-run
- node scripts/postman/provider-validation-fixture-probe.js against the raw GitHub fixture URLs