### PR TITLE
Enable Azure in provider overrides

### DIFF
--- a/config/providers.yaml
+++ b/config/providers.yaml
@@ -3,4 +3,4 @@
 # enabled: auto defers to the normal env-driven runtime behavior.
 providers:
   azure:
-    enabled: false
+    enabled: auto


### PR DESCRIPTION
## Summary
- stop repo-level Azure disablement by switching the override to auto
- keep Azure enablement gated by the existing credential checks

## Validation
- npm test -- --runInBand --coverage=false tests/unit/config/providerOverrides.test.js tests/unit/config/providerCatalog.test.js tests/unit/createApp.test.js tests/unit/utils/validateEnvVars.test.js tests/unit/scripts/postman/providerValidationScope.test.js