### PR TITLE
Harden CI: canonical OpenAPI spec + per-ref Allure Pages concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,8 +533,13 @@ jobs:
     needs:
       - allure-report
     runs-on: ubuntu-latest
+    # Per-ref group: this job only PREPARES an artifact (it never deploys), so it
+    # must not share the global "allure-pages-site" serialization group with the
+    # publish workflow. A global group made concurrent PRs contend, and GitHub
+    # marks the pending runs it drops as "failure" (not "cancelled"), which
+    # surfaced as a spurious red check on otherwise-green PRs.
     concurrency:
-      group: allure-pages-site
+      group: allure-pages-site-${{ github.ref }}
       cancel-in-progress: false
     permissions:
       actions: read

--- a/docs/openapi.base.json
+++ b/docs/openapi.base.json
@@ -1,88 +1,185 @@
 {
-  "openapi": "3.0.0",
-  "info": {
-    "title": "AI-Powered Alternative Text Provider API",
-    "version": "1.0.0",
-    "description": "This API provides descriptions to images, to contribute to the world-wide accessibility efforts."
-  },
   "components": {
-    "securitySchemes": {
-      "bearerAuth": {
-        "type": "http",
-        "scheme": "bearer",
-        "bearerFormat": "API token"
-      },
-      "apiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "X-API-Key"
-      }
-    },
     "schemas": {
       "ApiErrorResponse": {
-        "type": "object",
-        "required": [
-          "error",
-          "code"
-        ],
         "properties": {
-          "error": {
-            "type": "string",
-            "example": "Invalid image_source URL"
-          },
           "code": {
-            "type": "string",
-            "example": "INVALID_IMAGE_SOURCE_URL"
-          },
-          "requestId": {
-            "type": "string",
-            "example": "d5c9fca2-bef2-4ff6-92ff-0227d219d67e"
+            "example": "INVALID_IMAGE_SOURCE_URL",
+            "type": "string"
           },
           "details": {
-            "type": "array",
             "items": {
-              "type": "object",
+              "properties": {
+                "field": {
+                  "example": "image_source",
+                  "type": "string"
+                },
+                "issue": {
+                  "example": "invalid_url",
+                  "type": "string"
+                }
+              },
               "required": [
                 "field",
                 "issue"
               ],
-              "properties": {
-                "field": {
-                  "type": "string",
-                  "example": "image_source"
-                },
-                "issue": {
-                  "type": "string",
-                  "example": "invalid_url"
-                }
-              }
-            }
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "error": {
+            "example": "Invalid image_source URL",
+            "type": "string"
+          },
+          "requestId": {
+            "example": "d5c9fca2-bef2-4ff6-92ff-0227d219d67e",
+            "type": "string"
           }
-        }
+        },
+        "required": [
+          "error",
+          "code"
+        ],
+        "type": "object"
       },
       "DescriptionJobResponse": {
-        "type": "object",
+        "properties": {
+          "error": {
+            "properties": {
+              "code": {
+                "example": "DESCRIPTION_PROVIDER_TIMEOUT",
+                "type": "string"
+              },
+              "message": {
+                "example": "Replicate prediction failed",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "imageUrl": {
+            "example": "https://developer.chrome.com/static/images/ai-homepage-card.png",
+            "type": "string"
+          },
+          "jobId": {
+            "example": "8dbd0c163f9c85166abac1d449f5fe3e78244da0edb8ff6ea7f2e4c4cc6db83d",
+            "type": "string"
+          },
+          "model": {
+            "example": "replicate",
+            "type": "string"
+          },
+          "pollAfterMs": {
+            "example": 1000,
+            "type": "integer"
+          },
+          "result": {
+            "properties": {
+              "description": {
+                "example": "A man with glasses is playing a violin.",
+                "type": "string"
+              },
+              "imageUrl": {
+                "example": "https://developer.chrome.com/static/images/ai-homepage-card.png",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "status": {
+            "enum": [
+              "pending",
+              "processing",
+              "starting",
+              "succeeded",
+              "failed",
+              "canceled"
+            ],
+            "example": "pending",
+            "type": "string"
+          },
+          "statusUrl": {
+            "example": "/api/v1/accessibility/description-jobs/8dbd0c163f9c85166abac1d449f5fe3e78244da0edb8ff6ea7f2e4c4cc6db83d",
+            "type": "string"
+          }
+        },
         "required": [
           "jobId",
           "model",
           "imageUrl",
           "status"
         ],
+        "type": "object"
+      },
+      "PageDescriptionJobResponse": {
         "properties": {
+          "error": {
+            "properties": {
+              "code": {
+                "example": "PAGE_DESCRIPTION_JOB_FETCH_FAILED",
+                "type": "string"
+              },
+              "message": {
+                "example": "Page description job failed",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
           "jobId": {
-            "type": "string",
-            "example": "8dbd0c163f9c85166abac1d449f5fe3e78244da0edb8ff6ea7f2e4c4cc6db83d"
+            "example": "51cc340310a52659fbe9f3d2b9ef754f17f4f2376eb138dfb2cd7f0142ae5db0",
+            "type": "string"
           },
           "model": {
-            "type": "string",
-            "example": "replicate"
+            "example": "replicate",
+            "type": "string"
           },
-          "imageUrl": {
-            "type": "string",
-            "example": "https://developer.chrome.com/static/images/ai-homepage-card.png"
+          "pageUrl": {
+            "example": "https://developer.chrome.com/",
+            "type": "string"
+          },
+          "pollAfterMs": {
+            "example": 1000,
+            "type": "integer"
+          },
+          "result": {
+            "properties": {
+              "descriptions": {
+                "items": {
+                  "properties": {
+                    "description": {
+                      "example": "A man with glasses is playing a violin.",
+                      "type": "string"
+                    },
+                    "imageUrl": {
+                      "example": "https://developer.chrome.com/static/images/ai-homepage-card.png",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "model": {
+                "example": "replicate",
+                "type": "string"
+              },
+              "pageUrl": {
+                "example": "https://developer.chrome.com/",
+                "type": "string"
+              },
+              "totalImages": {
+                "example": 3,
+                "type": "integer"
+              },
+              "uniqueImages": {
+                "example": 2,
+                "type": "integer"
+              }
+            },
+            "type": "object"
           },
           "status": {
-            "type": "string",
             "enum": [
               "pending",
               "processing",
@@ -91,533 +188,113 @@
               "failed",
               "canceled"
             ],
-            "example": "pending"
-          },
-          "pollAfterMs": {
-            "type": "integer",
-            "example": 1000
+            "example": "pending",
+            "type": "string"
           },
           "statusUrl": {
-            "type": "string",
-            "example": "/api/v1/accessibility/description-jobs/8dbd0c163f9c85166abac1d449f5fe3e78244da0edb8ff6ea7f2e4c4cc6db83d"
-          },
-          "result": {
-            "type": "object",
-            "properties": {
-              "description": {
-                "type": "string",
-                "example": "A man with glasses is playing a violin."
-              },
-              "imageUrl": {
-                "type": "string",
-                "example": "https://developer.chrome.com/static/images/ai-homepage-card.png"
-              }
-            }
-          },
-          "error": {
-            "type": "object",
-            "properties": {
-              "message": {
-                "type": "string",
-                "example": "Replicate prediction failed"
-              },
-              "code": {
-                "type": "string",
-                "example": "DESCRIPTION_PROVIDER_TIMEOUT"
-              }
-            }
+            "example": "/api/v1/accessibility/page-description-jobs/51cc340310a52659fbe9f3d2b9ef754f17f4f2376eb138dfb2cd7f0142ae5db0",
+            "type": "string"
           }
-        }
-      },
-      "PageDescriptionJobResponse": {
-        "type": "object",
+        },
         "required": [
           "jobId",
           "model",
           "pageUrl",
           "status"
         ],
-        "properties": {
-          "jobId": {
-            "type": "string",
-            "example": "51cc340310a52659fbe9f3d2b9ef754f17f4f2376eb138dfb2cd7f0142ae5db0"
-          },
-          "model": {
-            "type": "string",
-            "example": "replicate"
-          },
-          "pageUrl": {
-            "type": "string",
-            "example": "https://developer.chrome.com/"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "pending",
-              "processing",
-              "starting",
-              "succeeded",
-              "failed",
-              "canceled"
-            ],
-            "example": "pending"
-          },
-          "pollAfterMs": {
-            "type": "integer",
-            "example": 1000
-          },
-          "statusUrl": {
-            "type": "string",
-            "example": "/api/v1/accessibility/page-description-jobs/51cc340310a52659fbe9f3d2b9ef754f17f4f2376eb138dfb2cd7f0142ae5db0"
-          },
-          "result": {
-            "type": "object",
-            "properties": {
-              "pageUrl": {
-                "type": "string",
-                "example": "https://developer.chrome.com/"
-              },
-              "model": {
-                "type": "string",
-                "example": "replicate"
-              },
-              "totalImages": {
-                "type": "integer",
-                "example": 3
-              },
-              "uniqueImages": {
-                "type": "integer",
-                "example": 2
-              },
-              "descriptions": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "description": {
-                      "type": "string",
-                      "example": "A man with glasses is playing a violin."
-                    },
-                    "imageUrl": {
-                      "type": "string",
-                      "example": "https://developer.chrome.com/static/images/ai-homepage-card.png"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "error": {
-            "type": "object",
-            "properties": {
-              "message": {
-                "type": "string",
-                "example": "Page description job failed"
-              },
-              "code": {
-                "type": "string",
-                "example": "PAGE_DESCRIPTION_JOB_FETCH_FAILED"
-              }
-            }
-          }
-        }
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "apiKeyAuth": {
+        "in": "header",
+        "name": "X-API-Key",
+        "type": "apiKey"
+      },
+      "bearerAuth": {
+        "bearerFormat": "API token",
+        "scheme": "bearer",
+        "type": "http"
       }
     }
   },
+  "info": {
+    "description": "This API provides descriptions to images, to contribute to the world-wide accessibility efforts.",
+    "title": "AI-Powered Alternative Text Provider API",
+    "version": "1.0.0"
+  },
+  "openapi": "3.0.0",
   "paths": {
-    "/api/accessibility/description": {
-      "get": {
-        "summary": "Returns a description for a given image",
-        "description": "Takes an image URL and sends it to the selected AI model to generate an alt-text description. Slow asynchronous providers such as `replicate` can return `202 Accepted` with a job status payload.",
-        "security": [
-          {
-            "bearerAuth": []
-          },
-          {
-            "apiKeyAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "image_source",
-            "in": "query",
-            "description": "URLEncoded address of the image.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "https%3A%2F%2Fdeveloper.chrome.com%2Fstatic%2Fimages%2Fai-homepage-card.png"
-            }
-          },
-          {
-            "name": "model",
-            "in": "query",
-            "description": "The AI model to use, for example `replicate`, `azure`, `ollama`, `huggingface`, `openai`, `openrouter`, or `together`.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "replicate",
-                "azure",
-                "ollama",
-                "huggingface",
-                "openai",
-                "openrouter",
-                "together"
-              ],
-              "example": "replicate"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "description": {
-                        "type": "string",
-                        "example": "A man with glasses is playing a violin."
-                      },
-                      "imageUrl": {
-                        "type": "string",
-                        "example": "https://developer.chrome.com/static/images/ai-homepage-card.png"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "Description job accepted and still processing",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DescriptionJobResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Missing or invalid parameters, or unsupported model",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid API authentication credentials",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "504": {
-            "description": "Description provider timed out before completing the request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/accessibility/descriptions": {
-      "get": {
-        "summary": "Returns descriptions for images found on a page",
-        "description": "Scrapes a website, preserves duplicate image entries in page order, and reuses a single prediction per unique image URL. Slow asynchronous providers such as `replicate` can return `202 Accepted` with a page-description job payload.",
-        "security": [
-          {
-            "bearerAuth": []
-          },
-          {
-            "apiKeyAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "url",
-            "in": "query",
-            "description": "URLEncoded address of the target website.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "https%3A%2F%2Fdeveloper.chrome.com%2F"
-            }
-          },
-          {
-            "name": "model",
-            "in": "query",
-            "description": "The AI model to use, for example `replicate`, `azure`, `ollama`, `huggingface`, `openai`, `openrouter`, or `together`.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "replicate",
-                "azure",
-                "ollama",
-                "huggingface",
-                "openai",
-                "openrouter",
-                "together"
-              ],
-              "example": "replicate"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "202": {
-            "description": "Page-description job accepted and still processing",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PageDescriptionJobResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Missing or invalid parameters, or unsupported model",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid API authentication credentials",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "504": {
-            "description": "Description provider timed out before completing the request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/accessibility/page-description-jobs/{jobId}": {
-      "get": {
-        "summary": "Returns the current status of an asynchronous page-description job",
-        "description": "Poll this endpoint after a `202 Accepted` response from the page-description route.",
-        "security": [
-          {
-            "bearerAuth": []
-          },
-          {
-            "apiKeyAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "jobId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Job has completed or failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PageDescriptionJobResponse"
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "Job is still processing",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PageDescriptionJobResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid API authentication credentials",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Page-description job not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/accessibility/description-jobs/{jobId}": {
-      "get": {
-        "summary": "Returns the current status of an asynchronous description job",
-        "description": "Poll this endpoint after a `202 Accepted` response from the single-image description route.",
-        "security": [
-          {
-            "bearerAuth": []
-          },
-          {
-            "apiKeyAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "jobId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Job has completed or failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DescriptionJobResponse"
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "Job is still processing",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DescriptionJobResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid API authentication credentials",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Description job not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          },
-          "504": {
-            "description": "Description provider timed out while checking job status",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/": {
       "get": {
-        "summary": "Get the public service index",
         "description": "Returns a stable discovery document for the public API surface.",
         "responses": {
           "200": {
-            "description": "Public service metadata and discovery links",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
+                  "properties": {
+                    "auth": {
+                      "properties": {
+                        "schemes": {
+                          "example": [
+                            "X-API-Key",
+                            "Bearer"
+                          ],
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "schemes"
+                      ],
+                      "type": "object"
+                    },
+                    "links": {
+                      "properties": {
+                        "api": {
+                          "example": "/api/v1",
+                          "type": "string"
+                        },
+                        "docs": {
+                          "example": "/api-docs/",
+                          "type": "string"
+                        },
+                        "health": {
+                          "example": "/api/health",
+                          "type": "string"
+                        },
+                        "ping": {
+                          "example": "/api/ping",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "api",
+                        "docs",
+                        "health",
+                        "ping"
+                      ],
+                      "type": "object"
+                    },
+                    "name": {
+                      "example": "alt-text-generator",
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "example": "ok",
+                      "type": "string"
+                    },
+                    "version": {
+                      "example": "1.0.0",
+                      "type": "string"
+                    }
+                  },
                   "required": [
                     "name",
                     "version",
@@ -626,174 +303,128 @@
                     "auth",
                     "requestId"
                   ],
-                  "properties": {
-                    "name": {
-                      "type": "string",
-                      "example": "alt-text-generator"
-                    },
-                    "version": {
-                      "type": "string",
-                      "example": "1.0.0"
-                    },
-                    "status": {
-                      "type": "string",
-                      "example": "ok"
-                    },
-                    "links": {
-                      "type": "object",
-                      "required": [
-                        "api",
-                        "docs",
-                        "health",
-                        "ping"
-                      ],
-                      "properties": {
-                        "api": {
-                          "type": "string",
-                          "example": "/api/v1"
-                        },
-                        "docs": {
-                          "type": "string",
-                          "example": "/api-docs/"
-                        },
-                        "health": {
-                          "type": "string",
-                          "example": "/api/health"
-                        },
-                        "ping": {
-                          "type": "string",
-                          "example": "/api/ping"
-                        }
-                      }
-                    },
-                    "auth": {
-                      "type": "object",
-                      "required": [
-                        "schemes"
-                      ],
-                      "properties": {
-                        "schemes": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          },
-                          "example": [
-                            "X-API-Key",
-                            "Bearer"
-                          ]
-                        }
-                      }
-                    },
-                    "requestId": {
-                      "type": "string"
-                    }
-                  }
+                  "type": "object"
                 }
               }
-            }
+            },
+            "description": "Public service metadata and discovery links"
           },
           "500": {
             "description": "Server error"
           }
-        }
+        },
+        "summary": "Get the public service index"
       }
     },
-    "/api/ping": {
+    "/api/accessibility/description": {
       "get": {
-        "summary": "Check if the API is available",
+        "description": "Takes an image URL and sends it to the selected AI model to generate an alt-text description. Slow asynchronous providers such as `replicate` can return `202 Accepted` with a job status payload.",
+        "parameters": [
+          {
+            "description": "URLEncoded address of the image.",
+            "in": "query",
+            "name": "image_source",
+            "required": true,
+            "schema": {
+              "example": "https%3A%2F%2Fdeveloper.chrome.com%2Fstatic%2Fimages%2Fai-homepage-card.png",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The AI model to use, for example `replicate`, `azure`, `ollama`, `huggingface`, `openai`, `openrouter`, or `together`.",
+            "in": "query",
+            "name": "model",
+            "required": true,
+            "schema": {
+              "enum": [
+                "replicate",
+                "azure",
+                "ollama",
+                "huggingface",
+                "openai",
+                "openrouter",
+                "together"
+              ],
+              "example": "replicate",
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "API is online and listening",
             "content": {
-              "text/plain": {
+              "application/json": {
                 "schema": {
-                  "type": "string",
-                  "example": "pong"
+                  "items": {
+                    "properties": {
+                      "description": {
+                        "example": "A man with glasses is playing a violin.",
+                        "type": "string"
+                      },
+                      "imageUrl": {
+                        "example": "https://developer.chrome.com/static/images/ai-homepage-card.png",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
                 }
               }
-            }
+            },
+            "description": "OK"
+          },
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DescriptionJobResponse"
+                }
+              }
+            },
+            "description": "Description job accepted and still processing"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid parameters, or unsupported model"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid API authentication credentials"
           },
           "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
             "description": "Server error"
-          }
-        }
-      }
-    },
-    "/api/health": {
-      "get": {
-        "summary": "Check if the API is ready to serve traffic",
-        "responses": {
-          "200": {
-            "description": "API is online and ready",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "message",
-                    "ready",
-                    "timestamp",
-                    "uptime"
-                  ],
-                  "properties": {
-                    "uptime": {
-                      "type": "number"
-                    },
-                    "message": {
-                      "type": "string",
-                      "example": "OK"
-                    },
-                    "ready": {
-                      "type": "boolean",
-                      "example": true
-                    },
-                    "timestamp": {
-                      "type": "number"
-                    }
-                  }
-                }
-              }
-            }
           },
-          "503": {
-            "description": "API is draining and should be removed from service",
+          "504": {
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": [
-                    "message",
-                    "ready",
-                    "timestamp",
-                    "uptime"
-                  ],
-                  "properties": {
-                    "uptime": {
-                      "type": "number"
-                    },
-                    "message": {
-                      "type": "string",
-                      "example": "DRAINING"
-                    },
-                    "ready": {
-                      "type": "boolean",
-                      "example": false
-                    },
-                    "timestamp": {
-                      "type": "number"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiErrorResponse"
                 }
               }
-            }
+            },
+            "description": "Description provider timed out before completing the request"
           }
-        }
-      }
-    },
-    "/api/scraper/images": {
-      "get": {
-        "summary": "Returns the list of images found in a website",
-        "description": "Visits the website, selects img elements, and returns their src URLs as JSON.",
+        },
         "security": [
           {
             "bearerAuth": []
@@ -802,68 +433,437 @@
             "apiKeyAuth": []
           }
         ],
+        "summary": "Returns a description for a given image"
+      }
+    },
+    "/api/accessibility/description-jobs/{jobId}": {
+      "get": {
+        "description": "Poll this endpoint after a `202 Accepted` response from the single-image description route.",
         "parameters": [
           {
-            "name": "url",
-            "in": "query",
-            "description": "URLEncoded address of the target website.",
+            "in": "path",
+            "name": "jobId",
             "required": true,
             "schema": {
-              "type": "string",
-              "example": "https%3A%2F%2Fdeveloper.chrome.com%2F"
+              "type": "string"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "imageSources": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/DescriptionJobResponse"
                 }
               }
-            }
+            },
+            "description": "Job has completed or failed"
           },
-          "400": {
-            "description": "Missing or invalid url parameter",
+          "202": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiErrorResponse"
+                  "$ref": "#/components/schemas/DescriptionJobResponse"
                 }
               }
-            }
+            },
+            "description": "Job is still processing"
           },
           "401": {
-            "description": "Missing or invalid API authentication credentials",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApiErrorResponse"
                 }
               }
-            }
+            },
+            "description": "Missing or invalid API authentication credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Description job not found"
           },
           "500": {
-            "description": "Server error",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApiErrorResponse"
                 }
               }
+            },
+            "description": "Server error"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Description provider timed out while checking job status"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "summary": "Returns the current status of an asynchronous description job"
+      }
+    },
+    "/api/accessibility/descriptions": {
+      "get": {
+        "description": "Scrapes a website, preserves duplicate image entries in page order, and reuses a single prediction per unique image URL. Slow asynchronous providers such as `replicate` can return `202 Accepted` with a page-description job payload.",
+        "parameters": [
+          {
+            "description": "URLEncoded address of the target website.",
+            "in": "query",
+            "name": "url",
+            "required": true,
+            "schema": {
+              "example": "https%3A%2F%2Fdeveloper.chrome.com%2F",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The AI model to use, for example `replicate`, `azure`, `ollama`, `huggingface`, `openai`, `openrouter`, or `together`.",
+            "in": "query",
+            "name": "model",
+            "required": true,
+            "schema": {
+              "enum": [
+                "replicate",
+                "azure",
+                "ollama",
+                "huggingface",
+                "openai",
+                "openrouter",
+                "together"
+              ],
+              "example": "replicate",
+              "type": "string"
             }
           }
-        }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDescriptionJobResponse"
+                }
+              }
+            },
+            "description": "Page-description job accepted and still processing"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid parameters, or unsupported model"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid API authentication credentials"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server error"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Description provider timed out before completing the request"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "summary": "Returns descriptions for images found on a page"
+      }
+    },
+    "/api/accessibility/page-description-jobs/{jobId}": {
+      "get": {
+        "description": "Poll this endpoint after a `202 Accepted` response from the page-description route.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "jobId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDescriptionJobResponse"
+                }
+              }
+            },
+            "description": "Job has completed or failed"
+          },
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageDescriptionJobResponse"
+                }
+              }
+            },
+            "description": "Job is still processing"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid API authentication credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Page-description job not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "summary": "Returns the current status of an asynchronous page-description job"
+      }
+    },
+    "/api/health": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "example": "OK",
+                      "type": "string"
+                    },
+                    "ready": {
+                      "example": true,
+                      "type": "boolean"
+                    },
+                    "timestamp": {
+                      "type": "number"
+                    },
+                    "uptime": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "ready",
+                    "timestamp",
+                    "uptime"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "API is online and ready"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "example": "DRAINING",
+                      "type": "string"
+                    },
+                    "ready": {
+                      "example": false,
+                      "type": "boolean"
+                    },
+                    "timestamp": {
+                      "type": "number"
+                    },
+                    "uptime": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "ready",
+                    "timestamp",
+                    "uptime"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "API is draining and should be removed from service"
+          }
+        },
+        "summary": "Check if the API is ready to serve traffic"
+      }
+    },
+    "/api/ping": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "example": "pong",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "API is online and listening"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        },
+        "summary": "Check if the API is available"
+      }
+    },
+    "/api/scraper/images": {
+      "get": {
+        "description": "Visits the website, selects img elements, and returns their src URLs as JSON.",
+        "parameters": [
+          {
+            "description": "URLEncoded address of the target website.",
+            "in": "query",
+            "name": "url",
+            "required": true,
+            "schema": {
+              "example": "https%3A%2F%2Fdeveloper.chrome.com%2F",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "imageSources": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid url parameter"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Missing or invalid API authentication credentials"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Server error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "apiKeyAuth": []
+          }
+        ],
+        "summary": "Returns the list of images found in a website"
       }
     }
   },

--- a/scripts/openapi/spec-utils.js
+++ b/scripts/openapi/spec-utils.js
@@ -35,16 +35,49 @@ function serializeSpec(spec) {
 }
 
 /**
+ * Returns a structurally identical copy of `value` with every object's keys
+ * sorted lexicographically. Arrays keep their order (it can be semantically
+ * meaningful in OpenAPI: `enum`, `parameters`, `required`, `security`, `tags`).
+ *
+ * This makes the committed artifact and the freshness gate depend only on the
+ * spec's *content*, not on the key-insertion order that swagger-jsdoc happens to
+ * emit. A generator upgrade that merely reorders keys (e.g. swagger-jsdoc 6.3.0
+ * moving response codes) therefore produces identical bytes, while a real
+ * contract change (added/removed/renamed path, schema, or field) still differs.
+ *
+ * @param {*} value
+ * @returns {*}
+ */
+function canonicalizeSpec(value) {
+  if (Array.isArray(value)) {
+    return value.map(canonicalizeSpec);
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return Object.keys(value)
+      .sort()
+      .reduce((acc, key) => {
+        acc[key] = canonicalizeSpec(value[key]);
+        return acc;
+      }, {});
+  }
+
+  return value;
+}
+
+/**
  * Regenerates the server-agnostic base spec from the JSDoc sources. The runtime
  * `servers` block is stripped because it is environment-specific and injected
- * by config/swagger.js at serve time.
+ * by config/swagger.js at serve time. The result is canonicalized so the
+ * committed artifact stays stable across swagger-jsdoc versions that only change
+ * key ordering.
  *
  * @returns {object}
  */
 function generateFreshSpec() {
   const spec = swaggerJSDoc(getSwaggerJSDocOptions());
   delete spec.servers;
-  return spec;
+  return canonicalizeSpec(spec);
 }
 
 /**
@@ -176,6 +209,7 @@ function listSecuritySchemeNames(spec) {
 module.exports = {
   GENERATED_SPEC_PATH,
   HTTP_METHODS,
+  canonicalizeSpec,
   collectRefs,
   generateFreshSpec,
   listOperations,

--- a/tests/unit/scripts/github/allurePagesWorkflow.test.js
+++ b/tests/unit/scripts/github/allurePagesWorkflow.test.js
@@ -78,6 +78,16 @@ describe('Unit | Workflows | CI Allure Pages', () => {
       Object.hasOwn(allurePagesJob, 'environment'),
       false,
     );
+    assertStringContainsInvariant(
+      'CI Allure Pages job scopes concurrency per ref so concurrent PRs never cancel each other into a spurious failure',
+      allurePagesJob.concurrency.group,
+      '${{ github.ref }}',
+    );
+    assertEqualInvariant(
+      'CI Allure Pages job queues rather than cancels in-progress site preparation',
+      allurePagesJob.concurrency['cancel-in-progress'],
+      false,
+    );
     assertEqualInvariant(
       'CI Allure Pages job fetches the durable gh-pages state branch',
       fetchPagesBranchStep.run,

--- a/tests/unit/scripts/openapi/specFreshness.test.js
+++ b/tests/unit/scripts/openapi/specFreshness.test.js
@@ -8,6 +8,7 @@ const {
 } = require('../../../../scripts/openapi/check-freshness');
 const {
   GENERATED_SPEC_PATH,
+  canonicalizeSpec,
   generateFreshSpec,
   readSpecText,
   serializeSpec,
@@ -85,8 +86,50 @@ describe('Unit | Scripts | OpenAPI | Freshness Check', () => {
     });
   });
 
+  describe('canonicalizeSpec', () => {
+    it('sorts object keys recursively', () => {
+      const result = canonicalizeSpec({ openapi: '3.0.0', info: { version: '1', title: 'x' } });
+
+      expect(Object.keys(result)).toEqual(['info', 'openapi']);
+      expect(Object.keys(result.info)).toEqual(['title', 'version']);
+    });
+
+    it('preserves array order and canonicalizes objects nested in arrays', () => {
+      const result = canonicalizeSpec({ tags: [{ name: 'b' }, { name: 'a' }], required: ['z', 'a'] });
+
+      expect(result.required).toEqual(['z', 'a']);
+      expect(result.tags.map((tag) => tag.name)).toEqual(['b', 'a']);
+    });
+
+    it('returns primitives and null unchanged', () => {
+      expect(canonicalizeSpec(null)).toBeNull();
+      expect(canonicalizeSpec(7)).toBe(7);
+      expect(canonicalizeSpec('s')).toBe('s');
+    });
+
+    it('is idempotent', () => {
+      const canonical = canonicalizeSpec({ b: { d: 1, c: 2 }, a: [{ z: 1, y: 2 }] });
+
+      expect(serializeSpec(canonicalizeSpec(canonical))).toBe(serializeSpec(canonical));
+    });
+
+    it('makes specs that differ only in key order serialize identically (the generator-version-resilience invariant)', () => {
+      const oneEmitOrder = {
+        openapi: '3.0.0',
+        paths: { '/x': { get: { summary: 's', responses: { default: {} }, tags: ['t'] } } },
+      };
+      const anotherEmitOrder = {
+        paths: { '/x': { get: { tags: ['t'], responses: { default: {} }, summary: 's' } } },
+        openapi: '3.0.0',
+      };
+
+      expect(serializeSpec(canonicalizeSpec(oneEmitOrder)))
+        .toBe(serializeSpec(canonicalizeSpec(anotherEmitOrder)));
+    });
+  });
+
   describe('committed artifact', () => {
-    it('is exactly what the generator produces (the freshness invariant)', () => {
+    it('is exactly what the canonical generator produces (the freshness invariant)', () => {
       expect(fs.existsSync(GENERATED_SPEC_PATH)).toBe(true);
       expect(readSpecText(GENERATED_SPEC_PATH)).toBe(serializeSpec(generateFreshSpec()));
     });


### PR DESCRIPTION
## Summary

Two unrelated CI defects, both surfaced by the current batch of dependency-update PRs, let cosmetic or environmental noise red otherwise-healthy builds. This hardens both so the required checks track real contract and test health only.

## 1. OpenAPI freshness survives generator key-order churn

**Problem.** `docs/openapi.base.json` is byte-pinned to the key order swagger-jsdoc happens to emit. The `swagger-jsdoc 6.2.8 → 6.3.0` bump reorders operation fields, so the freshness gate (`openapi` job) and the `specFreshness` invariant failed across `test:unit` (Node 20/22/24) and `test:ci` — four red required checks for a release that changed **no** public contract.

**Fix.** `generateFreshSpec` now canonicalizes output: object keys are sorted recursively, arrays keep their order (order is meaningful for `enum` / `parameters` / `required` / `security` / `tags`). The committed artifact and the freshness comparison therefore depend only on content. Real contract drift (added/removed/renamed path, schema, or field) still diffs; pure reordering no longer does.

**Verified.** Installed `swagger-jsdoc@6.3.0` transiently and regenerated — the canonical artifact is **byte-for-byte identical** to the 6.2.8 output. The committed spec is regenerated in canonical form (reorder only).

## 2. Allure Pages prep no longer false-fails on concurrent PRs

**Problem.** The `allure-pages` job shares the global `allure-pages-site` concurrency group with the publish workflow, yet it only *prepares* an artifact and never deploys. When several PRs run together they contend for that one group, and GitHub marks the pending runs it drops as **`failure`** (not `cancelled`) — a spurious red on green PRs.

**Fix.** Scope the prep job's group per `github.ref`. Concurrent refs stop cancelling each other; the publish workflow's intentional global serialization is untouched.

## Tests

- `canonicalizeSpec` unit coverage: recursive key sort, array-order preservation, idempotence, and the version-resilience invariant.
- Workflow invariant asserting the `allure-pages` prep job uses a per-ref concurrency group.
- Full `validate:fast` (lint + openapi:validate + openapi:check + unit lane) green locally.

## Impact on open dependency PRs

Once this lands, rebasing the open update PRs clears their red: the swagger-jsdoc bump passes freshness with no spec change on its branch, and the bumps that only tripped `allure-pages` go fully green.
