### PR TITLE
Fix security audit by pinning path-to-regexp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7259,9 +7259,9 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/performance-now": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,9 @@
     "swagger-ui-express": "^4.6.2",
     "undici": "^6.24.0"
   },
+  "overrides": {
+    "path-to-regexp": "0.1.13"
+  },
   "devDependencies": {
     "allure-commandline": "^2.37.0",
     "allure-jest": "^3.6.0",


### PR DESCRIPTION
## Summary
- fix recurring Security Audit workflow failures caused by a high-severity advisory in transitive `path-to-regexp@0.1.12`
- add an npm override to force `path-to-regexp@0.1.13`
- refresh `package-lock.json` so CI installs the patched resolution

## Notes
- this keeps the existing fail-on-high/critical audit gate unchanged
