### PR TITLE
Centralize test env/mock isolation with shared Jest setup (QE-009)

### DIFF
--- a/config/jest/jest.base.cjs
+++ b/config/jest/jest.base.cjs
@@ -4,6 +4,10 @@ const path = require('node:path');
 const ROOT_DIR = path.resolve(__dirname, '..', '..');
 const JEST_CONFIG_DIR = __dirname;
 
+// Shared lifecycle (env + mock restoration) every lane inherits, so the cleanup
+// cannot drift between lanes or be forgotten in a single suite.
+const JEST_SETUP_FILE = path.join(ROOT_DIR, 'tests', 'setup', 'jest.setup.js');
+
 // Coverage gate shared by the coverage and CI lanes so the threshold is
 // identical regardless of which entry point enforces it.
 const COVERAGE_COLLECTION_PATTERNS = [
@@ -132,6 +136,7 @@ function createLaneConfig({
     rootDir: ROOT_DIR,
     displayName,
     testMatch,
+    setupFilesAfterEnv: [JEST_SETUP_FILE],
     ...resolveTestEnvironment(),
   };
 
@@ -160,6 +165,7 @@ const COMPOSED_LANES = [
 
 module.exports = {
   ROOT_DIR,
+  JEST_SETUP_FILE,
   COVERAGE_COLLECTION_PATTERNS,
   COVERAGE_PATH_IGNORE_PATTERNS,
   COVERAGE_THRESHOLD,

--- a/tests/setup/jest.setup.js
+++ b/tests/setup/jest.setup.js
@@ -1,0 +1,27 @@
+/**
+ * QE-009 shared Jest lifecycle, registered for every lane via
+ * setupFilesAfterEnv.
+ *
+ * It snapshots the environment each test file inherits and restores it (and
+ * resets Jest mock state) after every test, so a missed manual restore in one
+ * test cannot contaminate another when Jest runs files in parallel. Tests that
+ * need a specific environment use the helpers in tests/setup/testEnv.js; the
+ * cleanup here is automatic and needs no per-file afterEach.
+ */
+
+const BASELINE_ENV = { ...process.env };
+
+function restoreBaselineEnv() {
+  Object.keys(process.env).forEach((key) => {
+    if (!(key in BASELINE_ENV)) {
+      delete process.env[key];
+    }
+  });
+  Object.assign(process.env, BASELINE_ENV);
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  jest.clearAllMocks();
+  restoreBaselineEnv();
+});

--- a/tests/setup/testEnv.js
+++ b/tests/setup/testEnv.js
@@ -1,0 +1,100 @@
+/**
+ * QE-009 shared test-environment helpers.
+ *
+ * Pairs with tests/setup/jest.setup.js, which restores the file's baseline
+ * environment (and Jest mock state) after every test. These helpers let a test
+ * mutate the environment or load a module against a specific environment
+ * without hand-rolling save/restore or module-cache juggling.
+ */
+
+/**
+ * Applies environment overrides in place. A string (or number) value sets the
+ * key; `null` or `undefined` deletes it. Values are coerced to strings to match
+ * how process.env stores them.
+ *
+ * @param {Record<string, string | number | null | undefined>} [overrides]
+ */
+function setEnv(overrides = {}) {
+  Object.entries(overrides).forEach(([key, value]) => {
+    if (value === null || value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = String(value);
+    }
+  });
+}
+
+/**
+ * Runs `fn` with `overrides` applied to process.env, then restores the exact
+ * prior environment — even if `fn` throws or rejects. Returns whatever `fn`
+ * returns, awaiting it when it is a promise.
+ *
+ * @template T
+ * @param {Record<string, string | number | null | undefined>} overrides
+ * @param {() => T} fn
+ * @returns {T}
+ */
+function withEnv(overrides, fn) {
+  const snapshot = { ...process.env };
+  const restore = () => {
+    Object.keys(process.env).forEach((key) => {
+      if (!(key in snapshot)) {
+        delete process.env[key];
+      }
+    });
+    Object.assign(process.env, snapshot);
+  };
+
+  setEnv(overrides);
+
+  let result;
+  try {
+    result = fn();
+  } catch (error) {
+    restore();
+    throw error;
+  }
+
+  if (result !== null && typeof result === 'object' && typeof result.then === 'function') {
+    return result.then(
+      (value) => {
+        restore();
+        return value;
+      },
+      (error) => {
+        restore();
+        throw error;
+      },
+    );
+  }
+
+  restore();
+  return result;
+}
+
+/**
+ * Loads a module against a fresh registry so its module-level environment reads
+ * run again, optionally applying `overrides` first. `loader` is a callback that
+ * performs the require, keeping require resolution in the caller's module scope
+ * (e.g. `loadFreshModule(() => require('../../../config'), { LOG_LEVEL: 'warn' })`).
+ * Any overrides persist until the active test ends, where jest.setup.js restores
+ * the file's baseline environment.
+ *
+ * @template T
+ * @param {() => T} loader
+ * @param {Record<string, string | number | null | undefined>} [overrides]
+ * @returns {T}
+ */
+function loadFreshModule(loader, overrides) {
+  if (overrides) {
+    setEnv(overrides);
+  }
+
+  let loaded;
+  jest.isolateModules(() => {
+    loaded = loader();
+  });
+  return loaded;
+}
+
+module.exports = { setEnv, withEnv, loadFreshModule };

--- a/tests/unit/config/index.test.js
+++ b/tests/unit/config/index.test.js
@@ -2,7 +2,6 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const ORIGINAL_ENV = process.env;
 const {
   DEFAULT_DESCRIPTION_JOB_CLAIM_TTL_MS,
   DEFAULT_DESCRIPTION_JOB_COMPLETED_TTL_MS,
@@ -17,30 +16,23 @@ const {
   DEFAULT_RATE_LIMIT_REDIS_PREFIX,
   DEFAULT_UNIT_LOCAL_REDIS_URL,
 } = require('../../../config/rateLimitStore');
+const { loadFreshModule } = require('../../setup/testEnv');
 
-const loadConfig = ({ overrides = {}, remove = [] } = {}) => {
-  jest.resetModules();
-  process.env = { ...ORIGINAL_ENV };
-  process.env.PROVIDER_OVERRIDES_FILE = path.join(
-    __dirname,
-    '../../fixtures/provider-overrides.missing.yaml',
-  );
+const DEFAULT_PROVIDER_OVERRIDES_FILE = path.join(
+  __dirname,
+  '../../fixtures/provider-overrides.missing.yaml',
+);
 
-  remove.forEach((key) => {
-    delete process.env[key];
-  });
-
-  Object.entries(overrides).forEach(([key, value]) => {
-    process.env[key] = value;
-  });
-
-  return require('../../../config');
-};
-
-afterEach(() => {
-  process.env = ORIGINAL_ENV;
-  jest.resetModules();
-});
+// Env restoration and module-cache isolation are handled by tests/setup; this
+// loader only declares the environment each fresh config load should see.
+const loadConfig = ({ overrides = {}, remove = [] } = {}) => loadFreshModule(
+  () => require('../../../config'),
+  {
+    PROVIDER_OVERRIDES_FILE: DEFAULT_PROVIDER_OVERRIDES_FILE,
+    ...Object.fromEntries(remove.map((key) => [key, undefined])),
+    ...overrides,
+  },
+);
 
 describe('Unit | Config | Index', () => {
   it('uses the documented defaults when optional env vars are unset', () => {

--- a/tests/unit/infrastructure/logger.test.js
+++ b/tests/unit/infrastructure/logger.test.js
@@ -1,4 +1,4 @@
-const ORIGINAL_ENV = process.env;
+const { setEnv, loadFreshModule } = require('../../setup/testEnv');
 
 const mockStdSerializers = {
   err: jest.fn((error) => ({
@@ -51,14 +51,7 @@ const loadLoggerModule = ({
   env = {},
   randomUUID = 'generated-request-id',
 } = {}) => {
-  jest.resetModules();
-  process.env = { ...ORIGINAL_ENV };
-  delete process.env.NODE_ENV;
-  delete process.env.LOG_LEVEL;
-
-  Object.entries(env).forEach(([key, value]) => {
-    process.env[key] = value;
-  });
+  setEnv({ NODE_ENV: undefined, LOG_LEVEL: undefined, ...env });
 
   mockRandomUUID.mockReset().mockReturnValue(randomUUID);
   mockFs.existsSync.mockReset();
@@ -79,7 +72,7 @@ const loadLoggerModule = ({
   });
   mockPinoHttp.stdSerializers = mockStdSerializers;
 
-  const loggerModule = require('../../../src/infrastructure/logger');
+  const loggerModule = loadFreshModule(() => require('../../../src/infrastructure/logger'));
 
   return {
     loggerModule,
@@ -89,12 +82,6 @@ const loadLoggerModule = ({
     requestLoggerOptions: mockRequestLogger.options,
   };
 };
-
-afterEach(() => {
-  process.env = ORIGINAL_ENV;
-  jest.clearAllMocks();
-  jest.resetModules();
-});
 
 describe('Unit | Infrastructure | Logger', () => {
   it('uses process-stream logging in production without touching the filesystem', () => {

--- a/tests/unit/jestConfig.test.js
+++ b/tests/unit/jestConfig.test.js
@@ -6,38 +6,19 @@ const {
   COVERAGE_PATH_IGNORE_PATTERNS,
   COVERAGE_THRESHOLD,
 } = require('../../config/jest/jest.base.cjs');
+const { loadFreshModule } = require('../setup/testEnv');
 
+// tests/setup restores ALLURE_RESULTS_DIR after each test; this loader only
+// declares whether it is set for a given config load.
 function loadJestConfig(allureResultsDir) {
-  let config;
-
-  if (typeof allureResultsDir === 'string') {
-    process.env.ALLURE_RESULTS_DIR = allureResultsDir;
-  } else {
-    delete process.env.ALLURE_RESULTS_DIR;
-  }
-
-  jest.resetModules();
-  jest.isolateModules(() => {
+  return loadFreshModule(
     // eslint-disable-next-line import/no-dynamic-require
-    config = require(CONFIG_PATH);
-  });
-
-  return config;
+    () => require(CONFIG_PATH),
+    { ALLURE_RESULTS_DIR: typeof allureResultsDir === 'string' ? allureResultsDir : undefined },
+  );
 }
 
 describe('Unit | Jest Configuration', () => {
-  const originalAllureResultsDir = process.env.ALLURE_RESULTS_DIR;
-
-  afterEach(() => {
-    if (typeof originalAllureResultsDir === 'string') {
-      process.env.ALLURE_RESULTS_DIR = originalAllureResultsDir;
-    } else {
-      delete process.env.ALLURE_RESULTS_DIR;
-    }
-
-    jest.resetModules();
-  });
-
   it('keeps the standard node environment when Allure is disabled', () => {
     const config = loadJestConfig();
 

--- a/tests/unit/scripts/postman/providerValidationPublicFixtures.test.js
+++ b/tests/unit/scripts/postman/providerValidationPublicFixtures.test.js
@@ -5,14 +5,9 @@ const {
   buildRawGitHubUrl,
   resolvePublicFixtureRepositoryContext,
 } = require('../../../../scripts/postman/provider-validation-public-fixtures');
+const { setEnv } = require('../../../setup/testEnv');
 
 describe('Unit | Scripts | Postman | Provider Validation Public Fixtures', () => {
-  const originalEnv = { ...process.env };
-
-  afterEach(() => {
-    process.env = { ...originalEnv };
-  });
-
   it('builds raw GitHub urls for the default repository and ref', () => {
     expect(buildPublicProviderValidationFixtureUrls({
       repository: 'jsugg/alt-text-generator',
@@ -26,8 +21,7 @@ describe('Unit | Scripts | Postman | Provider Validation Public Fixtures', () =>
   });
 
   it('prefers GitHub repository context when it is available', () => {
-    process.env.GITHUB_REPOSITORY = 'octo/example';
-    process.env.GITHUB_SHA = '0123456789abcdef';
+    setEnv({ GITHUB_REPOSITORY: 'octo/example', GITHUB_SHA: '0123456789abcdef' });
 
     expect(resolvePublicFixtureRepositoryContext()).toEqual({
       repository: 'octo/example',

--- a/tests/unit/setup/fixtures/envAtLoad.js
+++ b/tests/unit/setup/fixtures/envAtLoad.js
@@ -1,0 +1,4 @@
+// Fixture for loadFreshModule isolation: captures an env var at module-load
+// time. Re-requiring it yields the cached value unless a fresh module registry
+// re-evaluates this file, which is exactly what loadFreshModule must do.
+module.exports = process.env.QE009_FRESH;

--- a/tests/unit/setup/testEnv.test.js
+++ b/tests/unit/setup/testEnv.test.js
@@ -1,0 +1,75 @@
+const { setEnv, withEnv, loadFreshModule } = require('../../setup/testEnv');
+
+describe('Unit | Test Setup | testEnv helpers', () => {
+  describe('setEnv', () => {
+    it('sets string values and coerces numbers to strings', () => {
+      setEnv({ QE009_A: 'x', QE009_B: 7 });
+
+      expect(process.env.QE009_A).toBe('x');
+      expect(process.env.QE009_B).toBe('7');
+    });
+
+    it('deletes keys given null or undefined', () => {
+      process.env.QE009_DELME = 'present';
+
+      setEnv({ QE009_DELME: undefined });
+
+      expect('QE009_DELME' in process.env).toBe(false);
+    });
+  });
+
+  describe('withEnv', () => {
+    it('applies overrides for the callback then restores the prior environment', () => {
+      process.env.QE009_KEEP = 'original';
+
+      const seen = withEnv({ QE009_KEEP: 'temp', QE009_NEW: 'added' }, () => ({
+        keep: process.env.QE009_KEEP,
+        added: process.env.QE009_NEW,
+      }));
+
+      expect(seen).toEqual({ keep: 'temp', added: 'added' });
+      expect(process.env.QE009_KEEP).toBe('original');
+      expect('QE009_NEW' in process.env).toBe(false);
+    });
+
+    it('restores the environment even when the callback throws', () => {
+      process.env.QE009_KEEP = 'original';
+
+      expect(() => withEnv({ QE009_KEEP: 'temp' }, () => {
+        throw new Error('boom');
+      })).toThrow('boom');
+
+      expect(process.env.QE009_KEEP).toBe('original');
+    });
+
+    it('awaits and restores after an async callback', async () => {
+      delete process.env.QE009_ASYNC;
+
+      const result = await withEnv({ QE009_ASYNC: 'on' }, async () => {
+        expect(process.env.QE009_ASYNC).toBe('on');
+        return 'done';
+      });
+
+      expect(result).toBe('done');
+      expect('QE009_ASYNC' in process.env).toBe(false);
+    });
+  });
+
+  describe('loadFreshModule', () => {
+    it('applies overrides before invoking the loader', () => {
+      delete process.env.QE009_FRESH;
+
+      const seen = loadFreshModule(() => process.env.QE009_FRESH, { QE009_FRESH: 'ready' });
+
+      expect(seen).toBe('ready');
+    });
+
+    it('re-evaluates module-level reads on each load via a fresh registry', () => {
+      const first = loadFreshModule(() => require('./fixtures/envAtLoad'), { QE009_FRESH: 'first' });
+      const second = loadFreshModule(() => require('./fixtures/envAtLoad'), { QE009_FRESH: 'second' });
+
+      expect(first).toBe('first');
+      expect(second).toBe('second');
+    });
+  });
+});

--- a/tests/unit/utils/validateEnvVars.test.js
+++ b/tests/unit/utils/validateEnvVars.test.js
@@ -1,6 +1,7 @@
 const path = require('node:path');
 
-const ORIGINAL_ENV = process.env;
+const { loadFreshModule } = require('../../setup/testEnv');
+
 const NO_PROVIDER_OVERRIDES_FILE = path.join(
   __dirname,
   '../../fixtures/provider-overrides.missing.yaml',
@@ -57,31 +58,18 @@ const PROVIDER_ENV_KEYS = [
   'TOGETHER_PROMPT',
 ];
 
-const loadValidator = ({ overrides = {}, remove = [] } = {}) => {
-  jest.resetModules();
-  process.env = { ...ORIGINAL_ENV };
-
-  PROVIDER_ENV_KEYS.forEach((key) => {
-    delete process.env[key];
-  });
-
-  process.env.PROVIDER_OVERRIDES_FILE = NO_PROVIDER_OVERRIDES_FILE;
-
-  remove.forEach((key) => {
-    delete process.env[key];
-  });
-
-  Object.entries(overrides).forEach(([key, value]) => {
-    process.env[key] = value;
-  });
-
-  return require('../../../src/utils/validateEnvVars').validateEnvVars;
-};
-
-afterEach(() => {
-  process.env = ORIGINAL_ENV;
-  jest.resetModules();
-});
+// Env restoration and module-cache isolation are handled by tests/setup. Each
+// load starts from the provider-free baseline (every provider key cleared) and
+// then applies the test's removals and overrides.
+const loadValidator = ({ overrides = {}, remove = [] } = {}) => loadFreshModule(
+  () => require('../../../src/utils/validateEnvVars').validateEnvVars,
+  {
+    ...Object.fromEntries(PROVIDER_ENV_KEYS.map((key) => [key, undefined])),
+    PROVIDER_OVERRIDES_FILE: NO_PROVIDER_OVERRIDES_FILE,
+    ...Object.fromEntries(remove.map((key) => [key, undefined])),
+    ...overrides,
+  },
+);
 
 describe('Unit | Utils | Validate Env Vars', () => {
   it('accepts a Replicate-only provider configuration', () => {


### PR DESCRIPTION
## Summary

QE-009 from the testing roadmap: environment and module-cache handling was ad hoc and duplicated. Five specs each carried their own `const ORIGINAL_ENV = process.env`, a `beforeEach`/`afterEach` save-restore, and hand-rolled `jest.resetModules()`. A single forgotten restore can contaminate an unrelated test once Jest runs files in parallel — exactly the kind of latent flake this centralizes away.

## Change

- **`tests/setup/jest.setup.js`** — registered for every lane via `setupFilesAfterEnv` in `createLaneConfig`, so the cleanup cannot drift between lanes or be forgotten in one suite. It snapshots the environment each test file inherits and restores it (and resets Jest mock state) after every test.
- **`tests/setup/testEnv.js`** — `setEnv`, `withEnv(overrides, fn)`, and `loadFreshModule(loader, overrides)` helpers. `loadFreshModule` takes a `() => require(...)` callback so require resolution stays in the caller's module scope, and loads through `jest.isolateModules` for a fresh registry.
- **Refactored specs** — `config/index`, `utils/validateEnvVars`, `infrastructure/logger`, `jestConfig`, and `scripts/postman/providerValidationPublicFixtures` now use the helpers and drop their bespoke env/module bookkeeping.

## Safety

The global setup was added and the **full unit lane run before any spec was refactored** — all 86 suites stayed green, proving the automatic env + mock restoration is non-breaking for the other suites, not just the five touched here.

## Tests

- New `testEnv` helper unit tests: value coercion, deletion, scoped restore (including throw and async paths), and fresh-registry re-evaluation.
- Unit, integration, and script lanes green under default Jest parallelism.

## Roadmap

Closes the last open item from the testing-best-practices remediation (QE-001..QE-018); QE-009 was the only finding without an artifact.
