### PR TITLE
refactor: rename clip model key to replicate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ PORT=8080
 TLS_PORT=8443
 
 # Configure at least one provider before booting the app.
-# Replicate enables the `clip` model.
+# Replicate enables the `replicate` model.
 # REPLICATE_API_TOKEN=replace-me
 # Azure enables the `azure` model.
 # ACV_API_ENDPOINT=https://example.cognitiveservices.azure.com/computervision/imageanalysis:analyze?api-version=2024-02-01
@@ -25,7 +25,7 @@ TLS_PORT=8443
 # REPLICATE_REQUEST_TIMEOUT_MS=15000
 # REPLICATE_POLL_INTERVAL_MS=500
 
-# Optional async description-job storage for slow providers such as `clip`.
+# Optional async description-job storage for slow providers such as `replicate`.
 # DESCRIPTION_JOB_STORE=auto
 # DESCRIPTION_JOB_REDIS_URL=redis://127.0.0.1:6379
 # DESCRIPTION_JOB_REDIS_PREFIX=alt-text-generator:description-jobs:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -174,7 +174,7 @@ Modes:
   - covers core smoke, route aliases, protected-endpoint auth, scraper contract, one Azure-stubbed description, and routing checks
 - `npm run postman:full`
   - full local provider-integration suite
-  - includes protected-endpoint auth, page descriptions, negative-path coverage, deterministic async `clip` page-job success/failure coverage, and mocked provider-validation coverage for `clip`, `azure`, `huggingface`, `openai`, and `openrouter`
+  - includes protected-endpoint auth, page descriptions, negative-path coverage, deterministic async `replicate` page-job success/failure coverage, and mocked provider-validation coverage for `replicate`, `azure`, `huggingface`, `openai`, and `openrouter`
   - writes JSON and JUnit reports to `reports/newman/`
 - `npm run postman:full:allure`
   - runs the same local full suite with the Allure reporter enabled
@@ -188,11 +188,11 @@ Modes:
   - targets a deployed base URL and waits for rollout stabilization before starting Newman
   - uses repo-controlled public provider-validation fixtures
   - supports `azure`, `replicate`, `huggingface`, `openai`, `openrouter`, `together`, or `all` through `LIVE_PROVIDER_SCOPE`
-  - follows async `202 Accepted` job polling automatically for slow providers such as Replicate-backed `clip`
+  - follows async `202 Accepted` job polling automatically for slow providers such as Replicate-backed `replicate`
 - `npm run postman:post-deploy -- --base-url https://wcag.qcraft.com.br`
   - post-deploy smoke verification
   - runs the post-deploy folders plus the same low-cost Hugging Face, OpenAI, and Together subset and writes `post-deploy*.json` / `post-deploy*.xml`
-  - does not automatically run `clip`; deterministic async `clip` coverage stays in `postman:full`, while manual `postman:live-provider` can validate Replicate against production on demand
+  - does not automatically run `replicate`; deterministic async `replicate` coverage stays in `postman:full`, while manual `postman:live-provider` can validate Replicate against production on demand
 
 Contribution standards for folder naming, tier placement, and assertion policy are documented in [docs/postman-standards.md](./docs/postman-standards.md).
 
@@ -204,7 +204,7 @@ Deterministic harness characteristics:
 - `postman:smoke` and `postman:full` use `postman/environments/alt-text-generator.local.postman_environment.json`
 - `postman:live-provider` and `postman:post-deploy` use `postman/environments/alt-text-generator.live.postman_environment.json`
 - configures mocked Azure, Replicate, and OpenAI-compatible providers to point at the fixture server stub endpoints during `postman:full`
-- the Replicate fixture is stateful, so `postman:full` exercises real async `202 -> poll -> terminal` clip page-job behavior instead of an instant-success shortcut
+- the Replicate fixture is stateful, so `postman:full` exercises real async `202 -> poll -> terminal` replicate page-job behavior instead of an instant-success shortcut
 - uses shared provider-validation fixtures from `tests/fixtures/provider-validation/public` for `postman:pre-production-provider`, `postman:live-provider`, and `postman:post-deploy`
 - runs Newman with insecure local TLS enabled because development certificates may be self-signed
 
@@ -255,7 +255,7 @@ Allure workflow:
 
 API routes that generate descriptions require a `model` query parameter. Today the runtime registers:
 
-- `clip` (Replicate-backed)
+- `replicate` (Replicate-backed)
   - single-image and page-description requests can return `202 Accepted` with a job payload when the provider stays slow beyond the configured inline wait window
 - `azure` (Azure Computer Vision-backed, registered only when `ACV_API_ENDPOINT` and
   `ACV_SUBSCRIPTION_KEY` are set)
@@ -320,7 +320,7 @@ Notes:
 | Variable | Required | Default | Description |
 | --- | --- | --- | --- |
 | `NODE_ENV` | No | `development` | Valid values: `development`, `production`, `test`. |
-| `REPLICATE_API_TOKEN` | No | none | Required only to register the `clip` provider and for real Replicate-backed descriptions. |
+| `REPLICATE_API_TOKEN` | No | none | Required only to register the `replicate` provider and for real Replicate-backed descriptions. |
 | `PAGE_DESCRIPTION_CONCURRENCY` | No | `3` | Max concurrent provider calls during one page-description request. |
 | `API_AUTH_ENABLED` | No | derived from `API_AUTH_TOKENS` | Explicitly enables or disables API auth. Defaults to `true` when `API_AUTH_TOKENS` contains at least one token, otherwise `false`. |
 | `API_AUTH_TOKENS` | No | unset | Optional comma-separated API tokens. When API auth is enabled, scraper and description endpoints require either `Authorization: Bearer <token>` or `X-API-Key: <token>`. |
@@ -367,7 +367,7 @@ Development TLS behavior:
 
 ### Async Description Job Controls
 
-These settings govern the single-image async handoff used by slow providers such as `clip`.
+These settings govern the single-image async handoff used by slow providers such as `replicate`.
 The current implementation uses provider polling rather than inbound webhooks.
 
 | Variable | Required | Default | Description |
@@ -382,7 +382,7 @@ The current implementation uses provider polling rather than inbound webhooks.
 | `DESCRIPTION_JOB_FAILED_TTL_MS` | No | `300000` | TTL for failed async jobs. |
 | `DESCRIPTION_JOB_CLAIM_TTL_MS` | No | `30000` | Lease window used to keep one runner responsible for a pending async description job while it is actively processing. |
 
-### Replicate (clip provider)
+### Replicate
 
 | Variable | Required | Default | Description |
 | --- | --- | --- | --- |
@@ -508,9 +508,9 @@ Do not collapse those into a single smoke test. Treat them as separate checks.
 | Docs | `GET /api-docs/` | `200 OK` | docs stack only |
 | Scraper preflight | `npm run doctor:tls -- <target>` | `200` or site-specific expected status | trust store / target policy |
 | Scraper API | `GET /api/scraper/images?...` | `200` with `imageSources` array | scraper logic or target policy |
-| Replicate execution | `GET /api/accessibility/description?...&model=clip` | `200` with non-empty description or `202` with a job payload | vendor account / model execution |
+| Replicate execution | `GET /api/accessibility/description?...&model=replicate` | `200` with non-empty description or `202` with a job payload | vendor account / model execution |
 | Azure execution | `GET /api/accessibility/description?...&model=azure` | `200` with non-empty description | Azure credentials / model execution |
-| Page orchestration | `GET /api/accessibility/descriptions?...&model=clip` | `200` with ordered `descriptions` array or `202` with a page-job payload | orchestration / provider reuse |
+| Page orchestration | `GET /api/accessibility/descriptions?...&model=replicate` | `200` with ordered `descriptions` array or `202` with a page-job payload | orchestration / provider reuse |
 
 ### Validation sequence (recommended)
 
@@ -537,7 +537,7 @@ curl -sk 'https://localhost:8443/api/scraper/images?url=https%3A%2F%2Fdeveloper.
 5. Validate Replicate through the app with a public image URL:
 
 ```bash
-curl -sk 'https://localhost:8443/api/accessibility/description?image_source=https%3A%2F%2Fwww.google.com%2Fimages%2Fbranding%2Fgooglelogo%2F1x%2Fgooglelogo_color_272x92dp.png&model=clip'
+curl -sk 'https://localhost:8443/api/accessibility/description?image_source=https%3A%2F%2Fwww.google.com%2Fimages%2Fbranding%2Fgooglelogo%2F1x%2Fgooglelogo_color_272x92dp.png&model=replicate'
 ```
 
 If the response is `202 Accepted`, poll the returned `statusUrl` until it becomes `200`:
@@ -555,7 +555,7 @@ curl -sk 'https://localhost:8443/api/accessibility/description?image_source=http
 7. Validate the page-level orchestration route:
 
 ```bash
-curl -sk 'https://localhost:8443/api/accessibility/descriptions?url=https%3A%2F%2Fdeveloper.chrome.com%2F&model=clip'
+curl -sk 'https://localhost:8443/api/accessibility/descriptions?url=https%3A%2F%2Fdeveloper.chrome.com%2F&model=replicate'
 ```
 
 If the response is `202 Accepted`, poll the returned `statusUrl` until it becomes `200`:

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ Alt-Text 4 All is an HTTPS-first API that scrapes website images and generates A
 The service exposes these primary capabilities:
 
 - discover image URLs on a target page
-- generate alt text for a specific image with provider-backed models such as `clip`, `azure`, `ollama`, `huggingface`, `openai`, `openrouter`, and `together`
+- generate alt text for a specific image with provider-backed models such as `replicate`, `azure`, `ollama`, `huggingface`, `openai`, `openrouter`, and `together`
 - generate alt text for all images on a page while preserving duplicate entries
 
 ## Features
 
 - Website image scraping with relative URL resolution
 - AI-generated descriptions for image URLs
-- Async job handoff for slow single-image and page-description providers such as Replicate-backed `clip`
+- Async job handoff for slow single-image and page-description providers such as Replicate-backed `replicate`
 - HTTPS-first local runtime with automatic HTTP -> HTTPS redirect
 - Swagger UI for interactive API exploration
 - Lint and test automation in CI
@@ -36,7 +36,7 @@ The service exposes these primary capabilities:
 - `engines.node` allows Node 20 through 24; use Node 20 locally for the least friction.
 - npm 10+
 - At least one provider configuration:
-  - `REPLICATE_API_TOKEN` for the `clip` model
+  - `REPLICATE_API_TOKEN` for the `replicate` model
   - or `ACV_API_ENDPOINT` plus `ACV_SUBSCRIPTION_KEY` for the `azure` model
   - or `OLLAMA_MODEL` / `OLLAMA_BASE_URL` for the `ollama` model
   - or `OPENAI_API_KEY`, `HF_API_KEY` / `HF_TOKEN`, `OPENROUTER_API_KEY`, or `TOGETHER_API_KEY`
@@ -85,7 +85,7 @@ npm run postman:post-deploy -- --base-url https://wcag.qcraft.com.br
 Notes:
 
 - `postman:smoke` is the fast deterministic gate.
-- `postman:full` runs the full local provider-integration suite, including protected-endpoint auth coverage, deterministic async `clip` page-job success/failure scenarios, mocked provider-validation coverage, and JSON/JUnit reports under `reports/newman/`.
+- `postman:full` runs the full local provider-integration suite, including protected-endpoint auth coverage, deterministic async `replicate` page-job success/failure scenarios, mocked provider-validation coverage, and JSON/JUnit reports under `reports/newman/`.
 - CI also emits `reports/jest/junit.xml` from the canonical Node 20 Jest lane and publishes one combined GitHub test report that joins Jest and Newman results.
 - `postman:pre-production-provider` boots the app locally and runs the low-cost real-provider validation set used immediately before promotion, currently Hugging Face, OpenAI, and Together when configured.
 - `postman:live-provider` is the production description-service validation command for deployed-app plus live-provider checks against a supplied base URL.
@@ -99,13 +99,13 @@ Notes:
 - `LIVE_PROVIDER_SCOPE=auto` keeps the provider-validation preference order: Azure, then Replicate, then Hugging Face, then OpenRouter, then OpenAI, then Together AI.
 - `provider_scope=all` runs every provider that is configured for that environment; it does not require every supported provider to be enabled everywhere.
 - Local provider integration is fully mocked and never spends live provider credits.
-- Pre-production and post-deploy use the low-cost Hugging Face, OpenAI, and Together subset. The async `clip` page-job path is covered deterministically in `postman:full`, and manual production live-provider validation can still run Replicate end to end against the same repo-controlled public provider-validation fixtures.
+- Pre-production and post-deploy use the low-cost Hugging Face, OpenAI, and Together subset. The async `replicate` page-job path is covered deterministically in `postman:full`, and manual production live-provider validation can still run Replicate end to end against the same repo-controlled public provider-validation fixtures.
 - `postman:smoke` and `postman:full` use the local Postman environment; `postman:live-provider` and `postman:post-deploy` use the live Postman environment.
 - Outside GitHub Actions, set `PROVIDER_VALIDATION_PUBLIC_REF=<pushed-sha-or-ref>` if you need live-provider runs to use a branch-specific fixture revision before it lands on `main`.
 - Production live-provider validation refuses localhost/private-network targets.
 - Provider-validation runs upload Newman artifacts and append request, assertion, failure, and response-time metrics to the GitHub Actions step summary.
 - Local harness runs accept self-signed development TLS.
-- The deterministic full suite uses local stubs for Azure, Replicate, and OpenAI-compatible provider request shapes. The Replicate stub is stateful, so local clip validation exercises the real `202 Accepted` polling contract instead of an instant success shortcut.
+- The deterministic full suite uses local stubs for Azure, Replicate, and OpenAI-compatible provider request shapes. The Replicate stub is stateful, so local replicate validation exercises the real `202 Accepted` polling contract instead of an instant success shortcut.
 
 Contribution standards for the contract suite live in [docs/postman-standards.md](./docs/postman-standards.md).
 
@@ -148,7 +148,7 @@ Notes:
 Required at startup:
 
 - At least one provider configuration:
-  - `REPLICATE_API_TOKEN` to register `clip`
+  - `REPLICATE_API_TOKEN` to register `replicate`
   - or `ACV_API_ENDPOINT` plus `ACV_SUBSCRIPTION_KEY` to register `azure`
   - or `OLLAMA_MODEL` / `OLLAMA_BASE_URL` to register `ollama`
   - or `OPENAI_API_KEY`, `HF_API_KEY` / `HF_TOKEN`, `OPENROUTER_API_KEY`, or `TOGETHER_API_KEY`
@@ -233,15 +233,15 @@ GET `/api/accessibility/description` or `/api/v1/accessibility/description`
 - Summary: returns an alt-text description for a given image
 - Query params:
   - `image_source`: URL-encoded address of the image
-  - `model`: AI model identifier, such as `clip`, `azure`, `ollama`, `huggingface`, `openai`, `openrouter`, or `together`
+  - `model`: AI model identifier, such as `replicate`, `azure`, `ollama`, `huggingface`, `openai`, `openrouter`, or `together`
 - Notes:
   - fast providers return `200` with the description array immediately
-  - slow async providers such as `clip` can return `202` with `jobId`, `status`, `pollAfterMs`, and `statusUrl`
+  - slow async providers such as `replicate` can return `202` with `jobId`, `status`, `pollAfterMs`, and `statusUrl`
 
 Example:
 
 ```bash
-curl -sk "https://localhost:8443/api/accessibility/description?image_source=https%3A%2F%2Fwww.google.com%2Fimages%2Fbranding%2Fgooglelogo%2F1x%2Fgooglelogo_color_272x92dp.png&model=clip"
+curl -sk "https://localhost:8443/api/accessibility/description?image_source=https%3A%2F%2Fwww.google.com%2Fimages%2Fbranding%2Fgooglelogo%2F1x%2Fgooglelogo_color_272x92dp.png&model=replicate"
 ```
 
 GET `/api/accessibility/description-jobs/:jobId` or `/api/v1/accessibility/description-jobs/:jobId`
@@ -262,17 +262,17 @@ GET `/api/accessibility/descriptions` or `/api/v1/accessibility/descriptions`
 - Summary: scrapes a page and returns descriptions for its images
 - Query params:
   - `url`: URL-encoded address of the target website
-  - `model`: AI model identifier, such as `clip`, `azure`, `ollama`, `huggingface`, `openai`, `openrouter`, or `together`
+  - `model`: AI model identifier, such as `replicate`, `azure`, `ollama`, `huggingface`, `openai`, `openrouter`, or `together`
 - Notes:
   - fast providers return `200` with the completed page-description payload
-  - slow async providers such as `clip` can return `202` with `jobId`, `status`, `pollAfterMs`, and `statusUrl`
+  - slow async providers such as `replicate` can return `202` with `jobId`, `status`, `pollAfterMs`, and `statusUrl`
   - preserves duplicate image entries in page order
   - reuses one prediction per unique normalized image URL per request
 
 Example:
 
 ```bash
-curl -sk "https://localhost:8443/api/accessibility/descriptions?url=https%3A%2F%2Fdeveloper.chrome.com%2F&model=clip"
+curl -sk "https://localhost:8443/api/accessibility/descriptions?url=https%3A%2F%2Fdeveloper.chrome.com%2F&model=replicate"
 ```
 
 GET `/api/accessibility/page-description-jobs/:jobId` or `/api/v1/accessibility/page-description-jobs/:jobId`

--- a/config/swagger-base.js
+++ b/config/swagger-base.js
@@ -86,7 +86,7 @@ const createSwaggerDefinition = () => ({
           },
           model: {
             type: 'string',
-            example: 'clip',
+            example: 'replicate',
           },
           imageUrl: {
             type: 'string',
@@ -143,7 +143,7 @@ const createSwaggerDefinition = () => ({
           },
           model: {
             type: 'string',
-            example: 'clip',
+            example: 'replicate',
           },
           pageUrl: {
             type: 'string',
@@ -171,7 +171,7 @@ const createSwaggerDefinition = () => ({
               },
               model: {
                 type: 'string',
-                example: 'clip',
+                example: 'replicate',
               },
               totalImages: {
                 type: 'integer',

--- a/docs/openapi.base.json
+++ b/docs/openapi.base.json
@@ -75,7 +75,7 @@
           },
           "model": {
             "type": "string",
-            "example": "clip"
+            "example": "replicate"
           },
           "imageUrl": {
             "type": "string",
@@ -144,7 +144,7 @@
           },
           "model": {
             "type": "string",
-            "example": "clip"
+            "example": "replicate"
           },
           "pageUrl": {
             "type": "string",
@@ -179,7 +179,7 @@
               },
               "model": {
                 "type": "string",
-                "example": "clip"
+                "example": "replicate"
               },
               "totalImages": {
                 "type": "integer",
@@ -228,7 +228,7 @@
     "/api/accessibility/description": {
       "get": {
         "summary": "Returns a description for a given image",
-        "description": "Takes an image URL and sends it to the selected AI model to generate an alt-text description. Slow asynchronous providers such as `clip` can return `202 Accepted` with a job status payload.",
+        "description": "Takes an image URL and sends it to the selected AI model to generate an alt-text description. Slow asynchronous providers such as `replicate` can return `202 Accepted` with a job status payload.",
         "security": [
           {
             "bearerAuth": []
@@ -251,12 +251,12 @@
           {
             "name": "model",
             "in": "query",
-            "description": "The AI model to use, for example `clip`, `azure`, `ollama`, `huggingface`, `openai`, `openrouter`, or `together`.",
+            "description": "The AI model to use, for example `replicate`, `azure`, `ollama`, `huggingface`, `openai`, `openrouter`, or `together`.",
             "required": true,
             "schema": {
               "type": "string",
               "enum": [
-                "clip",
+                "replicate",
                 "azure",
                 "ollama",
                 "huggingface",
@@ -264,7 +264,7 @@
                 "openrouter",
                 "together"
               ],
-              "example": "clip"
+              "example": "replicate"
             }
           }
         ],
@@ -348,7 +348,7 @@
     "/api/accessibility/descriptions": {
       "get": {
         "summary": "Returns descriptions for images found on a page",
-        "description": "Scrapes a website, preserves duplicate image entries in page order, and reuses a single prediction per unique image URL. Slow asynchronous providers such as `clip` can return `202 Accepted` with a page-description job payload.",
+        "description": "Scrapes a website, preserves duplicate image entries in page order, and reuses a single prediction per unique image URL. Slow asynchronous providers such as `replicate` can return `202 Accepted` with a page-description job payload.",
         "security": [
           {
             "bearerAuth": []
@@ -371,12 +371,12 @@
           {
             "name": "model",
             "in": "query",
-            "description": "The AI model to use, for example `clip`, `azure`, `ollama`, `huggingface`, `openai`, `openrouter`, or `together`.",
+            "description": "The AI model to use, for example `replicate`, `azure`, `ollama`, `huggingface`, `openai`, `openrouter`, or `together`.",
             "required": true,
             "schema": {
               "type": "string",
               "enum": [
-                "clip",
+                "replicate",
                 "azure",
                 "ollama",
                 "huggingface",
@@ -384,7 +384,7 @@
                 "openrouter",
                 "together"
               ],
-              "example": "clip"
+              "example": "replicate"
             }
           }
         ],

--- a/draft-potential-new-development-2.md
+++ b/draft-potential-new-development-2.md
@@ -174,7 +174,7 @@ Modes:
   - covers core smoke, route aliases, protected-endpoint auth, scraper contract, one Azure-stubbed description, and routing checks
 - `npm run postman:full`
   - full local provider-integration suite
-  - includes protected-endpoint auth, page descriptions, negative-path coverage, deterministic async `clip` page-job success/failure coverage, and mocked provider-validation coverage for `clip`, `azure`, `huggingface`, `openai`, and `openrouter`
+  - includes protected-endpoint auth, page descriptions, negative-path coverage, deterministic async `replicate` page-job success/failure coverage, and mocked provider-validation coverage for `replicate`, `azure`, `huggingface`, `openai`, and `openrouter`
   - writes JSON and JUnit reports to `reports/newman/`
 - `npm run postman:full:allure`
   - runs the same local full suite with the Allure reporter enabled
@@ -188,11 +188,11 @@ Modes:
   - targets a deployed base URL and waits for rollout stabilization before starting Newman
   - uses repo-controlled public provider-validation fixtures
   - supports `azure`, `replicate`, `huggingface`, `openai`, `openrouter`, `together`, or `all` through `LIVE_PROVIDER_SCOPE`
-  - follows async `202 Accepted` job polling automatically for slow providers such as Replicate-backed `clip`
+  - follows async `202 Accepted` job polling automatically for slow providers such as Replicate-backed `replicate`
 - `npm run postman:post-deploy -- --base-url https://wcag.qcraft.com.br`
   - post-deploy smoke verification
   - runs the post-deploy folders plus the same low-cost Hugging Face, OpenAI, and Together subset and writes `post-deploy*.json` / `post-deploy*.xml`
-  - does not automatically run `clip`; deterministic async `clip` coverage stays in `postman:full`, while manual `postman:live-provider` can validate Replicate against production on demand
+  - does not automatically run `replicate`; deterministic async `replicate` coverage stays in `postman:full`, while manual `postman:live-provider` can validate Replicate against production on demand
 
 Contribution standards for folder naming, tier placement, and assertion policy are documented in [docs/postman-standards.md](./docs/postman-standards.md).
 
@@ -204,7 +204,7 @@ Deterministic harness characteristics:
 - `postman:smoke` and `postman:full` use `postman/environments/alt-text-generator.local.postman_environment.json`
 - `postman:live-provider` and `postman:post-deploy` use `postman/environments/alt-text-generator.live.postman_environment.json`
 - configures mocked Azure, Replicate, and OpenAI-compatible providers to point at the fixture server stub endpoints during `postman:full`
-- the Replicate fixture is stateful, so `postman:full` exercises real async `202 -> poll -> terminal` clip page-job behavior instead of an instant-success shortcut
+- the Replicate fixture is stateful, so `postman:full` exercises real async `202 -> poll -> terminal` replicate page-job behavior instead of an instant-success shortcut
 - uses shared provider-validation fixtures from `tests/fixtures/provider-validation/public` for `postman:pre-production-provider`, `postman:live-provider`, and `postman:post-deploy`
 - runs Newman with insecure local TLS enabled because development certificates may be self-signed
 
@@ -255,7 +255,7 @@ Allure workflow:
 
 API routes that generate descriptions require a `model` query parameter. Today the runtime registers:
 
-- `clip` (Replicate-backed)
+- `replicate` (Replicate-backed)
   - single-image and page-description requests can return `202 Accepted` with a job payload when the provider stays slow beyond the configured inline wait window
 - `azure` (Azure Computer Vision-backed, registered only when `ACV_API_ENDPOINT` and
   `ACV_SUBSCRIPTION_KEY` are set)
@@ -320,7 +320,7 @@ Notes:
 | Variable | Required | Default | Description |
 | --- | --- | --- | --- |
 | `NODE_ENV` | No | `development` | Valid values: `development`, `production`, `test`. |
-| `REPLICATE_API_TOKEN` | No | none | Required only to register the `clip` provider and for real Replicate-backed descriptions. |
+| `REPLICATE_API_TOKEN` | No | none | Required only to register the `replicate` provider and for real Replicate-backed descriptions. |
 | `PAGE_DESCRIPTION_CONCURRENCY` | No | `3` | Max concurrent provider calls during one page-description request. |
 | `API_AUTH_ENABLED` | No | derived from `API_AUTH_TOKENS` | Explicitly enables or disables API auth. Defaults to `true` when `API_AUTH_TOKENS` contains at least one token, otherwise `false`. |
 | `API_AUTH_TOKENS` | No | unset | Optional comma-separated API tokens. When API auth is enabled, scraper and description endpoints require either `Authorization: Bearer <token>` or `X-API-Key: <token>`. |
@@ -367,7 +367,7 @@ Development TLS behavior:
 
 ### Async Description Job Controls
 
-These settings govern the single-image async handoff used by slow providers such as `clip`.
+These settings govern the single-image async handoff used by slow providers such as `replicate`.
 The current implementation uses provider polling rather than inbound webhooks.
 
 | Variable | Required | Default | Description |
@@ -382,7 +382,7 @@ The current implementation uses provider polling rather than inbound webhooks.
 | `DESCRIPTION_JOB_FAILED_TTL_MS` | No | `300000` | TTL for failed async jobs. |
 | `DESCRIPTION_JOB_CLAIM_TTL_MS` | No | `30000` | Lease window used to keep one runner responsible for a pending async description job while it is actively processing. |
 
-### Replicate (clip provider)
+### Replicate (replicate provider)
 
 | Variable | Required | Default | Description |
 | --- | --- | --- | --- |
@@ -508,9 +508,9 @@ Do not collapse those into a single smoke test. Treat them as separate checks.
 | Docs | `GET /api-docs/` | `200 OK` | docs stack only |
 | Scraper preflight | `npm run doctor:tls -- <target>` | `200` or site-specific expected status | trust store / target policy |
 | Scraper API | `GET /api/scraper/images?...` | `200` with `imageSources` array | scraper logic or target policy |
-| Replicate execution | `GET /api/accessibility/description?...&model=clip` | `200` with non-empty description or `202` with a job payload | vendor account / model execution |
+| Replicate execution | `GET /api/accessibility/description?...&model=replicate` | `200` with non-empty description or `202` with a job payload | vendor account / model execution |
 | Azure execution | `GET /api/accessibility/description?...&model=azure` | `200` with non-empty description | Azure credentials / model execution |
-| Page orchestration | `GET /api/accessibility/descriptions?...&model=clip` | `200` with ordered `descriptions` array or `202` with a page-job payload | orchestration / provider reuse |
+| Page orchestration | `GET /api/accessibility/descriptions?...&model=replicate` | `200` with ordered `descriptions` array or `202` with a page-job payload | orchestration / provider reuse |
 
 ### Validation sequence (recommended)
 
@@ -537,7 +537,7 @@ curl -sk 'https://localhost:8443/api/scraper/images?url=https%3A%2F%2Fdeveloper.
 5. Validate Replicate through the app with a public image URL:
 
 ```bash
-curl -sk 'https://localhost:8443/api/accessibility/description?image_source=https%3A%2F%2Fwww.google.com%2Fimages%2Fbranding%2Fgooglelogo%2F1x%2Fgooglelogo_color_272x92dp.png&model=clip'
+curl -sk 'https://localhost:8443/api/accessibility/description?image_source=https%3A%2F%2Fwww.google.com%2Fimages%2Fbranding%2Fgooglelogo%2F1x%2Fgooglelogo_color_272x92dp.png&model=replicate'
 ```
 
 If the response is `202 Accepted`, poll the returned `statusUrl` until it becomes `200`:
@@ -555,7 +555,7 @@ curl -sk 'https://localhost:8443/api/accessibility/description?image_source=http
 7. Validate the page-level orchestration route:
 
 ```bash
-curl -sk 'https://localhost:8443/api/accessibility/descriptions?url=https%3A%2F%2Fdeveloper.chrome.com%2F&model=clip'
+curl -sk 'https://localhost:8443/api/accessibility/descriptions?url=https%3A%2F%2Fdeveloper.chrome.com%2F&model=replicate'
 ```
 
 If the response is `202 Accepted`, poll the returned `statusUrl` until it becomes `200`:

--- a/draft-potential-new-readme-2.md
+++ b/draft-potential-new-readme-2.md
@@ -16,14 +16,14 @@ Alt-Text 4 All is an HTTPS-first API that scrapes website images and generates A
 The service exposes these primary capabilities:
 
 - discover image URLs on a target page
-- generate alt text for a specific image with provider-backed models such as `clip`, `azure`, `ollama`, `huggingface`, `openai`, `openrouter`, and `together`
+- generate alt text for a specific image with provider-backed models such as `replicate`, `azure`, `ollama`, `huggingface`, `openai`, `openrouter`, and `together`
 - generate alt text for all images on a page while preserving duplicate entries
 
 ## Features
 
 - Website image scraping with relative URL resolution
 - AI-generated descriptions for image URLs
-- Async job handoff for slow single-image and page-description providers such as Replicate-backed `clip`
+- Async job handoff for slow single-image and page-description providers such as Replicate-backed `replicate`
 - HTTPS-first local runtime with automatic HTTP -> HTTPS redirect
 - Swagger UI for interactive API exploration
 - Lint and test automation in CI
@@ -36,7 +36,7 @@ The service exposes these primary capabilities:
 - `engines.node` allows Node 20 through 24; use Node 20 locally for the least friction.
 - npm 10+
 - At least one provider configuration:
-  - `REPLICATE_API_TOKEN` for the `clip` model
+  - `REPLICATE_API_TOKEN` for the `replicate` model
   - or `ACV_API_ENDPOINT` plus `ACV_SUBSCRIPTION_KEY` for the `azure` model
   - or `OLLAMA_MODEL` / `OLLAMA_BASE_URL` for the `ollama` model
   - or `OPENAI_API_KEY`, `HF_API_KEY` / `HF_TOKEN`, `OPENROUTER_API_KEY`, or `TOGETHER_API_KEY`
@@ -85,7 +85,7 @@ npm run postman:post-deploy -- --base-url https://wcag.qcraft.com.br
 Notes:
 
 - `postman:smoke` is the fast deterministic gate.
-- `postman:full` runs the full local provider-integration suite, including protected-endpoint auth coverage, deterministic async `clip` page-job success/failure scenarios, mocked provider-validation coverage, and JSON/JUnit reports under `reports/newman/`.
+- `postman:full` runs the full local provider-integration suite, including protected-endpoint auth coverage, deterministic async `replicate` page-job success/failure scenarios, mocked provider-validation coverage, and JSON/JUnit reports under `reports/newman/`.
 - CI also emits `reports/jest/junit.xml` from the canonical Node 20 Jest lane and publishes one combined GitHub test report that joins Jest and Newman results.
 - `postman:pre-production-provider` boots the app locally and runs the low-cost real-provider validation set used immediately before promotion, currently Hugging Face, OpenAI, and Together when configured.
 - `postman:live-provider` is the production description-service validation command for deployed-app plus live-provider checks against a supplied base URL.
@@ -99,13 +99,13 @@ Notes:
 - `LIVE_PROVIDER_SCOPE=auto` keeps the provider-validation preference order: Azure, then Replicate, then Hugging Face, then OpenRouter, then OpenAI, then Together AI.
 - `provider_scope=all` runs every provider that is configured for that environment; it does not require every supported provider to be enabled everywhere.
 - Local provider integration is fully mocked and never spends live provider credits.
-- Pre-production and post-deploy use the low-cost Hugging Face, OpenAI, and Together subset. The async `clip` page-job path is covered deterministically in `postman:full`, and manual production live-provider validation can still run Replicate end to end against the same repo-controlled public provider-validation fixtures.
+- Pre-production and post-deploy use the low-cost Hugging Face, OpenAI, and Together subset. The async `replicate` page-job path is covered deterministically in `postman:full`, and manual production live-provider validation can still run Replicate end to end against the same repo-controlled public provider-validation fixtures.
 - `postman:smoke` and `postman:full` use the local Postman environment; `postman:live-provider` and `postman:post-deploy` use the live Postman environment.
 - Outside GitHub Actions, set `PROVIDER_VALIDATION_PUBLIC_REF=<pushed-sha-or-ref>` if you need live-provider runs to use a branch-specific fixture revision before it lands on `main`.
 - Production live-provider validation refuses localhost/private-network targets.
 - Provider-validation runs upload Newman artifacts and append request, assertion, failure, and response-time metrics to the GitHub Actions step summary.
 - Local harness runs accept self-signed development TLS.
-- The deterministic full suite uses local stubs for Azure, Replicate, and OpenAI-compatible provider request shapes. The Replicate stub is stateful, so local clip validation exercises the real `202 Accepted` polling contract instead of an instant success shortcut.
+- The deterministic full suite uses local stubs for Azure, Replicate, and OpenAI-compatible provider request shapes. The Replicate stub is stateful, so local replicate validation exercises the real `202 Accepted` polling contract instead of an instant success shortcut.
 
 Contribution standards for the contract suite live in [docs/postman-standards.md](./docs/postman-standards.md).
 
@@ -148,7 +148,7 @@ Notes:
 Required at startup:
 
 - At least one provider configuration:
-  - `REPLICATE_API_TOKEN` to register `clip`
+  - `REPLICATE_API_TOKEN` to register `replicate`
   - or `ACV_API_ENDPOINT` plus `ACV_SUBSCRIPTION_KEY` to register `azure`
   - or `OLLAMA_MODEL` / `OLLAMA_BASE_URL` to register `ollama`
   - or `OPENAI_API_KEY`, `HF_API_KEY` / `HF_TOKEN`, `OPENROUTER_API_KEY`, or `TOGETHER_API_KEY`
@@ -233,15 +233,15 @@ GET `/api/accessibility/description` or `/api/v1/accessibility/description`
 - Summary: returns an alt-text description for a given image
 - Query params:
   - `image_source`: URL-encoded address of the image
-  - `model`: AI model identifier, such as `clip`, `azure`, `ollama`, `huggingface`, `openai`, `openrouter`, or `together`
+  - `model`: AI model identifier, such as `replicate`, `azure`, `ollama`, `huggingface`, `openai`, `openrouter`, or `together`
 - Notes:
   - fast providers return `200` with the description array immediately
-  - slow async providers such as `clip` can return `202` with `jobId`, `status`, `pollAfterMs`, and `statusUrl`
+  - slow async providers such as `replicate` can return `202` with `jobId`, `status`, `pollAfterMs`, and `statusUrl`
 
 Example:
 
 ```bash
-curl -sk "https://localhost:8443/api/accessibility/description?image_source=https%3A%2F%2Fwww.google.com%2Fimages%2Fbranding%2Fgooglelogo%2F1x%2Fgooglelogo_color_272x92dp.png&model=clip"
+curl -sk "https://localhost:8443/api/accessibility/description?image_source=https%3A%2F%2Fwww.google.com%2Fimages%2Fbranding%2Fgooglelogo%2F1x%2Fgooglelogo_color_272x92dp.png&model=replicate"
 ```
 
 GET `/api/accessibility/description-jobs/:jobId` or `/api/v1/accessibility/description-jobs/:jobId`
@@ -262,17 +262,17 @@ GET `/api/accessibility/descriptions` or `/api/v1/accessibility/descriptions`
 - Summary: scrapes a page and returns descriptions for its images
 - Query params:
   - `url`: URL-encoded address of the target website
-  - `model`: AI model identifier, such as `clip`, `azure`, `ollama`, `huggingface`, `openai`, `openrouter`, or `together`
+  - `model`: AI model identifier, such as `replicate`, `azure`, `ollama`, `huggingface`, `openai`, `openrouter`, or `together`
 - Notes:
   - fast providers return `200` with the completed page-description payload
-  - slow async providers such as `clip` can return `202` with `jobId`, `status`, `pollAfterMs`, and `statusUrl`
+  - slow async providers such as `replicate` can return `202` with `jobId`, `status`, `pollAfterMs`, and `statusUrl`
   - preserves duplicate image entries in page order
   - reuses one prediction per unique normalized image URL per request
 
 Example:
 
 ```bash
-curl -sk "https://localhost:8443/api/accessibility/descriptions?url=https%3A%2F%2Fdeveloper.chrome.com%2F&model=clip"
+curl -sk "https://localhost:8443/api/accessibility/descriptions?url=https%3A%2F%2Fdeveloper.chrome.com%2F&model=replicate"
 ```
 
 GET `/api/accessibility/page-description-jobs/:jobId` or `/api/v1/accessibility/page-description-jobs/:jobId`

--- a/jobs.md
+++ b/jobs.md
@@ -6,13 +6,13 @@ Updated: 2026-03-14 11:28:05Z
 
 - Project: `alt-text-generator`
 - Current production symptom:
-  - `clip` requests to `https://wcag.qcraft.com.br/api/v1/accessibility/description` hang for a long time and do not return a response body in a reasonable window.
+  - `replicate` requests to `https://wcag.qcraft.com.br/api/v1/accessibility/description` hang for a long time and do not return a response body in a reasonable window.
   - Verified behavior:
     - `azure`, `huggingface`, `openai`, `openrouter`, and `together` returned `200` with usable descriptions.
     - `ollama` is not enabled in production and returns `400 UNKNOWN_MODEL`.
-    - `clip` timed out at 20s, 45s, and 120s with `curl` receiving `0` bytes.
+    - `replicate` timed out at 20s, 45s, and 120s with `curl` receiving `0` bytes.
 - Current implementation:
-  - The Replicate provider is wired by `src/providers/definitions/clip.js`.
+  - The Replicate provider is wired by `src/providers/definitions/replicate.js`.
   - The request path blocks on `replicate.run()` inside `src/services/ReplicateDescriberService.js`.
   - The single-image controller awaits `describer.describeImage(imageSource)` directly inside the user request lifecycle.
   - The page-description controller and service also reuse the same provider path.
@@ -36,7 +36,7 @@ const output = await this.replicate.run(modelRef, {
 
 ### Production evidence
 
-- Render logs show `clip` requests reaching the app and logging `Generating alt text` with:
+- Render logs show `replicate` requests reaching the app and logging `Generating alt text` with:
   - model ref `rmokady/clip_prefix_caption:9a34a6339872a03f45236f114321fb51fc7aa8269d38ae0ce5334969981e4cd8`
 - The same logs show request completion only after the client had already disconnected, with null/unfinished response state on the app side.
 - This means the app is not rejecting the request quickly; it is waiting too long on upstream prediction completion.
@@ -75,7 +75,7 @@ const output = await this.replicate.run(modelRef, {
    - Good hardening step.
    - Still not the best final architecture.
 
-3. Switch `clip` to an asynchronous prediction workflow with job status and result caching.
+3. Switch `replicate` to an asynchronous prediction workflow with job status and result caching.
    - Best fit for long-running or bursty providers.
    - Clean separation between request lifecycle and prediction lifecycle.
    - Compatible with a future warm deployment if needed.
@@ -88,11 +88,11 @@ const output = await this.replicate.run(modelRef, {
 
 ### Goal
 
-Implement a robust async `clip` flow for single-image descriptions, while also hardening the legacy synchronous `clip` usage so it fails cleanly instead of hanging indefinitely.
+Implement a robust async `replicate` flow for single-image descriptions, while also hardening the legacy synchronous `replicate` usage so it fails cleanly instead of hanging indefinitely.
 
 ### Scope
 
-- Add durable description job orchestration for async-capable providers, starting with `clip`.
+- Add durable description job orchestration for async-capable providers, starting with `replicate`.
 - Keep existing synchronous behavior for fast providers.
 - Keep Swagger/OpenAPI docs current.
 - Add tests for controller behavior, job orchestration, and Replicate provider behavior.
@@ -116,7 +116,7 @@ Implement a robust async `clip` flow for single-image descriptions, while also h
 
 4. Update the single-image controller:
    - fast providers: unchanged `200`
-   - async providers like `clip`:
+   - async providers like `replicate`:
      - return cached result immediately if available
      - otherwise start/reuse a job
      - wait a short bounded window
@@ -146,7 +146,7 @@ Implement a robust async `clip` flow for single-image descriptions, while also h
 ### Validation plan
 
 - Run targeted unit tests for new services and controllers.
-- Run integration tests for the new async `clip` flow.
+- Run integration tests for the new async `replicate` flow.
 - Run full `npm test`.
 - Run `npm run lint`.
 - Regenerate and validate Swagger/OpenAPI docs.

--- a/postman/collections/alt-text-generator.postman_collection.json
+++ b/postman/collections/alt-text-generator.postman_collection.json
@@ -1477,7 +1477,7 @@
       "name": "35 Async Page Description Jobs (Clip Stub)",
       "item": [
         {
-          "name": "Start async clip page description success",
+          "name": "Start async replicate page description success",
           "request": {
             "method": "GET",
             "header": [
@@ -1508,7 +1508,7 @@
                 },
                 {
                   "key": "model",
-                  "value": "clip"
+                  "value": "replicate"
                 }
               ]
             }
@@ -1520,14 +1520,14 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('clip page descriptions return 202 while the async job is pending', function () {",
+                  "pm.test('replicate page descriptions return 202 while the async job is pending', function () {",
                   "  pm.response.to.have.status(202);",
                   "});",
                   "",
                   "const body = pm.response.json();",
                   "",
-                  "pm.test('pending clip page job response contains expected metadata', function () {",
-                  "  pm.expect(body.model).to.eql('clip');",
+                  "pm.test('pending replicate page job response contains expected metadata', function () {",
+                  "  pm.expect(body.model).to.eql('replicate');",
                   "  pm.expect(body.pageUrl).to.eql(pm.environment.get('samplePageUrl'));",
                   "  pm.expect(body.status).to.match(/^(pending|processing)$/);",
                   "  pm.expect(body.pollAfterMs).to.be.a('number');",
@@ -1536,14 +1536,14 @@
                   "",
                   "pm.collectionVariables.set('asyncClipSuccessPageJobStatusUrl', body.statusUrl);",
                   "pm.collectionVariables.set('asyncClipSuccessPageJobPollCount', '0');",
-                  "pm.execution.setNextRequest('Poll async clip page description success');"
+                  "pm.execution.setNextRequest('Poll async replicate page description success');"
                 ]
               }
             }
           ]
         },
         {
-          "name": "Poll async clip page description success",
+          "name": "Poll async replicate page description success",
           "request": {
             "method": "GET",
             "header": [
@@ -1569,25 +1569,25 @@
                   "pm.collectionVariables.set('asyncClipSuccessPageJobPollCount', String(attempt));",
                   "",
                   "if (pm.response.code === 202) {",
-                  "  pm.test('clip page job stays pending until completion', function () {",
+                  "  pm.test('replicate page job stays pending until completion', function () {",
                   "    pm.expect(body.status).to.match(/^(pending|processing)$/);",
                   "    pm.expect(body.statusUrl).to.eql(pm.collectionVariables.get('asyncClipSuccessPageJobStatusUrl'));",
                   "  });",
-                  "  pm.test('clip page job polling stays within the attempt budget', function () {",
+                  "  pm.test('replicate page job polling stays within the attempt budget', function () {",
                   "    pm.expect(attempt).to.be.below(30);",
                   "  });",
                   "  const delayMs = Number(body.pollAfterMs || 0);",
-                  "  setTimeout(() => pm.execution.setNextRequest('Poll async clip page description success'), delayMs);",
+                  "  setTimeout(() => pm.execution.setNextRequest('Poll async replicate page description success'), delayMs);",
                   "} else {",
-                  "  pm.test('clip page job eventually returns 200', function () {",
+                  "  pm.test('replicate page job eventually returns 200', function () {",
                   "    pm.response.to.have.status(200);",
                   "  });",
-                  "  pm.test('terminal clip page job succeeded with expected payload', function () {",
+                  "  pm.test('terminal replicate page job succeeded with expected payload', function () {",
                   "    pm.expect(body.status).to.eql('succeeded');",
-                  "    pm.expect(body.model).to.eql('clip');",
+                  "    pm.expect(body.model).to.eql('replicate');",
                   "    pm.expect(body.pageUrl).to.eql(expectedPageUrl);",
                   "    pm.expect(body.result.pageUrl).to.eql(expectedPageUrl);",
-                  "    pm.expect(body.result.model).to.eql('clip');",
+                  "    pm.expect(body.result.model).to.eql('replicate');",
                   "    pm.expect(body.result.totalImages).to.eql(3);",
                   "    pm.expect(body.result.uniqueImages).to.eql(2);",
                   "    pm.expect(body.result.descriptions.map((item) => item.imageUrl)).to.eql([",
@@ -1601,7 +1601,7 @@
                   "  });",
                   "  pm.collectionVariables.unset('asyncClipSuccessPageJobStatusUrl');",
                   "  pm.collectionVariables.unset('asyncClipSuccessPageJobPollCount');",
-                  "  pm.execution.setNextRequest('Start async clip page description failure');",
+                  "  pm.execution.setNextRequest('Start async replicate page description failure');",
                   "}"
                 ]
               }
@@ -1609,7 +1609,7 @@
           ]
         },
         {
-          "name": "Start async clip page description failure",
+          "name": "Start async replicate page description failure",
           "request": {
             "method": "GET",
             "header": [
@@ -1640,7 +1640,7 @@
                 },
                 {
                   "key": "model",
-                  "value": "clip"
+                  "value": "replicate"
                 }
               ]
             }
@@ -1652,14 +1652,14 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('clip provider failure page returns 202 while the async job is pending', function () {",
+                  "pm.test('replicate provider failure page returns 202 while the async job is pending', function () {",
                   "  pm.response.to.have.status(202);",
                   "});",
                   "",
                   "const body = pm.response.json();",
                   "",
-                  "pm.test('failed clip page job response contains expected metadata', function () {",
-                  "  pm.expect(body.model).to.eql('clip');",
+                  "pm.test('failed replicate page job response contains expected metadata', function () {",
+                  "  pm.expect(body.model).to.eql('replicate');",
                   "  pm.expect(body.pageUrl).to.eql(pm.environment.get('sampleProviderFailurePageUrl'));",
                   "  pm.expect(body.status).to.match(/^(pending|processing)$/);",
                   "  pm.expect(body.statusUrl).to.match(/^\\/api\\/v1\\/accessibility\\/page-description-jobs\\//);",
@@ -1667,14 +1667,14 @@
                   "",
                   "pm.collectionVariables.set('asyncClipFailurePageJobStatusUrl', body.statusUrl);",
                   "pm.collectionVariables.set('asyncClipFailurePageJobPollCount', '0');",
-                  "pm.execution.setNextRequest('Poll async clip page description failure');"
+                  "pm.execution.setNextRequest('Poll async replicate page description failure');"
                 ]
               }
             }
           ]
         },
         {
-          "name": "Poll async clip page description failure",
+          "name": "Poll async replicate page description failure",
           "request": {
             "method": "GET",
             "header": [
@@ -1697,22 +1697,22 @@
                   "pm.collectionVariables.set('asyncClipFailurePageJobPollCount', String(attempt));",
                   "",
                   "if (pm.response.code === 202) {",
-                  "  pm.test('failed clip page job stays pending until it settles', function () {",
+                  "  pm.test('failed replicate page job stays pending until it settles', function () {",
                   "    pm.expect(body.status).to.match(/^(pending|processing)$/);",
                   "    pm.expect(body.statusUrl).to.eql(pm.collectionVariables.get('asyncClipFailurePageJobStatusUrl'));",
                   "  });",
-                  "  pm.test('failed clip page job polling stays within the attempt budget', function () {",
+                  "  pm.test('failed replicate page job polling stays within the attempt budget', function () {",
                   "    pm.expect(attempt).to.be.below(30);",
                   "  });",
                   "  const delayMs = Number(body.pollAfterMs || 0);",
-                  "  setTimeout(() => pm.execution.setNextRequest('Poll async clip page description failure'), delayMs);",
+                  "  setTimeout(() => pm.execution.setNextRequest('Poll async replicate page description failure'), delayMs);",
                   "} else {",
-                  "  pm.test('failed clip page job eventually returns 200', function () {",
+                  "  pm.test('failed replicate page job eventually returns 200', function () {",
                   "    pm.response.to.have.status(200);",
                   "  });",
-                  "  pm.test('terminal clip page job exposes the provider failure', function () {",
+                  "  pm.test('terminal replicate page job exposes the provider failure', function () {",
                   "    pm.expect(body.status).to.eql('failed');",
-                  "    pm.expect(body.model).to.eql('clip');",
+                  "    pm.expect(body.model).to.eql('replicate');",
                   "    pm.expect(body.pageUrl).to.eql(pm.environment.get('sampleProviderFailurePageUrl'));",
                   "    pm.expect(body.error).to.eql({ message: 'stub replicate provider failure' });",
                   "    pm.expect(body).not.to.have.property('result');",
@@ -2010,7 +2010,7 @@
                   "pm.test('error identifies unknown model and available providers', function () {",
                   "  pm.expect(body).to.have.property('error');",
                   "  pm.expect(body.error).to.include(\"Unknown model 'unknownmodel'\");",
-                  "  pm.expect(body.error).to.include('clip');",
+                  "  pm.expect(body.error).to.include('replicate');",
                   "  pm.expect(body.error).to.include('azure');",
                   "});"
                 ]
@@ -2189,7 +2189,7 @@
                   "pm.test('error identifies unknown model and available providers', function () {",
                   "  pm.expect(body).to.have.property('error');",
                   "  pm.expect(body.error).to.include(\"Unknown model 'unknownmodel'\");",
-                  "  pm.expect(body.error).to.include('clip');",
+                  "  pm.expect(body.error).to.include('replicate');",
                   "  pm.expect(body.error).to.include('azure');",
                   "});"
                 ]

--- a/src/api/v1/controllers/descriptionController.js
+++ b/src/api/v1/controllers/descriptionController.js
@@ -46,7 +46,7 @@ class DescriptionController {
    *     summary: Returns a description for a given image
    *     description: Takes an image URL and sends it to the selected AI model
    *       to generate an alt-text description. Slow asynchronous providers such
-   *       as `clip` can return `202 Accepted` with a job status payload.
+   *       as `replicate` can return `202 Accepted` with a job status payload.
    *     security:
    *       - bearerAuth: []
    *       - apiKeyAuth: []
@@ -60,20 +60,20 @@ class DescriptionController {
    *           example: https%3A%2F%2Fdeveloper.chrome.com%2Fstatic%2Fimages%2Fai-homepage-card.png
    *       - name: model
    *         in: query
-   *         description: The AI model to use, for example `clip`, `azure`,
+   *         description: The AI model to use, for example `replicate`, `azure`,
    *           `ollama`, `huggingface`, `openai`, `openrouter`, or `together`.
    *         required: true
    *         schema:
    *           type: string
    *           enum:
-   *             - clip
+   *             - replicate
    *             - azure
    *             - ollama
    *             - huggingface
    *             - openai
    *             - openrouter
    *             - together
-   *           example: clip
+   *           example: replicate
    *     responses:
    *       200:
    *         description: OK
@@ -195,7 +195,7 @@ class DescriptionController {
    *     summary: Returns descriptions for images found on a page
    *     description: Scrapes a website, preserves duplicate image entries in page
    *       order, and reuses a single prediction per unique image URL. Slow
-   *       asynchronous providers such as `clip` can return `202 Accepted` with
+   *       asynchronous providers such as `replicate` can return `202 Accepted` with
    *       a page-description job payload.
    *     security:
    *       - bearerAuth: []
@@ -210,20 +210,20 @@ class DescriptionController {
    *           example: https%3A%2F%2Fdeveloper.chrome.com%2F
    *       - name: model
    *         in: query
-   *         description: The AI model to use, for example `clip`, `azure`,
+   *         description: The AI model to use, for example `replicate`, `azure`,
    *           `ollama`, `huggingface`, `openai`, `openrouter`, or `together`.
    *         required: true
    *         schema:
    *           type: string
    *           enum:
-   *             - clip
+   *             - replicate
    *             - azure
    *             - ollama
    *             - huggingface
    *             - openai
    *             - openrouter
    *             - together
-   *           example: clip
+   *           example: replicate
    *     responses:
    *       200:
    *         description: OK

--- a/src/createApp.js
+++ b/src/createApp.js
@@ -74,7 +74,7 @@ const createApp = ({
       },
       providerClients: {
         ...(providerClients ?? {}),
-        ...(replicateClient ? { clip: replicateClient, replicate: replicateClient } : {}),
+        ...(replicateClient ? { replicate: replicateClient } : {}),
       },
     });
   const resolvedPageDescriptionService = pageDescriptionService

--- a/src/providers/definitions/index.js
+++ b/src/providers/definitions/index.js
@@ -1,4 +1,4 @@
-const clip = require('./clip');
+const replicate = require('./replicate');
 const azure = require('./azure');
 const ollama = require('./ollama');
 const huggingface = require('./huggingface');
@@ -7,7 +7,7 @@ const openrouter = require('./openrouter');
 const together = require('./together');
 
 module.exports = Object.freeze([
-  clip,
+  replicate,
   azure,
   ollama,
   huggingface,

--- a/src/providers/definitions/replicate.js
+++ b/src/providers/definitions/replicate.js
@@ -19,10 +19,10 @@ const buildReplicateClient = (providerConfig, fetch) => new Replicate({
 });
 
 module.exports = {
-  key: 'clip',
+  key: 'replicate',
   configKey: 'replicate',
-  displayName: 'Replicate CLIP',
-  startupHint: 'REPLICATE_API_TOKEN to enable clip',
+  displayName: 'Replicate',
+  startupHint: 'REPLICATE_API_TOKEN to enable replicate',
   buildEnvSchema: (Joi) => ({
     REPLICATE_API_TOKEN: Joi.string().optional(),
     REPLICATE_API_ENDPOINT: Joi.string().uri().optional(),
@@ -55,7 +55,7 @@ module.exports = {
     scopeKey: 'replicate',
     autoPriority: 20,
     folderName: '90 Provider Validation',
-    requestEnvVars: ['model=clip'],
+    requestEnvVars: ['model=replicate'],
     scopeRequirement: 'REPLICATE_API_TOKEN',
     allRequirement: 'REPLICATE_API_TOKEN',
   },

--- a/tests/integration/api.test.js
+++ b/tests/integration/api.test.js
@@ -377,7 +377,7 @@ describe('Integration | API', () => {
 
       const res = await secureGet(
         app,
-        '/api/accessibility/description?model=clip',
+        '/api/accessibility/description?model=replicate',
       );
 
       expect(res.status).toBe(400);
@@ -390,7 +390,7 @@ describe('Integration | API', () => {
     });
 
     it('returns 400 for an unknown model', async () => {
-      const factory = new ImageDescriberFactory().register('clip', {
+      const factory = new ImageDescriberFactory().register('replicate', {
         describeImage: jest.fn(),
       });
       const { app } = buildTestApp({ imageDescriberFactory: factory });
@@ -415,14 +415,14 @@ describe('Integration | API', () => {
           imageUrl: 'https://example.com/img.jpg',
         }),
       };
-      const factory = new ImageDescriberFactory().register('clip', mockDescriber);
+      const factory = new ImageDescriberFactory().register('replicate', mockDescriber);
       const { app } = buildTestApp({ imageDescriberFactory: factory });
 
       const res = await secureGet(
         app,
         `/api/accessibility/description?image_source=${
           encodeURIComponent('https://example.com/img.jpg')
-        }&model=clip`,
+        }&model=replicate`,
       );
 
       expect(res.status).toBe(200);
@@ -432,7 +432,7 @@ describe('Integration | API', () => {
       }]);
     });
 
-    it('returns 202 with job metadata for pending async clip descriptions', async () => {
+    it('returns 202 with job metadata for pending async replicate descriptions', async () => {
       const asyncProvider = {
         createDescriptionJob: jest.fn(),
         getDescriptionJob: jest.fn(),
@@ -441,19 +441,19 @@ describe('Integration | API', () => {
         resolveDescription: jest.fn().mockResolvedValue({
           kind: 'pending',
           job: {
-            id: 'job-clip',
+            id: 'job-replicate',
             status: 'processing',
           },
         }),
         getJobStatus: jest.fn(),
         buildJobResponse: jest.fn().mockReturnValue({
-          jobId: 'job-clip',
+          jobId: 'job-replicate',
           status: 'processing',
-          statusUrl: '/api/v1/accessibility/description-jobs/job-clip',
+          statusUrl: '/api/v1/accessibility/description-jobs/job-replicate',
           pollAfterMs: 1000,
         }),
       };
-      const factory = new ImageDescriberFactory().register('clip', asyncProvider);
+      const factory = new ImageDescriberFactory().register('replicate', asyncProvider);
       const { app } = buildTestApp({
         imageDescriberFactory: factory,
         descriptionJobService,
@@ -463,14 +463,14 @@ describe('Integration | API', () => {
         app,
         `/api/accessibility/description?image_source=${
           encodeURIComponent('https://example.com/img.jpg')
-        }&model=clip`,
+        }&model=replicate`,
       );
 
       expect(res.status).toBe(202);
       expect(res.body).toEqual({
-        jobId: 'job-clip',
+        jobId: 'job-replicate',
         status: 'processing',
-        statusUrl: '/api/v1/accessibility/description-jobs/job-clip',
+        statusUrl: '/api/v1/accessibility/description-jobs/job-replicate',
         pollAfterMs: 1000,
       });
     });
@@ -528,7 +528,7 @@ describe('Integration | API', () => {
         config: runtimeConfig,
       });
 
-      expect(services.imageDescriberFactory.getAvailableModels()).toEqual(['clip', 'azure']);
+      expect(services.imageDescriberFactory.getAvailableModels()).toEqual(['replicate', 'azure']);
 
       const res = await secureGet(
         app,
@@ -568,7 +568,7 @@ describe('Integration | API', () => {
 
       const res = await secureGet(
         app,
-        '/api/accessibility/descriptions?model=clip',
+        '/api/accessibility/descriptions?model=replicate',
       );
 
       expect(res.status).toBe(400);
@@ -598,7 +598,7 @@ describe('Integration | API', () => {
             imageUrl,
           })),
       };
-      const factory = new ImageDescriberFactory().register('clip', mockDescriber);
+      const factory = new ImageDescriberFactory().register('replicate', mockDescriber);
       const { app } = buildTestApp({
         scraperService,
         imageDescriberFactory: factory,
@@ -608,14 +608,14 @@ describe('Integration | API', () => {
         app,
         `/api/accessibility/descriptions?url=${
           encodeURIComponent('https://example.com/page')
-        }&model=clip`,
+        }&model=replicate`,
       );
 
       expect(res.status).toBe(200);
       expect(mockDescriber.describeImage).toHaveBeenCalledTimes(2);
       expect(res.body).toEqual({
         pageUrl: 'https://example.com/page',
-        model: 'clip',
+        model: 'replicate',
         totalImages: 3,
         uniqueImages: 2,
         descriptions: [
@@ -691,7 +691,7 @@ describe('Integration | API', () => {
       });
     });
 
-    it('returns 202 with page-job metadata for pending async clip page descriptions', async () => {
+    it('returns 202 with page-job metadata for pending async replicate page descriptions', async () => {
       const asyncProvider = {
         createDescriptionJob: jest.fn(),
         getDescriptionJob: jest.fn(),
@@ -700,19 +700,19 @@ describe('Integration | API', () => {
         resolvePageDescription: jest.fn().mockResolvedValue({
           kind: 'pending',
           job: {
-            id: 'page-job-clip',
+            id: 'page-job-replicate',
             status: 'processing',
           },
         }),
         getJobStatus: jest.fn(),
         buildJobResponse: jest.fn().mockReturnValue({
-          jobId: 'page-job-clip',
+          jobId: 'page-job-replicate',
           status: 'processing',
-          statusUrl: '/api/v1/accessibility/page-description-jobs/page-job-clip',
+          statusUrl: '/api/v1/accessibility/page-description-jobs/page-job-replicate',
           pollAfterMs: 1000,
         }),
       };
-      const factory = new ImageDescriberFactory().register('clip', asyncProvider);
+      const factory = new ImageDescriberFactory().register('replicate', asyncProvider);
       const { app } = buildTestApp({
         imageDescriberFactory: factory,
         pageDescriptionJobService,
@@ -722,14 +722,14 @@ describe('Integration | API', () => {
         app,
         `/api/accessibility/descriptions?url=${
           encodeURIComponent('https://example.com/page')
-        }&model=clip`,
+        }&model=replicate`,
       );
 
       expect(res.status).toBe(202);
       expect(res.body).toEqual({
-        jobId: 'page-job-clip',
+        jobId: 'page-job-replicate',
         status: 'processing',
-        statusUrl: '/api/v1/accessibility/page-description-jobs/page-job-clip',
+        statusUrl: '/api/v1/accessibility/page-description-jobs/page-job-replicate',
         pollAfterMs: 1000,
       });
     });
@@ -740,25 +740,25 @@ describe('Integration | API', () => {
       const descriptionJobService = {
         resolveDescription: jest.fn(),
         getJobStatus: jest.fn().mockResolvedValue({
-          id: 'job-clip',
+          id: 'job-replicate',
           status: 'processing',
         }),
         buildJobResponse: jest.fn().mockReturnValue({
-          jobId: 'job-clip',
+          jobId: 'job-replicate',
           status: 'processing',
-          statusUrl: '/api/v1/accessibility/description-jobs/job-clip',
+          statusUrl: '/api/v1/accessibility/description-jobs/job-replicate',
           pollAfterMs: 1000,
         }),
       };
       const { app } = buildTestApp({ descriptionJobService });
 
-      const res = await secureGet(app, '/api/accessibility/description-jobs/job-clip');
+      const res = await secureGet(app, '/api/accessibility/description-jobs/job-replicate');
 
       expect(res.status).toBe(202);
       expect(res.body).toEqual({
-        jobId: 'job-clip',
+        jobId: 'job-replicate',
         status: 'processing',
-        statusUrl: '/api/v1/accessibility/description-jobs/job-clip',
+        statusUrl: '/api/v1/accessibility/description-jobs/job-replicate',
         pollAfterMs: 1000,
       });
     });
@@ -769,22 +769,22 @@ describe('Integration | API', () => {
       const pageDescriptionJobService = {
         resolvePageDescription: jest.fn(),
         getJobStatus: jest.fn().mockResolvedValue({
-          id: 'page-job-clip',
+          id: 'page-job-replicate',
           status: 'succeeded',
           result: {
             pageUrl: 'https://example.com/page',
-            model: 'clip',
+            model: 'replicate',
             totalImages: 1,
             uniqueImages: 1,
             descriptions: [],
           },
         }),
         buildJobResponse: jest.fn().mockReturnValue({
-          jobId: 'page-job-clip',
+          jobId: 'page-job-replicate',
           status: 'succeeded',
           result: {
             pageUrl: 'https://example.com/page',
-            model: 'clip',
+            model: 'replicate',
             totalImages: 1,
             uniqueImages: 1,
             descriptions: [],
@@ -793,15 +793,15 @@ describe('Integration | API', () => {
       };
       const { app } = buildTestApp({ pageDescriptionJobService });
 
-      const res = await secureGet(app, '/api/accessibility/page-description-jobs/page-job-clip');
+      const res = await secureGet(app, '/api/accessibility/page-description-jobs/page-job-replicate');
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual({
-        jobId: 'page-job-clip',
+        jobId: 'page-job-replicate',
         status: 'succeeded',
         result: {
           pageUrl: 'https://example.com/page',
-          model: 'clip',
+          model: 'replicate',
           totalImages: 1,
           uniqueImages: 1,
           descriptions: [],
@@ -813,25 +813,25 @@ describe('Integration | API', () => {
       const pageDescriptionJobService = {
         resolvePageDescription: jest.fn(),
         getJobStatus: jest.fn().mockResolvedValue({
-          id: 'page-job-clip',
+          id: 'page-job-replicate',
           status: 'processing',
         }),
         buildJobResponse: jest.fn().mockReturnValue({
-          jobId: 'page-job-clip',
+          jobId: 'page-job-replicate',
           status: 'processing',
-          statusUrl: '/api/v1/accessibility/page-description-jobs/page-job-clip',
+          statusUrl: '/api/v1/accessibility/page-description-jobs/page-job-replicate',
           pollAfterMs: 1000,
         }),
       };
       const { app } = buildTestApp({ pageDescriptionJobService });
 
-      const res = await secureGet(app, '/api/accessibility/page-description-jobs/page-job-clip');
+      const res = await secureGet(app, '/api/accessibility/page-description-jobs/page-job-replicate');
 
       expect(res.status).toBe(202);
       expect(res.body).toEqual({
-        jobId: 'page-job-clip',
+        jobId: 'page-job-replicate',
         status: 'processing',
-        statusUrl: '/api/v1/accessibility/page-description-jobs/page-job-clip',
+        statusUrl: '/api/v1/accessibility/page-description-jobs/page-job-replicate',
         pollAfterMs: 1000,
       });
     });
@@ -905,7 +905,7 @@ describe('Integration | API', () => {
         app,
         `/api/accessibility/description?image_source=${
           encodeURIComponent('https://example.com/img.jpg')
-        }&model=clip`,
+        }&model=replicate`,
       );
 
       expect(res.status).toBe(401);
@@ -917,7 +917,7 @@ describe('Integration | API', () => {
     });
 
     it('accepts X-API-Key authentication on protected endpoints', async () => {
-      const factory = new ImageDescriberFactory().register('clip', {
+      const factory = new ImageDescriberFactory().register('replicate', {
         describeImage: jest.fn().mockResolvedValue({
           description: 'authenticated description',
           imageUrl: 'https://example.com/img.jpg',
@@ -932,7 +932,7 @@ describe('Integration | API', () => {
         app,
         `/api/accessibility/description?image_source=${
           encodeURIComponent('https://example.com/img.jpg')
-        }&model=clip`,
+        }&model=replicate`,
       ).set('X-API-Key', 'dummy-2');
 
       expect(res.status).toBe(200);

--- a/tests/integration/asyncPageDescriptionJobs.test.js
+++ b/tests/integration/asyncPageDescriptionJobs.test.js
@@ -101,7 +101,7 @@ class StubAsyncClipDescriber {
   }
 
   static buildFailureError(imageUrl) {
-    const error = new Error(`stub clip provider failure for ${imageUrl}`);
+    const error = new Error(`stub replicate provider failure for ${imageUrl}`);
     error.code = 'STUB_CLIP_PROVIDER_FAILURE';
     return error;
   }
@@ -189,7 +189,7 @@ describe('Integration | Async Page Description Jobs', () => {
 
   const buildTestApp = () => {
     const imageDescriberFactory = new ImageDescriberFactory();
-    imageDescriberFactory.register('clip', new StubAsyncClipDescriber());
+    imageDescriberFactory.register('replicate', new StubAsyncClipDescriber());
 
     const appLogger = createAppLogger();
     const requestLogger = createRequestLogger();
@@ -243,17 +243,17 @@ describe('Integration | Async Page Description Jobs', () => {
     throw new Error(`Timed out waiting for terminal job status at ${statusUrl}`);
   };
 
-  it('returns 202, settles the page job, and serves cached results on repeat clip requests', async () => {
+  it('returns 202, settles the page job, and serves cached results on repeat replicate requests', async () => {
     const app = buildTestApp();
     const pageUrl = `${fixtureBaseUrl}/fixtures/page-with-images`;
     const startResponse = await secureGet(
       app,
-      `/api/v1/accessibility/descriptions?url=${encodeURIComponent(pageUrl)}&model=clip`,
+      `/api/v1/accessibility/descriptions?url=${encodeURIComponent(pageUrl)}&model=replicate`,
     );
 
     expect(startResponse.status).toBe(202);
     expect(startResponse.body).toMatchObject({
-      model: 'clip',
+      model: 'replicate',
       pageUrl,
       status: expect.stringMatching(/^(pending|processing)$/),
       statusUrl: expect.stringMatching(/^\/api\/v1\/accessibility\/page-description-jobs\//),
@@ -262,12 +262,12 @@ describe('Integration | Async Page Description Jobs', () => {
     const finalResponse = await pollJobUntilTerminal(app, startResponse.body.statusUrl);
 
     expect(finalResponse.body).toMatchObject({
-      model: 'clip',
+      model: 'replicate',
       pageUrl,
       status: 'succeeded',
       result: {
         pageUrl,
-        model: 'clip',
+        model: 'replicate',
         totalImages: 3,
         uniqueImages: 2,
       },
@@ -280,19 +280,19 @@ describe('Integration | Async Page Description Jobs', () => {
 
     const cachedResponse = await secureGet(
       app,
-      `/api/v1/accessibility/descriptions?url=${encodeURIComponent(pageUrl)}&model=clip`,
+      `/api/v1/accessibility/descriptions?url=${encodeURIComponent(pageUrl)}&model=replicate`,
     );
 
     expect(cachedResponse.status).toBe(200);
     expect(cachedResponse.body).toEqual(finalResponse.body.result);
   });
 
-  it('returns 202 and eventually exposes a terminal failed page job when a clip image job fails', async () => {
+  it('returns 202 and eventually exposes a terminal failed page job when a replicate image job fails', async () => {
     const app = buildTestApp();
     const pageUrl = `${fixtureBaseUrl}/fixtures/page-with-provider-failure`;
     const startResponse = await secureGet(
       app,
-      `/api/v1/accessibility/descriptions?url=${encodeURIComponent(pageUrl)}&model=clip`,
+      `/api/v1/accessibility/descriptions?url=${encodeURIComponent(pageUrl)}&model=replicate`,
     );
 
     expect(startResponse.status).toBe(202);
@@ -301,12 +301,12 @@ describe('Integration | Async Page Description Jobs', () => {
     const finalResponse = await pollJobUntilTerminal(app, startResponse.body.statusUrl);
 
     expect(finalResponse.body).toMatchObject({
-      model: 'clip',
+      model: 'replicate',
       pageUrl,
       status: 'failed',
       error: {
         code: 'STUB_CLIP_PROVIDER_FAILURE',
-        message: `stub clip provider failure for ${fixtureBaseUrl}/assets/provider-error.png`,
+        message: `stub replicate provider failure for ${fixtureBaseUrl}/assets/provider-error.png`,
       },
     });
     expect(finalResponse.body).not.toHaveProperty('result');

--- a/tests/unit/config/providerCatalog.test.js
+++ b/tests/unit/config/providerCatalog.test.js
@@ -120,7 +120,7 @@ describe('Unit | Config | Provider Catalog', () => {
       OPENROUTER_API_KEY: 'openrouter-key',
       TOGETHER_API_KEY: 'together-key',
     }).map((provider) => provider.key)).toEqual([
-      'clip',
+      'replicate',
       'azure',
       'ollama',
       'huggingface',
@@ -134,7 +134,7 @@ describe('Unit | Config | Provider Catalog', () => {
       openai: { apiKey: 'openai-key' },
       huggingface: { apiKey: 'hf-key' },
       ollama: { enabled: true },
-    }).map((provider) => provider.key)).toEqual(['clip', 'ollama', 'huggingface', 'openai']);
+    }).map((provider) => provider.key)).toEqual(['replicate', 'ollama', 'huggingface', 'openai']);
   });
 
   it('validates provider-specific env rules and exposes provider-validation metadata', () => {
@@ -158,7 +158,7 @@ describe('Unit | Config | Provider Catalog', () => {
       TOGETHER_MODEL: 'Qwen/Qwen3-VL-8B-Instruct',
     })[0]).toMatch(/TOGETHER_API_KEY/);
     expect(getProviderCatalog().map((provider) => provider.key)).toEqual([
-      'clip',
+      'replicate',
       'azure',
       'ollama',
       'huggingface',
@@ -180,7 +180,7 @@ describe('Unit | Config | Provider Catalog', () => {
     expect(getProviderValidationByScope('azure').displayName).toBe('Azure Computer Vision');
   });
 
-  it('treats a Replicate token as sufficient enablement for clip', () => {
+  it('treats a Replicate token as sufficient enablement for replicate', () => {
     const sections = buildProviderConfigSections({
       REPLICATE_API_TOKEN: 'replicate-token',
     });
@@ -191,6 +191,6 @@ describe('Unit | Config | Provider Catalog', () => {
     });
     expect(getConfiguredProvidersFromEnv({
       REPLICATE_API_TOKEN: 'replicate-token',
-    }).map((provider) => provider.key)).toEqual(['clip']);
+    }).map((provider) => provider.key)).toEqual(['replicate']);
   });
 });

--- a/tests/unit/config/swagger.test.js
+++ b/tests/unit/config/swagger.test.js
@@ -117,7 +117,7 @@ describe('Unit | Config | Swagger', () => {
     expect(pageUrl.schema.example).toBe('https%3A%2F%2Fdeveloper.chrome.com%2F');
     expect(scraperUrl.schema.example).toBe('https%3A%2F%2Fdeveloper.chrome.com%2F');
     expect(descriptionModel.schema.enum).toEqual([
-      'clip',
+      'replicate',
       'azure',
       'ollama',
       'huggingface',

--- a/tests/unit/controllers/descriptionController.test.js
+++ b/tests/unit/controllers/descriptionController.test.js
@@ -40,7 +40,7 @@ describe('Unit | Controllers | Description Controller', () => {
 
     it('forwards a validation error when image_source is missing', async () => {
       const controller = createController(new ImageDescriberFactory());
-      const req = { query: { model: 'clip' } };
+      const req = { query: { model: 'replicate' } };
       const res = makeResMock();
       const next = jest.fn();
 
@@ -75,7 +75,7 @@ describe('Unit | Controllers | Description Controller', () => {
 
     it('forwards a validation error for an invalid image_source URL', async () => {
       const controller = createController(new ImageDescriberFactory());
-      const req = { query: { image_source: 'not-a-url', model: 'clip' } };
+      const req = { query: { image_source: 'not-a-url', model: 'replicate' } };
       const res = makeResMock();
       const next = jest.fn();
 
@@ -91,7 +91,7 @@ describe('Unit | Controllers | Description Controller', () => {
     });
 
     it('forwards a validation error for an unknown model', async () => {
-      const controller = createController(new ImageDescriberFactory().register('clip', {
+      const controller = createController(new ImageDescriberFactory().register('replicate', {
         describeImage: jest.fn(),
       }));
       const req = {
@@ -122,12 +122,12 @@ describe('Unit | Controllers | Description Controller', () => {
         }),
       };
       const controller = createController(
-        new ImageDescriberFactory().register('clip', mockDescriber),
+        new ImageDescriberFactory().register('replicate', mockDescriber),
       );
       const req = {
         query: {
           image_source: encodeURIComponent('https://example.com/img.jpg'),
-          model: 'clip',
+          model: 'replicate',
         },
         log: mockLogger,
       };
@@ -149,12 +149,12 @@ describe('Unit | Controllers | Description Controller', () => {
         describeImage: jest.fn().mockRejectedValue(error),
       };
       const controller = createController(
-        new ImageDescriberFactory().register('clip', mockDescriber),
+        new ImageDescriberFactory().register('replicate', mockDescriber),
       );
       const req = {
         query: {
           image_source: encodeURIComponent('https://example.com/img.jpg'),
-          model: 'clip',
+          model: 'replicate',
         },
         log: mockLogger,
       };
@@ -191,14 +191,14 @@ describe('Unit | Controllers | Description Controller', () => {
         }),
       };
       const controller = createController(
-        new ImageDescriberFactory().register('clip', asyncProvider),
+        new ImageDescriberFactory().register('replicate', asyncProvider),
         { describePage: jest.fn() },
         descriptionJobService,
       );
       const req = {
         query: {
           image_source: encodeURIComponent('https://example.com/img.jpg'),
-          model: 'clip',
+          model: 'replicate',
         },
         log: mockLogger,
       };
@@ -225,12 +225,12 @@ describe('Unit | Controllers | Description Controller', () => {
         describeImage: jest.fn().mockRejectedValue(error),
       };
       const controller = createController(
-        new ImageDescriberFactory().register('clip', mockDescriber),
+        new ImageDescriberFactory().register('replicate', mockDescriber),
       );
       const req = {
         query: {
           image_source: encodeURIComponent('https://example.com/img.jpg'),
-          model: 'clip',
+          model: 'replicate',
         },
         log: mockLogger,
       };
@@ -254,7 +254,7 @@ describe('Unit | Controllers | Description Controller', () => {
 
     it('forwards a validation error when url is missing', async () => {
       const controller = createController(new ImageDescriberFactory());
-      const req = { query: { model: 'clip' } };
+      const req = { query: { model: 'replicate' } };
       const res = makeResMock();
       const next = jest.fn();
 
@@ -271,7 +271,7 @@ describe('Unit | Controllers | Description Controller', () => {
 
     it('forwards a validation error when url is invalid', async () => {
       const controller = createController(new ImageDescriberFactory());
-      const req = { query: { url: 'not-a-url', model: 'clip' } };
+      const req = { query: { url: 'not-a-url', model: 'replicate' } };
       const res = makeResMock();
       const next = jest.fn();
 
@@ -289,12 +289,12 @@ describe('Unit | Controllers | Description Controller', () => {
     it('forwards a validation error for an unknown model', async () => {
       const controller = createController(
         new ImageDescriberFactory(),
-        { describePage: jest.fn().mockRejectedValue(new Error('Unknown model: clip')) },
+        { describePage: jest.fn().mockRejectedValue(new Error('Unknown model: replicate')) },
       );
       const req = {
         query: {
           url: encodeURIComponent('https://example.com/page'),
-          model: 'clip',
+          model: 'replicate',
         },
       };
       const res = makeResMock();
@@ -313,7 +313,7 @@ describe('Unit | Controllers | Description Controller', () => {
     it('returns ordered descriptions on success', async () => {
       const expected = {
         pageUrl: 'https://example.com/page',
-        model: 'clip',
+        model: 'replicate',
         totalImages: 3,
         uniqueImages: 2,
         descriptions: [
@@ -335,7 +335,7 @@ describe('Unit | Controllers | Description Controller', () => {
         describePage: jest.fn().mockResolvedValue(expected),
       };
       const controller = createController(
-        new ImageDescriberFactory().register('clip', {
+        new ImageDescriberFactory().register('replicate', {
           describeImage: jest.fn(),
         }),
         pageDescriptionService,
@@ -343,7 +343,7 @@ describe('Unit | Controllers | Description Controller', () => {
       const req = {
         query: {
           url: encodeURIComponent('https://example.com/page'),
-          model: 'clip',
+          model: 'replicate',
         },
         log: mockLogger,
       };
@@ -354,7 +354,7 @@ describe('Unit | Controllers | Description Controller', () => {
 
       expect(pageDescriptionService.describePage).toHaveBeenCalledWith({
         pageUrl: 'https://example.com/page',
-        model: 'clip',
+        model: 'replicate',
       });
       expect(res.json).toHaveBeenCalledWith(expected);
       expect(next).not.toHaveBeenCalled();
@@ -379,7 +379,7 @@ describe('Unit | Controllers | Description Controller', () => {
         }),
       };
       const controller = createController(
-        new ImageDescriberFactory().register('clip', asyncProvider),
+        new ImageDescriberFactory().register('replicate', asyncProvider),
         { describePage: jest.fn() },
         undefined,
         pageDescriptionJobService,
@@ -387,7 +387,7 @@ describe('Unit | Controllers | Description Controller', () => {
       const req = {
         query: {
           url: encodeURIComponent('https://example.com/page'),
-          model: 'clip',
+          model: 'replicate',
         },
         log: mockLogger,
       };
@@ -407,7 +407,7 @@ describe('Unit | Controllers | Description Controller', () => {
     it('forwards an internal error when page orchestration fails', async () => {
       const error = new Error('network error');
       const controller = createController(
-        new ImageDescriberFactory().register('clip', {
+        new ImageDescriberFactory().register('replicate', {
           describeImage: jest.fn(),
         }),
         { describePage: jest.fn().mockRejectedValue(error) },
@@ -415,7 +415,7 @@ describe('Unit | Controllers | Description Controller', () => {
       const req = {
         query: {
           url: encodeURIComponent('https://example.com/page'),
-          model: 'clip',
+          model: 'replicate',
         },
         log: mockLogger,
       };
@@ -440,7 +440,7 @@ describe('Unit | Controllers | Description Controller', () => {
         timeoutMs: 1000,
       });
       const controller = createController(
-        new ImageDescriberFactory().register('clip', {
+        new ImageDescriberFactory().register('replicate', {
           describeImage: jest.fn(),
         }),
         { describePage: jest.fn().mockRejectedValue(error) },
@@ -448,7 +448,7 @@ describe('Unit | Controllers | Description Controller', () => {
       const req = {
         query: {
           url: encodeURIComponent('https://example.com/page'),
-          model: 'clip',
+          model: 'replicate',
         },
         log: mockLogger,
       };
@@ -533,7 +533,7 @@ describe('Unit | Controllers | Description Controller', () => {
           status: 'succeeded',
           result: {
             pageUrl: 'https://example.com/page',
-            model: 'clip',
+            model: 'replicate',
             totalImages: 1,
             uniqueImages: 1,
             descriptions: [],
@@ -544,7 +544,7 @@ describe('Unit | Controllers | Description Controller', () => {
           status: 'succeeded',
           result: {
             pageUrl: 'https://example.com/page',
-            model: 'clip',
+            model: 'replicate',
             totalImages: 1,
             uniqueImages: 1,
             descriptions: [],
@@ -571,7 +571,7 @@ describe('Unit | Controllers | Description Controller', () => {
         status: 'succeeded',
         result: {
           pageUrl: 'https://example.com/page',
-          model: 'clip',
+          model: 'replicate',
           totalImages: 1,
           uniqueImages: 1,
           descriptions: [],

--- a/tests/unit/createApp.test.js
+++ b/tests/unit/createApp.test.js
@@ -72,8 +72,8 @@ describe('Unit | Application Composition', () => {
       maxRedirects: 4,
       maxContentLength: 2048,
     });
-    expect(services.imageDescriberFactory.getAvailableModels()).toEqual(['clip', 'azure']);
-    expect(services.imageDescriberFactory.get('clip').replicate).toBe(replicateClient);
+    expect(services.imageDescriberFactory.getAvailableModels()).toEqual(['replicate', 'azure']);
+    expect(services.imageDescriberFactory.get('replicate').replicate).toBe(replicateClient);
     expect(services.imageDescriberFactory.get('azure').httpClient).toBe(httpClient);
     expect(services.pageDescriptionService.scraperService).toBe(services.scraperService);
     expect(services.pageDescriptionService.imageDescriberFactory)
@@ -109,8 +109,8 @@ describe('Unit | Application Composition', () => {
 
       expect(app).toBeDefined();
       expect(app.get('trust proxy')).toBe(1);
-      expect(services.imageDescriberFactory.getAvailableModels()).toEqual(['clip']);
-      expect(services.imageDescriberFactory.get('clip').replicate).toBeDefined();
+      expect(services.imageDescriberFactory.getAvailableModels()).toEqual(['replicate']);
+      expect(services.imageDescriberFactory.get('replicate').replicate).toBeDefined();
     } finally {
       defaultAppLogger.level = originalLevel;
     }
@@ -203,10 +203,10 @@ describe('Unit | Application Composition', () => {
       config,
     });
 
-    expect(services.imageDescriberFactory.getAvailableModels()).toEqual(['clip']);
+    expect(services.imageDescriberFactory.getAvailableModels()).toEqual(['replicate']);
   });
 
-  it('does not register clip when the Replicate token is missing', () => {
+  it('does not register replicate when the Replicate token is missing', () => {
     const config = {
       replicate: {
         apiEndpoint: 'https://replicate.example.com',
@@ -232,7 +232,7 @@ describe('Unit | Application Composition', () => {
     expect(services.imageDescriberFactory.getAvailableModels()).toEqual([]);
   });
 
-  it('does not register clip when Replicate is explicitly disabled', () => {
+  it('does not register replicate when Replicate is explicitly disabled', () => {
     const config = {
       replicate: {
         enabled: false,

--- a/tests/unit/middleware/requestFilter.test.js
+++ b/tests/unit/middleware/requestFilter.test.js
@@ -123,7 +123,7 @@ describe('Unit | Middleware | Request Filter', () => {
   it('passes secure requests through so endpoint validation can handle query semantics', () => {
     const { next, res } = invokeMiddleware({
       protocol: 'https',
-      url: '/api/accessibility/description?image_source=not-a-url&model=clip',
+      url: '/api/accessibility/description?image_source=not-a-url&model=replicate',
     });
 
     expect(next).toHaveBeenCalledTimes(1);

--- a/tests/unit/services/DescriptionJobService.test.js
+++ b/tests/unit/services/DescriptionJobService.test.js
@@ -23,7 +23,7 @@ describe('Unit | Services | Description Job Service', () => {
       getDescriptionJob: jest.fn(),
     };
     const service = new DescriptionJobService({
-      imageDescriberFactory: new ImageDescriberFactory().register('clip', describer),
+      imageDescriberFactory: new ImageDescriberFactory().register('replicate', describer),
       jobStore,
       logger: {},
       waitTimeoutMs: 10,
@@ -35,13 +35,13 @@ describe('Unit | Services | Description Job Service', () => {
     });
     const imageUrl = 'https://images.example.org/cat.jpg';
     const jobId = DescriptionJobService.buildJobId({
-      model: 'clip',
+      model: 'replicate',
       imageUrl,
     });
 
     await jobStore.set({
       id: jobId,
-      model: 'clip',
+      model: 'replicate',
       imageUrl,
       providerJobId: 'prediction-cached',
       status: 'succeeded',
@@ -55,7 +55,7 @@ describe('Unit | Services | Description Job Service', () => {
     });
 
     const outcome = await service.resolveDescription({
-      model: 'clip',
+      model: 'replicate',
       imageUrl,
     });
 
@@ -89,7 +89,7 @@ describe('Unit | Services | Description Job Service', () => {
       }),
     };
     const service = new DescriptionJobService({
-      imageDescriberFactory: new ImageDescriberFactory().register('clip', describer),
+      imageDescriberFactory: new ImageDescriberFactory().register('replicate', describer),
       jobStore,
       logger: {},
       waitTimeoutMs: 10,
@@ -101,7 +101,7 @@ describe('Unit | Services | Description Job Service', () => {
     });
 
     const outcome = await service.resolveDescription({
-      model: 'clip',
+      model: 'replicate',
       imageUrl: 'https://example.com/cat.jpg',
     });
 
@@ -127,7 +127,7 @@ describe('Unit | Services | Description Job Service', () => {
       }),
     };
     const service = new DescriptionJobService({
-      imageDescriberFactory: new ImageDescriberFactory().register('clip', describer),
+      imageDescriberFactory: new ImageDescriberFactory().register('replicate', describer),
       jobStore,
       logger: {},
       waitTimeoutMs: 0,
@@ -139,14 +139,14 @@ describe('Unit | Services | Description Job Service', () => {
     });
 
     const outcome = await service.resolveDescription({
-      model: 'clip',
+      model: 'replicate',
       imageUrl: 'https://example.com/cat.jpg',
     });
 
     expect(outcome.kind).toBe('pending');
     expect(service.buildJobResponse(outcome.job)).toMatchObject({
       jobId: expect.any(String),
-      model: 'clip',
+      model: 'replicate',
       imageUrl: 'https://example.com/cat.jpg',
       status: 'processing',
       pollAfterMs: 1,
@@ -168,7 +168,7 @@ describe('Unit | Services | Description Job Service', () => {
         },
       }),
     };
-    const factory = new ImageDescriberFactory().register('clip', describer);
+    const factory = new ImageDescriberFactory().register('replicate', describer);
     const service = new DescriptionJobService({
       imageDescriberFactory: factory,
       jobStore,
@@ -181,12 +181,12 @@ describe('Unit | Services | Description Job Service', () => {
       sleep: jest.fn().mockResolvedValue(undefined),
     });
     const jobId = DescriptionJobService.buildJobId({
-      model: 'clip',
+      model: 'replicate',
       imageUrl: 'https://example.com/cat.jpg',
     });
     await jobStore.set({
       id: jobId,
-      model: 'clip',
+      model: 'replicate',
       imageUrl: 'https://example.com/cat.jpg',
       providerJobId: 'prediction-3',
       status: 'processing',
@@ -220,7 +220,7 @@ describe('Unit | Services | Description Job Service', () => {
       getDescriptionJob: jest.fn(),
     };
     const service = new DescriptionJobService({
-      imageDescriberFactory: new ImageDescriberFactory().register('clip', describer),
+      imageDescriberFactory: new ImageDescriberFactory().register('replicate', describer),
       jobStore,
       logger: {},
       waitTimeoutMs: 10,
@@ -232,7 +232,7 @@ describe('Unit | Services | Description Job Service', () => {
     });
 
     const outcome = await service.resolveDescription({
-      model: 'clip',
+      model: 'replicate',
       imageUrl,
     });
 
@@ -262,7 +262,7 @@ describe('Unit | Services | Description Job Service', () => {
       getDescriptionJob: jest.fn(),
     };
     const service = new DescriptionJobService({
-      imageDescriberFactory: new ImageDescriberFactory().register('clip', describer),
+      imageDescriberFactory: new ImageDescriberFactory().register('replicate', describer),
       jobStore,
       logger: {},
       waitTimeoutMs: 10,
@@ -274,7 +274,7 @@ describe('Unit | Services | Description Job Service', () => {
     });
 
     await expect(service.resolveDescription({
-      model: 'clip',
+      model: 'replicate',
       imageUrl,
     })).rejects.toMatchObject({
       message: 'prediction failed',
@@ -291,7 +291,7 @@ describe('Unit | Services | Description Job Service', () => {
       getDescriptionJob: jest.fn(),
     };
     const service = new DescriptionJobService({
-      imageDescriberFactory: new ImageDescriberFactory().register('clip', describer),
+      imageDescriberFactory: new ImageDescriberFactory().register('replicate', describer),
       jobStore,
       logger: {},
       waitTimeoutMs: 10,
@@ -302,13 +302,13 @@ describe('Unit | Services | Description Job Service', () => {
       sleep: jest.fn().mockResolvedValue(undefined),
     });
     const failedJobId = DescriptionJobService.buildJobId({
-      model: 'clip',
+      model: 'replicate',
       imageUrl: 'https://images.example.org/failure.jpg',
     });
 
     await jobStore.set({
       id: failedJobId,
-      model: 'clip',
+      model: 'replicate',
       imageUrl: 'https://images.example.org/failure.jpg',
       providerJobId: 'prediction-failed',
       status: 'failed',

--- a/tests/unit/services/ImageDescriberFactory.test.js
+++ b/tests/unit/services/ImageDescriberFactory.test.js
@@ -5,28 +5,28 @@ const mockAzureDescriber = { describeImage: jest.fn() };
 
 describe('Unit | Services | Image Describer Factory', () => {
   it('returns a registered describer by name', () => {
-    const factory = new ImageDescriberFactory().register('clip', mockDescriber);
-    expect(factory.get('clip')).toBe(mockDescriber);
+    const factory = new ImageDescriberFactory().register('replicate', mockDescriber);
+    expect(factory.get('replicate')).toBe(mockDescriber);
   });
 
   it('supports chained registration', () => {
     const factory = new ImageDescriberFactory()
-      .register('clip', mockDescriber)
+      .register('replicate', mockDescriber)
       .register('azure', mockAzureDescriber);
-    expect(factory.get('clip')).toBe(mockDescriber);
+    expect(factory.get('replicate')).toBe(mockDescriber);
     expect(factory.get('azure')).toBe(mockAzureDescriber);
   });
 
   it('throws a descriptive error for an unknown model', () => {
-    const factory = new ImageDescriberFactory().register('clip', mockDescriber);
-    expect(() => factory.get('gpt4')).toThrow("Unknown model 'gpt4'. Available models: clip");
+    const factory = new ImageDescriberFactory().register('replicate', mockDescriber);
+    expect(() => factory.get('gpt4')).toThrow("Unknown model 'gpt4'. Available models: replicate");
   });
 
   it('lists available models', () => {
     const factory = new ImageDescriberFactory()
-      .register('clip', mockDescriber)
+      .register('replicate', mockDescriber)
       .register('azure', mockAzureDescriber);
-    expect(factory.getAvailableModels()).toEqual(['clip', 'azure']);
+    expect(factory.getAvailableModels()).toEqual(['replicate', 'azure']);
   });
 
   it('returns empty array when no models registered', () => {

--- a/tests/unit/services/PageDescriptionJobService.test.js
+++ b/tests/unit/services/PageDescriptionJobService.test.js
@@ -55,19 +55,19 @@ describe('Unit | Services | Page Description Job Service', () => {
     });
     const pageUrl = 'https://example.com/page';
     const jobId = PageDescriptionJobService.buildJobId({
-      model: 'clip',
+      model: 'replicate',
       pageUrl,
     });
 
     await jobStore.set({
       id: jobId,
       jobType: 'page-description',
-      model: 'clip',
+      model: 'replicate',
       pageUrl,
       status: 'succeeded',
       result: {
         pageUrl,
-        model: 'clip',
+        model: 'replicate',
         totalImages: 1,
         uniqueImages: 1,
         descriptions: [],
@@ -78,7 +78,7 @@ describe('Unit | Services | Page Description Job Service', () => {
     });
 
     const outcome = await service.resolvePageDescription({
-      model: 'clip',
+      model: 'replicate',
       pageUrl,
     });
 
@@ -86,7 +86,7 @@ describe('Unit | Services | Page Description Job Service', () => {
       kind: 'completed',
       result: {
         pageUrl,
-        model: 'clip',
+        model: 'replicate',
       },
     });
     expect(pageDescriptionService.describePageWithResolver).not.toHaveBeenCalled();
@@ -97,7 +97,7 @@ describe('Unit | Services | Page Description Job Service', () => {
     const pageDescriptionService = {
       describePageWithResolver: jest.fn().mockImplementation(async ({ describeImage }) => ({
         pageUrl: 'https://example.com/page',
-        model: 'clip',
+        model: 'replicate',
         totalImages: 1,
         uniqueImages: 1,
         descriptions: [
@@ -131,7 +131,7 @@ describe('Unit | Services | Page Description Job Service', () => {
     });
 
     const outcome = await service.resolvePageDescription({
-      model: 'clip',
+      model: 'replicate',
       pageUrl: 'https://example.com/page',
     });
 
@@ -139,13 +139,13 @@ describe('Unit | Services | Page Description Job Service', () => {
       kind: 'completed',
       result: {
         pageUrl: 'https://example.com/page',
-        model: 'clip',
+        model: 'replicate',
         totalImages: 1,
         uniqueImages: 1,
       },
     });
     expect(descriptionJobService.resolveDescription).toHaveBeenCalledWith({
-      model: 'clip',
+      model: 'replicate',
       imageUrl: 'https://example.com/a.jpg',
     });
   });
@@ -179,14 +179,14 @@ describe('Unit | Services | Page Description Job Service', () => {
     });
 
     const outcome = await service.resolvePageDescription({
-      model: 'clip',
+      model: 'replicate',
       pageUrl: 'https://example.com/page',
     });
 
     expect(outcome.kind).toBe('pending');
     expect(service.buildJobResponse(outcome.job)).toMatchObject({
       jobId: expect.any(String),
-      model: 'clip',
+      model: 'replicate',
       pageUrl: 'https://example.com/page',
       status: expect.stringMatching(/pending|processing/),
       statusUrl: expect.stringContaining('/api/v1/accessibility/page-description-jobs/'),
@@ -229,13 +229,13 @@ describe('Unit | Services | Page Description Job Service', () => {
     });
 
     const firstOutcome = await service.resolvePageDescription({
-      model: 'clip',
+      model: 'replicate',
       pageUrl: 'https://example.com/page',
     });
     expect(firstOutcome.kind).toBe('pending');
 
     const failedJobId = PageDescriptionJobService.buildJobId({
-      model: 'clip',
+      model: 'replicate',
       pageUrl: 'https://example.com/page',
     });
     await service.activeJobs.get(failedJobId);
@@ -250,7 +250,7 @@ describe('Unit | Services | Page Description Job Service', () => {
     await jobStore.set({
       id: failedJobId,
       jobType: 'page-description',
-      model: 'clip',
+      model: 'replicate',
       pageUrl: 'https://example.com/page',
       status: 'pending',
       createdAt: new Date().toISOString(),
@@ -297,7 +297,7 @@ describe('Unit | Services | Page Description Job Service', () => {
     await jobStore.set({
       id: 'page-job-no-claim',
       jobType: 'page-description',
-      model: 'clip',
+      model: 'replicate',
       pageUrl: 'https://example.com/page',
       status: 'pending',
       createdAt: new Date().toISOString(),
@@ -318,7 +318,7 @@ describe('Unit | Services | Page Description Job Service', () => {
     const pageDescriptionService = {
       describePageWithResolver: jest.fn().mockImplementation(async ({ describeImage }) => ({
         pageUrl: 'https://example.com/page',
-        model: 'clip',
+        model: 'replicate',
         totalImages: 1,
         uniqueImages: 1,
         descriptions: [
@@ -365,14 +365,14 @@ describe('Unit | Services | Page Description Job Service', () => {
     });
 
     const outcome = await service.resolvePageDescription({
-      model: 'clip',
+      model: 'replicate',
       pageUrl: 'https://example.com/page',
     });
 
     expect(outcome.kind).toBe('completed');
     expect(pageDescriptionService.describePageWithResolver).toHaveBeenCalledTimes(1);
     expect(descriptionJobService.resolveDescription).toHaveBeenCalledWith({
-      model: 'clip',
+      model: 'replicate',
       imageUrl: 'https://example.com/a.jpg',
     });
     expect(descriptionJobService.getJobStatus).toHaveBeenCalledWith('description-job-1');
@@ -382,7 +382,7 @@ describe('Unit | Services | Page Description Job Service', () => {
     const pageDescriptionService = {
       describePageWithResolver: jest.fn().mockImplementation(async ({ describeImage }) => ({
         pageUrl: 'https://example.com/page',
-        model: 'clip',
+        model: 'replicate',
         totalImages: 1,
         uniqueImages: 1,
         descriptions: [
@@ -424,7 +424,7 @@ describe('Unit | Services | Page Description Job Service', () => {
     });
 
     await expect(service.resolveImageDescription({
-      model: 'clip',
+      model: 'replicate',
       imageUrl: 'https://example.com/a.jpg',
     })).rejects.toMatchObject({
       message: 'upstream child job failed',
@@ -432,7 +432,7 @@ describe('Unit | Services | Page Description Job Service', () => {
     });
 
     await expect(service.resolveImageDescription({
-      model: 'clip',
+      model: 'replicate',
       imageUrl: 'https://example.com/a.jpg',
     })).rejects.toThrow('Description job failed');
   });

--- a/tests/unit/services/PageDescriptionService.test.js
+++ b/tests/unit/services/PageDescriptionService.test.js
@@ -18,7 +18,7 @@ describe('Unit | Services | Page Description Service', () => {
         description: `description for ${imageUrl}`,
         imageUrl,
       }));
-    const imageDescriberFactory = new ImageDescriberFactory().register('clip', {
+    const imageDescriberFactory = new ImageDescriberFactory().register('replicate', {
       describeImage,
     });
     const service = new PageDescriptionService({
@@ -28,7 +28,7 @@ describe('Unit | Services | Page Description Service', () => {
 
     const result = await service.describePage({
       pageUrl: 'https://example.com/page',
-      model: 'clip',
+      model: 'replicate',
     });
 
     expect(scraperService.getImages).toHaveBeenCalledWith('https://example.com/page');
@@ -37,7 +37,7 @@ describe('Unit | Services | Page Description Service', () => {
     expect(describeImage).toHaveBeenNthCalledWith(2, 'https://example.com/b.jpg');
     expect(result).toEqual({
       pageUrl: 'https://example.com/page',
-      model: 'clip',
+      model: 'replicate',
       totalImages: 3,
       uniqueImages: 2,
       descriptions: [
@@ -206,7 +206,7 @@ describe('Unit | Services | Page Description Service', () => {
         imageUrl,
       };
     });
-    const imageDescriberFactory = new ImageDescriberFactory().register('clip', {
+    const imageDescriberFactory = new ImageDescriberFactory().register('replicate', {
       describeImage,
     });
     const service = new PageDescriptionService({
@@ -217,7 +217,7 @@ describe('Unit | Services | Page Description Service', () => {
 
     const result = await service.describePage({
       pageUrl: 'https://example.com/page',
-      model: 'clip',
+      model: 'replicate',
     });
 
     expect(maxInFlight).toBeLessThanOrEqual(2);
@@ -256,7 +256,7 @@ describe('Unit | Services | Page Description Service', () => {
           imageUrl,
         },
       }));
-    const imageDescriberFactory = new ImageDescriberFactory().register('clip', {
+    const imageDescriberFactory = new ImageDescriberFactory().register('replicate', {
       createDescriptionJob,
       getDescriptionJob,
     });
@@ -269,14 +269,14 @@ describe('Unit | Services | Page Description Service', () => {
 
     const result = await service.describePageWithAsyncJobs({
       pageUrl: 'https://example.com/page',
-      model: 'clip',
+      model: 'replicate',
     });
 
     expect(createDescriptionJob).toHaveBeenCalledTimes(2);
     expect(getDescriptionJob).toHaveBeenCalledTimes(2);
     expect(result).toEqual({
       pageUrl: 'https://example.com/page',
-      model: 'clip',
+      model: 'replicate',
       totalImages: 3,
       uniqueImages: 2,
       descriptions: [
@@ -343,7 +343,7 @@ describe('Unit | Services | Page Description Service', () => {
         ],
       }),
     };
-    const imageDescriberFactory = new ImageDescriberFactory().register('clip', {});
+    const imageDescriberFactory = new ImageDescriberFactory().register('replicate', {});
     const describeImage = jest.fn().mockImplementation(async (imageUrl) => ({
       description: `resolved by job ${imageUrl}`,
       imageUrl,
@@ -355,14 +355,14 @@ describe('Unit | Services | Page Description Service', () => {
 
     const result = await service.describePageWithResolver({
       pageUrl: 'https://example.com/page',
-      model: 'clip',
+      model: 'replicate',
       describeImage,
     });
 
     expect(describeImage).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
       pageUrl: 'https://example.com/page',
-      model: 'clip',
+      model: 'replicate',
       totalImages: 2,
       uniqueImages: 1,
       descriptions: [


### PR DESCRIPTION
## Summary
- rename the public provider/model key from `clip` to `replicate` across the API surface
- update the provider definition module, docs, OpenAPI/Postman assets, and tests to use `replicate` consistently
- keep the underlying Replicate upstream model configuration unchanged

## Validation
- npm run lint
- npm test -- --runInBand
- npm run postman:full

## Notes
- this is a public API contract change: `model=clip` is replaced by `model=replicate`