### PR TITLE
ci: Node 24 cutover — canonical gates, derived promotion checks (PR-2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '20'
+          node-version-file: .nvmrc
 
       - name: Validate docs
         if: needs.changes.outputs.docs_changed == 'true'
@@ -123,8 +123,6 @@ jobs:
       - name: Setup project
         if: needs.changes.outputs.docs_only != 'true'
         uses: ./.github/actions/setup-node-project
-        with:
-          node-version: '20'
 
       - name: Run lint
         if: needs.changes.outputs.docs_only != 'true'
@@ -148,8 +146,6 @@ jobs:
       - name: Setup project
         if: needs.changes.outputs.docs_only != 'true'
         uses: ./.github/actions/setup-node-project
-        with:
-          node-version: '20'
 
       - name: Validate OpenAPI contract
         if: needs.changes.outputs.docs_only != 'true'
@@ -185,7 +181,6 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - '20'
           - '22'
           - '24'
     steps:
@@ -211,82 +206,6 @@ jobs:
         run: echo "Docs-only change; unit matrix gate satisfied by docs validation."
 
   test-ci:
-    name: test:ci (20)
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    needs:
-      - changes
-    services:
-      redis:
-        image: redis:8.8.0-alpine3.23
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    env:
-      REDIS_INTEGRATION_MODE: required
-      REDIS_INTEGRATION_URL: redis://127.0.0.1:6379
-    steps:
-      - name: Checkout
-        if: needs.changes.outputs.docs_only != 'true'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Setup project
-        if: needs.changes.outputs.docs_only != 'true'
-        uses: ./.github/actions/setup-node-project
-        with:
-          node-version: '20'
-
-      - name: 'test:ci'
-        if: needs.changes.outputs.docs_only != 'true'
-        run: npm run test:ci
-        env:
-          ALLURE_RESULTS_DIR: reports/allure-results
-          NODE_ENV: test
-          REPLICATE_API_TOKEN: test-token
-          JEST_JUNIT_OUTPUT_DIR: reports/jest
-          JEST_JUNIT_OUTPUT_NAME: junit.xml
-          JEST_JUNIT_ADD_FILE_ATTRIBUTE: true
-
-      - name: Skip full Jest gate for docs-only change
-        if: needs.changes.outputs.docs_only == 'true'
-        run: echo "Docs-only change; canonical full Jest gate satisfied by docs validation."
-
-      - name: Upload Jest test results
-        if: always() && needs.changes.outputs.docs_only != 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: jest-results-node-20
-          path: reports/jest/
-          if-no-files-found: ignore
-          retention-days: 7
-
-      - name: Upload Jest coverage
-        if: always() && needs.changes.outputs.docs_only != 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: jest-coverage-node-20
-          path: coverage/
-          if-no-files-found: ignore
-          retention-days: 7
-
-      - name: Upload Jest Allure results
-        if: always() && needs.changes.outputs.docs_only != 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: jest-allure-results-node-20
-          path: reports/allure-results/
-          if-no-files-found: ignore
-          retention-days: 7
-
-  # Staged Node 24 full gate (required-check migration): runs the canonical
-  # test:ci lane on Node 24 alongside the Node 20 gate. Gate-only during the
-  # transition — it must not upload Jest/coverage/Allure artifacts, so the
-  # canonical Node 20 lane stays the single reporting source until cutover.
-  test-ci-24:
     name: test:ci (24)
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -313,19 +232,48 @@ jobs:
       - name: Setup project
         if: needs.changes.outputs.docs_only != 'true'
         uses: ./.github/actions/setup-node-project
-        with:
-          node-version: '24'
 
       - name: 'test:ci'
         if: needs.changes.outputs.docs_only != 'true'
         run: npm run test:ci
         env:
+          ALLURE_RESULTS_DIR: reports/allure-results
           NODE_ENV: test
           REPLICATE_API_TOKEN: test-token
+          JEST_JUNIT_OUTPUT_DIR: reports/jest
+          JEST_JUNIT_OUTPUT_NAME: junit.xml
+          JEST_JUNIT_ADD_FILE_ATTRIBUTE: true
 
       - name: Skip full Jest gate for docs-only change
         if: needs.changes.outputs.docs_only == 'true'
-        run: echo "Docs-only change; Node 24 full Jest gate satisfied by docs validation."
+        run: echo "Docs-only change; canonical full Jest gate satisfied by docs validation."
+
+      - name: Upload Jest test results
+        if: always() && needs.changes.outputs.docs_only != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: jest-results-node-24
+          path: reports/jest/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload Jest coverage
+        if: always() && needs.changes.outputs.docs_only != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: jest-coverage-node-24
+          path: coverage/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload Jest Allure results
+        if: always() && needs.changes.outputs.docs_only != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: jest-allure-results-node-24
+          path: reports/allure-results/
+          if-no-files-found: ignore
+          retention-days: 7
 
   newman:
     name: newman
@@ -344,8 +292,6 @@ jobs:
       - name: Setup project
         if: needs.changes.outputs.docs_only != 'true'
         uses: ./.github/actions/setup-node-project
-        with:
-          node-version: '20'
 
       - name: Lint Postman collection policy
         if: needs.changes.outputs.docs_only != 'true'
@@ -448,8 +394,6 @@ jobs:
 
       - name: Setup project
         uses: ./.github/actions/setup-node-project
-        with:
-          node-version: '20'
 
       - name: Download Jest Allure results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 24
+          node-version-file: .nvmrc
 
       - name: Review dependency changes
         env:

--- a/.github/workflows/live-provider-validation.yml
+++ b/.github/workflows/live-provider-validation.yml
@@ -57,8 +57,6 @@ jobs:
 
       - name: Setup project
         uses: ./.github/actions/setup-node-project
-        with:
-          node-version: '20'
 
       - name: Resolve provider scope
         env:

--- a/.github/workflows/local-provider-integration.yml
+++ b/.github/workflows/local-provider-integration.yml
@@ -52,8 +52,6 @@ jobs:
 
       - name: Setup project
         uses: ./.github/actions/setup-node-project
-        with:
-          node-version: '20'
 
       - name: Run local provider integration suite
         run: npm run postman:full

--- a/.github/workflows/post-deploy-verification.yml
+++ b/.github/workflows/post-deploy-verification.yml
@@ -53,8 +53,6 @@ jobs:
 
       - name: Setup project
         uses: ./.github/actions/setup-node-project
-        with:
-          node-version: '20'
 
       - name: Resolve post-deploy provider scope
         env:
@@ -120,8 +118,6 @@ jobs:
 
       - name: Setup project
         uses: ./.github/actions/setup-node-project
-        with:
-          node-version: '20'
 
       - name: Download Newman Allure results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Setup project
         uses: ./.github/actions/setup-node-project
-        with:
-          node-version: '20'
 
       - name: Resolve pre-production provider scope
         env:
@@ -76,7 +74,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '20'
+          node-version-file: .nvmrc
 
       - name: Resolve promotion auth strategy
         id: promotion-auth
@@ -110,7 +108,6 @@ jobs:
             --repo "${{ github.repository }}" \
             --source-branch "main" \
             --target-branch "production" \
-            --required-checks "actionlint,codeql,dependency-review,docs,lint,openapi,newman,test:ci (20),test:unit (20),test:unit (22),test:unit (24)" \
             --output-file "${GITHUB_OUTPUT}" \
             --summary-file "${GITHUB_STEP_SUMMARY}"
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Setup project
         uses: ./.github/actions/setup-node-project
-        with:
-          node-version: '20'
 
       - name: Run production dependency audit
         id: audit

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ reports/jest/*
 !reports/jest/.gitkeep
 
 repotoolingbot.2026-03-10.private-key.pem
+
+.local/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -28,7 +28,7 @@ If you only need a quick local boot, start with `README.md` and come back here f
 
 Recommended toolchain:
 
-- Node.js 24.x recommended (`.nvmrc` pins 24; compatibility is validated on Node 20, 22, and 24 while the staged Node 24 cutover completes)
+- Node.js 24.x (`.nvmrc` pins 24; Node 22 is also validated as a compatibility lane)
 - npm 10+
 
 Boot locally:
@@ -122,7 +122,7 @@ The repository uses a small workflow set with separate responsibilities:
 - `CI` in `.github/workflows/ci.yml`
   - runs on pushes to `main` and `production`
   - runs on pull requests targeting `main` and `production`
-  - executes `actionlint`, docs validation, `npm run lint`, OpenAPI validation, the fast `test:unit` lane on Node 20/22/24, and the canonical Node 20 `test:ci` lane
+  - executes `actionlint`, docs validation, `npm run lint`, OpenAPI validation, the fast `test:unit` lane on Node 22/24, and the canonical Node 24 `test:ci` lane
   - uses `postman:smoke` as the required deterministic Newman contract gate on pull requests and pushes
   - treats Markdown/docs-only changes as lightweight: docs validation runs, while lint/OpenAPI/Jest/Newman jobs publish successful no-op checks instead of booting expensive gates
   - publishes a Newman summary derived from JSON artifacts into the workflow summary
@@ -307,7 +307,7 @@ Allure workflow:
 - `npm run test:allure` uses `config/jest/jest.reporting.cjs` and enables the official `allure-jest` adapter only for that run.
 - `npm run postman:full:allure` enables the official Newman Allure reporter without removing the existing JSON/JUnit exports.
 - `npm run report:allure` mirrors CI by cleaning old results, running Jest, running the deterministic Newman harness, and generating HTML from the merged `reports/allure-results/` directory.
-- GitHub Actions publishes Allure from the canonical Node 20 Jest lane only so matrix lanes 22 and 24 do not duplicate unit tests in the merged report.
+- GitHub Actions publishes Allure from the canonical Node 24 Jest lane only so the Node 22 compatibility lane does not duplicate unit tests in the merged report.
 - The public GitHub Pages deployment is `https://jsugg.github.io/alt-text-generator/`; the suites view is `https://jsugg.github.io/alt-text-generator/#suites`.
 - Same-repository pull requests publish to `https://jsugg.github.io/alt-text-generator/pr/<number>/`, keeping a separate public Allure surface from `main`.
 - The CI workflow resolves a stream-specific history policy before report generation. `main` uses `ci-main`, same-repository pull requests use `ci-pr-<number>`, and pushes to `production` do not persist CI branch history.

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ The service exposes these primary capabilities:
 
 ## Requirements
 
-- CI validates Node 20, 22, and 24; a staged Node 24 full gate (`test:ci (24)`) runs ahead of the Node 24 cutover.
-- `engines.node` allows Node 20 through 24; `.nvmrc` pins Node 24 for local toolchains.
+- Node 24 is canonical (`.nvmrc`); CI also validates Node 22 as a compatibility lane.
+- `engines.node` allows Node 22 through 24; production (Render) resolves Node 24.
 - npm 10+
 - At least one provider configuration:
   - `REPLICATE_API_TOKEN` for the `replicate` model
@@ -115,7 +115,7 @@ Notes:
 - `postman:smoke` is the fast deterministic gate.
 - `postman:full` runs the full local provider-integration suite, including protected-endpoint auth coverage, deterministic async `replicate` page-job success/failure scenarios, mocked provider-validation coverage, and JSON/JUnit reports under `reports/newman/`.
 - Local smoke/full runs warm Swagger docs before Newman starts so docs cold-start latency stays outside the 15s Newman performance budget while Swagger status/content assertions remain blocking.
-- CI also emits `reports/jest/junit.xml` from the canonical Node 20 Jest lane and publishes one combined GitHub test report that joins Jest and Newman results.
+- CI also emits `reports/jest/junit.xml` from the canonical Node 24 Jest lane and publishes one combined GitHub test report that joins Jest and Newman results.
 - `postman:pre-production-provider` boots the app locally and runs the low-cost real-provider validation set used immediately before promotion, currently Hugging Face, OpenAI, and Together when configured.
 - `postman:live-provider` is the production description-service validation command for deployed-app plus live-provider checks against a supplied base URL.
 - `postman:post-deploy` runs post-deploy smoke plus the same low-cost real-provider validation set against a supplied base URL.
@@ -123,7 +123,7 @@ Notes:
 - When production auth is enabled, `postman:live-provider` and `postman:post-deploy` reuse `PRODUCTION_DEPLOY_VALIDATION_API_TOKEN` for provider-validation requests.
 - CI runs `postman:smoke` as the required Newman contract gate on pull requests and pushes.
 - `postman:full` runs in the path-gated/manual/scheduled Local Provider Integration workflow for provider/API/Postman harness risk, so ordinary CI no longer duplicates the expensive suite.
-- Fast unit tests run across Node 20/22/24; full integration, coverage, JUnit/Allure reporting, and Newman smoke run once on canonical Node 20.
+- Fast unit tests run across Node 22/24; full integration, coverage, JUnit/Allure reporting, and Newman smoke run once on canonical Node 24.
 - Docs-only changes get lightweight docs validation while expensive code gates publish successful no-op checks.
 - Post-deploy verification runs `postman:post-deploy` on `production` pushes so smoke and low-cost provider checks stay inside the Newman contract layer.
 - Post-deploy verification also reads `PRODUCTION_API_AUTH_ENABLED` and `PRODUCTION_DEPLOY_VALIDATION_API_TOKEN` from the GitHub Actions environment so protected-endpoint checks match the deployed Render `API_AUTH_ENABLED` / `API_AUTH_TOKENS` state.
@@ -172,7 +172,7 @@ Notes:
 - Fork PRs and post-deploy verification reports remain artifacts only; they do not publish to GitHub Pages.
 - Fork pull requests and custom post-deploy verification URLs stay ephemeral and do not restore or persist history artifacts.
 - Manual post-deploy verification against the canonical production URL only persists history when `persist_history=true` is selected in the workflow dispatch form.
-- CI only emits Jest Allure results from the Node 20 lane so unit tests do not appear three times in the merged report.
+- CI only emits Jest Allure results from the canonical Node 24 lane so the Node 22 compatibility lane does not duplicate unit tests in the merged report.
 - The Allure CLI requires Java when you generate the HTML report locally or in CI.
 
 ## Runtime Essentials

--- a/config/github/required-checks.json
+++ b/config/github/required-checks.json
@@ -1,0 +1,54 @@
+{
+  "description": "Single source of truth for GitHub required status checks. Every context must exactly match a workflow job display name. Verified offline (policy vs workflow job names) by tests/unit/scripts/github/requiredCheckPolicy.test.js and against live GitHub state by `npm run checks:verify -- --live`. See docs/required-checks.md for the migration and rollback procedure.",
+  "mainBranchProtection": {
+    "branch": "main",
+    "contexts": [
+      "actionlint",
+      "codeql",
+      "dependency-review",
+      "docs",
+      "lint",
+      "newman",
+      "openapi",
+      "test:ci (20)",
+      "test:unit (20)",
+      "test:unit (22)",
+      "test:unit (24)"
+    ]
+  },
+  "productionRuleset": {
+    "id": 13764136,
+    "name": "production",
+    "contexts": [
+      "actionlint",
+      "codeql",
+      "dependency-review",
+      "docs",
+      "lint",
+      "newman",
+      "openapi",
+      "test:ci (20)",
+      "test:unit (20)",
+      "test:unit (22)",
+      "test:unit (24)"
+    ],
+    "bypassActors": [
+      {
+        "actor_id": 5,
+        "actor_type": "RepositoryRole",
+        "bypass_mode": "always",
+        "rationale": "Repository admin break-glass on a single-maintainer repository."
+      },
+      {
+        "actor_id": 3062508,
+        "actor_type": "Integration",
+        "bypass_mode": "always",
+        "rationale": "Repository tooling GitHub App (REPO_TOOLING_GITHUB_APP_ID) used by promote-to-production to update the protected production ref."
+      }
+    ]
+  },
+  "retiredContextPatterns": [
+    "^test \\(\\d+\\)$",
+    "^test:all \\(\\d+\\)$"
+  ]
+}

--- a/config/github/required-checks.json
+++ b/config/github/required-checks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Single source of truth for GitHub required status checks. Every context must exactly match a workflow job display name. Verified offline (policy vs workflow job names) by tests/unit/scripts/github/requiredCheckPolicy.test.js and against live GitHub state by `npm run checks:verify -- --live`. See docs/required-checks.md for the migration and rollback procedure.",
+  "description": "Single source of truth for GitHub required status checks. Every context must exactly match a workflow job display name. Verified offline (policy vs workflow job names) by tests/unit/scripts/github/requiredCheckPolicy.test.js and against live GitHub state by `npm run checks:verify -- --live`. See docs/required-checks.md for the migration and rollback procedure. Node 24 is the canonical gate; the test:unit (22) lane still runs as a non-required compatibility signal.",
   "mainBranchProtection": {
     "branch": "main",
     "contexts": [
@@ -10,9 +10,7 @@
       "lint",
       "newman",
       "openapi",
-      "test:ci (20)",
-      "test:unit (20)",
-      "test:unit (22)",
+      "test:ci (24)",
       "test:unit (24)"
     ]
   },
@@ -27,9 +25,7 @@
       "lint",
       "newman",
       "openapi",
-      "test:ci (20)",
-      "test:unit (20)",
-      "test:unit (22)",
+      "test:ci (24)",
       "test:unit (24)"
     ],
     "bypassActors": [
@@ -49,6 +45,8 @@
   },
   "retiredContextPatterns": [
     "^test \\(\\d+\\)$",
-    "^test:all \\(\\d+\\)$"
+    "^test:all \\(\\d+\\)$",
+    "^test:ci \\(20\\)$",
+    "^test:unit \\(20\\)$"
   ]
 }

--- a/docs/required-checks.md
+++ b/docs/required-checks.md
@@ -1,0 +1,58 @@
+# Required status checks — policy, verification, and migration
+
+`config/github/required-checks.json` is the single source of truth for the
+required status checks on the `main` branch protection and the `production`
+repository ruleset (`13764136`). Every context in that file must exactly match
+a workflow job display name; GitHub matches required checks by name, so a job
+rename silently breaks the gate.
+
+## Verification
+
+| Command | Scope |
+|---|---|
+| `npm run checks:verify` | Offline: policy vs workflow job names, retired-name patterns, duplicates, and the promotion workflow's check list. Runs in unit tests too (`tests/unit/scripts/github/requiredCheckPolicy.test.js`). |
+| `npm run checks:verify -- --live` | Adds live GitHub verification: `main` branch protection contexts, production ruleset contexts, and ruleset bypass actors. Requires a `gh` login with admin read access; run manually, not in CI. |
+
+## Live-state export (before any policy mutation)
+
+Export and keep the current state before changing branch protection, rulesets,
+or repository settings. Store exports outside version control (for example
+`.local/ci-cd-evidence/`, which is gitignored):
+
+```bash
+gh api repos/jsugg/alt-text-generator/branches/main/protection > main-protection.json
+gh api repos/jsugg/alt-text-generator/rulesets/13764136 > production-ruleset.json
+gh api repos/jsugg/alt-text-generator/environments > environments.json
+gh api repos/jsugg/alt-text-generator/actions/permissions > actions-permissions.json
+```
+
+## Migration staging (Node 24 cutover)
+
+1. Add the new Node 24 gate (`test:ci (24)`) while the Node 20 gate still
+   exists; merge; then add the new context to live required checks.
+2. Only during the cutover window: remove Node 20 contexts from live
+   protection, then merge the workflow change that removes the Node 20 jobs.
+3. Patch the production ruleset to mirror the final release policy in the same
+   window; re-export both JSON states afterwards.
+4. Update `config/github/required-checks.json` in the same PR as the workflow
+   change so offline verification stays green at every step.
+
+## Rollback
+
+Reapply the exported JSON if a patch locks a branch or blocks promotion:
+
+```bash
+gh api -X PUT repos/jsugg/alt-text-generator/branches/main/protection/required_status_checks/contexts \
+  --input restored-contexts.json
+gh api -X PUT repos/jsugg/alt-text-generator/rulesets/13764136 --input production-ruleset.json
+```
+
+## Production ruleset bypass actors
+
+| Actor | Mode | Rationale |
+|---|---|---|
+| `RepositoryRole/5` (admin) | always | Admin break-glass on a single-maintainer repository. |
+| `Integration/3062508` | always | Repository tooling GitHub App (`REPO_TOOLING_GITHUB_APP_ID`); `promote-to-production` uses it to update the protected `production` ref. |
+
+Any other bypass actor is unintended; `npm run checks:verify -- --live` fails
+if the live bypass list drifts from the policy file.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "homepage": "https://github.com/jsugg/alt-text-generator#readme",
   "main": "src/app.js",
   "engines": {
-    "node": ">=20 <25"
+    "node": ">=22 <25"
   },
   "scripts": {
     "allure:clean": "node -e \"const fs=require('node:fs'); for (const dir of ['reports/allure-results','reports/allure-report']) { fs.rmSync(dir,{recursive:true,force:true}); fs.mkdirSync(dir,{recursive:true}); fs.writeFileSync(dir + '/.gitkeep', ''); }\"",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "allure:clean": "node -e \"const fs=require('node:fs'); for (const dir of ['reports/allure-results','reports/allure-report']) { fs.rmSync(dir,{recursive:true,force:true}); fs.mkdirSync(dir,{recursive:true}); fs.writeFileSync(dir + '/.gitkeep', ''); }\"",
     "allure:generate": "allure generate reports/allure-results --clean -o reports/allure-report",
     "allure:open": "allure open reports/allure-report",
+    "checks:verify": "node scripts/github/verify-required-checks.js",
     "doctor:tls": "node scripts/doctor-tls.js",
     "docs:validate": "node scripts/docs/validate-docs.js",
     "dev:test-env": "ENV_FILE=.env.test NODE_ENV=development nodemon src/app.js | pino-pretty -i streams,options",

--- a/scripts/github/verify-required-checks.js
+++ b/scripts/github/verify-required-checks.js
@@ -1,0 +1,518 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+/**
+ * Verifies the required status-check policy (config/github/required-checks.json)
+ * against workflow job display names and, with --live, against live GitHub
+ * branch protection and the production repository ruleset.
+ */
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const DEFAULT_POLICY_PATH = path.join(REPO_ROOT, 'config', 'github', 'required-checks.json');
+const WORKFLOWS_DIR = path.join(REPO_ROOT, '.github', 'workflows');
+const PROMOTE_WORKFLOW_FILE = 'promote-to-production.yml';
+const MATRIX_TOKEN_PATTERN = /\$\{\{\s*matrix\.([a-zA-Z0-9_-]+)\s*\}\}/gu;
+
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Parses command-line arguments.
+ *
+ * @param {string[]} argv
+ * @returns {{ live: boolean, policyPath: string, repo: string }}
+ */
+function parseArgs(argv) {
+  const args = {
+    live: false,
+    policyPath: DEFAULT_POLICY_PATH,
+    repo: process.env.GITHUB_REPOSITORY || 'jsugg/alt-text-generator',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+
+    if (token === '--live') {
+      args.live = true;
+    } else if (token === '--policy' || token === '--repo') {
+      const value = argv[index + 1];
+      index += 1;
+
+      if (value === undefined) {
+        throw new Error(`Missing value for ${token}`);
+      }
+
+      if (token === '--policy') {
+        args.policyPath = path.resolve(value);
+      } else {
+        args.repo = value;
+      }
+    } else {
+      throw new Error(`Unsupported argument: ${token}`);
+    }
+  }
+
+  return args;
+}
+
+/**
+ * Loads and shape-checks the required-check policy file.
+ *
+ * @param {string} [policyPath]
+ * @returns {{
+ *   mainBranchProtection: { branch: string, contexts: string[] },
+ *   productionRuleset: {
+ *     id: number,
+ *     contexts: string[],
+ *     bypassActors: { actor_id: number, actor_type: string, bypass_mode: string }[],
+ *   },
+ *   retiredContextPatterns: string[],
+ * }}
+ */
+function loadPolicy(policyPath = DEFAULT_POLICY_PATH) {
+  const policy = JSON.parse(fs.readFileSync(policyPath, 'utf8'));
+
+  if (
+    !isRecord(policy)
+    || !isRecord(policy.mainBranchProtection)
+    || !Array.isArray(policy.mainBranchProtection.contexts)
+    || !isRecord(policy.productionRuleset)
+    || !Array.isArray(policy.productionRuleset.contexts)
+    || !Array.isArray(policy.retiredContextPatterns)
+  ) {
+    throw new Error(`Malformed required-check policy: ${policyPath}`);
+  }
+
+  return policy;
+}
+
+/**
+ * Builds every combination of matrix axis values.
+ *
+ * @param {{ key: string, values: unknown[] }[]} axes
+ * @returns {{ key: string, value: unknown }[][]}
+ */
+function cartesianProduct(axes) {
+  return axes.reduce((combinations, axis) => (
+    combinations.flatMap((combination) => axis.values.map((value) => (
+      combination.concat([{ key: axis.key, value }])
+    )))
+  ), [[]]);
+}
+
+/**
+ * Resolves the check names a job publishes, expanding matrix name templates.
+ *
+ * @param {string} jobId
+ * @param {Record<string, any>} job
+ * @returns {{ names: string[], failures: string[] }}
+ */
+function expandJobCheckNames(jobId, job) {
+  const template = typeof job.name === 'string' ? job.name : jobId;
+
+  if (!template.includes('${{')) {
+    return { names: [template], failures: [] };
+  }
+
+  const matrix = isRecord(job.strategy) && isRecord(job.strategy.matrix)
+    ? job.strategy.matrix
+    : null;
+
+  if (!matrix) {
+    return {
+      names: [],
+      failures: [`job "${jobId}" uses an expression in its name without a matrix to resolve it`],
+    };
+  }
+
+  const axes = Object.entries(matrix)
+    .filter(([key, values]) => key !== 'include' && key !== 'exclude' && Array.isArray(values))
+    .map(([key, values]) => ({ key, values }));
+  const names = cartesianProduct(axes).map((combination) => {
+    const substitutions = new Map(combination.map(({ key, value }) => [key, String(value)]));
+
+    return template.replace(MATRIX_TOKEN_PATTERN, (token, key) => (
+      substitutions.has(key) ? substitutions.get(key) : token
+    ));
+  });
+  const unresolved = names.filter((name) => name.includes('${{'));
+
+  if (unresolved.length > 0) {
+    return {
+      names: [],
+      failures: [
+        `job "${jobId}" name "${template}" contains expressions the verifier cannot resolve: `
+        + unresolved.join(', '),
+      ],
+    };
+  }
+
+  return { names, failures: [] };
+}
+
+/**
+ * @param {unknown} triggers
+ * @returns {string[]}
+ */
+function normalizeTriggerNames(triggers) {
+  if (typeof triggers === 'string') {
+    return [triggers];
+  }
+
+  if (Array.isArray(triggers)) {
+    return triggers.filter((trigger) => typeof trigger === 'string');
+  }
+
+  if (isRecord(triggers)) {
+    return Object.keys(triggers);
+  }
+
+  return [];
+}
+
+/**
+ * Collects the check names published by branch-gating workflows (any workflow
+ * triggered by push or pull_request), keyed by check name with their sources.
+ *
+ * @param {string} [workflowsDir]
+ * @returns {{ checkNames: Map<string, string[]>, failures: string[] }}
+ */
+function collectEmittedCheckNames(workflowsDir = WORKFLOWS_DIR) {
+  const checkNames = new Map();
+  const failures = [];
+
+  fs.readdirSync(workflowsDir)
+    .filter((fileName) => fileName.endsWith('.yml') || fileName.endsWith('.yaml'))
+    .sort((left, right) => left.localeCompare(right))
+    .forEach((fileName) => {
+      const workflow = yaml.load(fs.readFileSync(path.join(workflowsDir, fileName), 'utf8'));
+
+      if (!isRecord(workflow) || !isRecord(workflow.jobs)) {
+        return;
+      }
+
+      const triggers = normalizeTriggerNames(workflow.on);
+
+      if (!triggers.includes('push') && !triggers.includes('pull_request')) {
+        return;
+      }
+
+      Object.entries(workflow.jobs).forEach(([jobId, job]) => {
+        if (!isRecord(job)) {
+          return;
+        }
+
+        const expansion = expandJobCheckNames(jobId, job);
+
+        failures.push(...expansion.failures.map((failure) => `${fileName}: ${failure}`));
+        expansion.names.forEach((name) => {
+          const sources = checkNames.get(name) || [];
+
+          sources.push(`${fileName}#${jobId}`);
+          checkNames.set(name, sources);
+        });
+      });
+    });
+
+  return { checkNames, failures };
+}
+
+/**
+ * @param {string[]} values
+ * @returns {string[]} values that appear more than once
+ */
+function findDuplicates(values) {
+  const seen = new Set();
+  const duplicates = new Set();
+
+  values.forEach((value) => {
+    if (seen.has(value)) {
+      duplicates.add(value);
+    }
+
+    seen.add(value);
+  });
+
+  return [...duplicates];
+}
+
+/**
+ * Verifies the policy against workflow-emitted check names.
+ *
+ * @param {ReturnType<typeof loadPolicy>} policy
+ * @param {ReturnType<typeof collectEmittedCheckNames>} collected
+ * @returns {string[]} failure descriptions; empty when the policy holds
+ */
+function verifyOfflinePolicy(policy, collected) {
+  const failures = [...collected.failures];
+  const retiredPatterns = policy.retiredContextPatterns.map((pattern) => new RegExp(pattern, 'u'));
+  const mainContexts = policy.mainBranchProtection.contexts;
+  const productionContexts = policy.productionRuleset.contexts;
+
+  collected.checkNames.forEach((sources, name) => {
+    if (sources.length > 1) {
+      failures.push(
+        `check name "${name}" is published by multiple jobs (${sources.join(', ')}); `
+        + 'required-check contexts must be unambiguous',
+      );
+    }
+  });
+
+  [
+    { contexts: mainContexts, label: 'mainBranchProtection' },
+    { contexts: productionContexts, label: 'productionRuleset' },
+  ].forEach(({ contexts, label }) => {
+    findDuplicates(contexts).forEach((context) => {
+      failures.push(`${label} lists duplicate context "${context}"`);
+    });
+    contexts.forEach((context) => {
+      if (!collected.checkNames.has(context)) {
+        failures.push(
+          `${label} context "${context}" is not published by any push/pull_request workflow job`,
+        );
+      }
+
+      retiredPatterns.forEach((pattern) => {
+        if (pattern.test(context)) {
+          failures.push(`${label} context "${context}" matches retired pattern ${pattern}`);
+        }
+      });
+    });
+  });
+
+  const mainContextSet = new Set(mainContexts);
+
+  productionContexts.forEach((context) => {
+    if (!mainContextSet.has(context)) {
+      failures.push(
+        `productionRuleset context "${context}" is not part of the main branch policy; `
+        + 'the release ruleset must not require checks main does not gate on',
+      );
+    }
+  });
+
+  return failures;
+}
+
+/**
+ * Extracts the hardcoded --required-checks list from the promotion workflow.
+ *
+ * @param {string} [workflowsDir]
+ * @returns {string[]|null} the parsed list, or null when the flag is absent
+ */
+function parsePromotionRequiredChecks(workflowsDir = WORKFLOWS_DIR) {
+  const workflow = yaml.load(
+    fs.readFileSync(path.join(workflowsDir, PROMOTE_WORKFLOW_FILE), 'utf8'),
+  );
+
+  if (!isRecord(workflow) || !isRecord(workflow.jobs)) {
+    throw new Error(`Malformed workflow: ${PROMOTE_WORKFLOW_FILE}`);
+  }
+
+  const runCommands = Object.values(workflow.jobs).flatMap((job) => (
+    isRecord(job) && Array.isArray(job.steps)
+      ? job.steps.filter((step) => isRecord(step) && typeof step.run === 'string')
+      : []
+  )).map((step) => step.run);
+  const promotionCommand = runCommands.find((run) => run.includes('promote-to-production.js'));
+
+  if (!promotionCommand) {
+    throw new Error(`${PROMOTE_WORKFLOW_FILE} does not invoke promote-to-production.js`);
+  }
+
+  const match = promotionCommand.match(/--required-checks\s+"([^"]*)"/u);
+
+  if (!match) {
+    return null;
+  }
+
+  return match[1].split(',').map((value) => value.trim()).filter(Boolean);
+}
+
+/**
+ * Compares two context lists as sets and reports both diff directions.
+ *
+ * @param {string} label
+ * @param {string[]} expected
+ * @param {string[]} actual
+ * @returns {string[]}
+ */
+function formatSetDiff(label, expected, actual) {
+  const expectedSet = new Set(expected);
+  const actualSet = new Set(actual);
+  const missing = expected.filter((value) => !actualSet.has(value));
+  const unexpected = actual.filter((value, index) => (
+    !expectedSet.has(value) && actual.indexOf(value) === index
+  ));
+  const failures = [];
+
+  if (missing.length > 0) {
+    failures.push(`${label}: missing expected contexts: ${missing.join(', ')}`);
+  }
+
+  if (unexpected.length > 0) {
+    failures.push(`${label}: unexpected contexts: ${unexpected.join(', ')}`);
+  }
+
+  return failures;
+}
+
+/**
+ * Verifies the promotion workflow stays aligned with the policy while it still
+ * hardcodes required checks. A null list (flag removed) is aligned by design:
+ * the promotion script then derives checks from live main branch protection.
+ *
+ * @param {ReturnType<typeof loadPolicy>} policy
+ * @param {string[]|null} promotionChecks
+ * @returns {string[]}
+ */
+function verifyPromotionAlignment(policy, promotionChecks) {
+  if (promotionChecks === null) {
+    return [];
+  }
+
+  return formatSetDiff(
+    'promotion workflow --required-checks',
+    policy.mainBranchProtection.contexts,
+    promotionChecks,
+  );
+}
+
+/**
+ * Runs a gh CLI command and returns trimmed stdout.
+ *
+ * @param {string[]} args
+ * @returns {string}
+ */
+function runGh(args) {
+  return execFileSync('gh', args, {
+    encoding: 'utf8',
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+/**
+ * @param {string[]} args
+ * @returns {any}
+ */
+function runGhJson(args) {
+  return JSON.parse(runGh(args));
+}
+
+/**
+ * Verifies live main branch protection against the policy.
+ *
+ * @param {ReturnType<typeof loadPolicy>} policy
+ * @param {string} repo
+ * @returns {string[]}
+ */
+function verifyLiveMainProtection(policy, repo) {
+  const { branch } = policy.mainBranchProtection;
+  const payload = runGhJson(['api', `repos/${repo}/branches/${branch}/protection`]);
+  const liveContexts = payload.required_status_checks.contexts;
+
+  return formatSetDiff(
+    `live ${branch} branch protection`,
+    policy.mainBranchProtection.contexts,
+    liveContexts,
+  ).concat(findDuplicates(liveContexts).map((context) => (
+    `live ${branch} branch protection lists duplicate context "${context}"`
+  )));
+}
+
+/**
+ * Verifies the live production ruleset (contexts and bypass actors).
+ *
+ * @param {ReturnType<typeof loadPolicy>} policy
+ * @param {string} repo
+ * @returns {string[]}
+ */
+function verifyLiveProductionRuleset(policy, repo) {
+  const ruleset = runGhJson(['api', `repos/${repo}/rulesets/${policy.productionRuleset.id}`]);
+  const checksRule = (ruleset.rules || []).find((rule) => rule.type === 'required_status_checks');
+
+  if (!checksRule) {
+    return [`live ruleset ${policy.productionRuleset.id} has no required_status_checks rule`];
+  }
+
+  const liveContexts = checksRule.parameters.required_status_checks.map((entry) => entry.context);
+  const failures = formatSetDiff(
+    `live production ruleset ${policy.productionRuleset.id}`,
+    policy.productionRuleset.contexts,
+    liveContexts,
+  );
+
+  findDuplicates(liveContexts).forEach((context) => {
+    failures.push(
+      `live production ruleset ${policy.productionRuleset.id} lists duplicate context "${context}"`,
+    );
+  });
+
+  const normalizeActors = (actors) => actors
+    .map(({ actor_id: actorId, actor_type: actorType, bypass_mode: bypassMode }) => (
+      `${actorType}/${actorId} (${bypassMode})`
+    ))
+    .sort((left, right) => left.localeCompare(right));
+  const expectedActors = normalizeActors(policy.productionRuleset.bypassActors || []);
+  const liveActors = normalizeActors(ruleset.bypass_actors || []);
+
+  return failures.concat(formatSetDiff(
+    `live production ruleset ${policy.productionRuleset.id} bypass actors`,
+    expectedActors,
+    liveActors,
+  ));
+}
+
+/**
+ * Main entry point.
+ */
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const policy = loadPolicy(options.policyPath);
+  const failures = verifyOfflinePolicy(policy, collectEmittedCheckNames())
+    .concat(verifyPromotionAlignment(policy, parsePromotionRequiredChecks()));
+
+  console.log(`Offline policy verification: ${failures.length === 0 ? 'OK' : 'FAILED'}`);
+
+  if (options.live) {
+    const liveFailures = verifyLiveMainProtection(policy, options.repo)
+      .concat(verifyLiveProductionRuleset(policy, options.repo));
+
+    console.log(`Live policy verification: ${liveFailures.length === 0 ? 'OK' : 'FAILED'}`);
+    failures.push(...liveFailures);
+  }
+
+  if (failures.length > 0) {
+    failures.forEach((failure) => console.error(`  - ${failure}`));
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  collectEmittedCheckNames,
+  expandJobCheckNames,
+  findDuplicates,
+  formatSetDiff,
+  loadPolicy,
+  parseArgs,
+  parsePromotionRequiredChecks,
+  verifyLiveMainProtection,
+  verifyLiveProductionRuleset,
+  verifyOfflinePolicy,
+  verifyPromotionAlignment,
+};

--- a/tests/unit/jestLaneConfigs.test.js
+++ b/tests/unit/jestLaneConfigs.test.js
@@ -7,7 +7,6 @@ const {
   assertDeepEqualInvariant,
   assertEqualInvariant,
   assertExpressionContainsInvariant,
-  assertNoActionReferencesInvariant,
   assertNoRunCommandContainsInvariant,
   assertStepUsesAction,
   findStepByName,
@@ -345,7 +344,6 @@ describe('Unit | Jest Lane Configs', () => {
         'openapi',
         'test-unit',
         'test-ci',
-        'test-ci-24',
         'newman',
         'test-report',
         'allure-report',
@@ -360,9 +358,9 @@ describe('Unit | Jest Lane Configs', () => {
       'docs',
     );
     assertDeepEqualInvariant(
-      'CI unit matrix covers every supported Node version with the fast lane only',
+      'CI unit matrix covers the canonical Node 24 plus the Node 22 compatibility signal',
       unitJob.strategy.matrix['node-version'],
-      ['20', '22', '24'],
+      ['22', '24'],
     );
     assertEqualInvariant(
       'CI unit matrix job name reports the unit package script and Node version',
@@ -375,9 +373,9 @@ describe('Unit | Jest Lane Configs', () => {
       'npm run test:unit -- --ci',
     );
     assertEqualInvariant(
-      'CI canonical full gate publishes the documented Node 20 check name',
+      'CI canonical full gate publishes the documented Node 24 check name',
       testCiJob.name,
-      'test:ci (20)',
+      'test:ci (24)',
     );
     assertDeepEqualInvariant(
       'CI Redis integration uses the pinned service container',
@@ -412,48 +410,12 @@ describe('Unit | Jest Lane Configs', () => {
       'smoke',
     );
 
-    const testCi24Job = getJob(workflow, 'test-ci-24');
-    const testCi24Step = findStepByName(testCi24Job, 'test-ci-24', 'test:ci');
-    const testCi24Setup = findStepByName(testCi24Job, 'test-ci-24', 'Setup project');
+    const testCiSetup = findStepByName(testCiJob, 'test-ci', 'Setup project');
 
     assertEqualInvariant(
-      'CI staged Node 24 full gate publishes the documented check name',
-      testCi24Job.name,
-      'test:ci (24)',
-    );
-    assertDeepEqualInvariant(
-      'CI staged Node 24 full gate installs Node 24 through the setup composite',
-      testCi24Setup.with,
-      { 'node-version': '24' },
-    );
-    assertDeepEqualInvariant(
-      'CI staged Node 24 full gate uses the pinned Redis service container',
-      testCi24Job.services.redis,
-      testCiJob.services.redis,
-    );
-    assertDeepEqualInvariant(
-      'CI staged Node 24 full gate requires the service-backed Redis URL',
-      testCi24Job.env,
-      {
-        REDIS_INTEGRATION_MODE: 'required',
-        REDIS_INTEGRATION_URL: 'redis://127.0.0.1:6379',
-      },
-    );
-    assertEqualInvariant(
-      'CI staged Node 24 full gate runs test:ci through the package script',
-      testCi24Step.run,
-      'npm run test:ci',
-    );
-    assertExpressionContainsInvariant(
-      'CI staged Node 24 full gate skips expensive setup for docs-only changes',
-      testCi24Step.if,
-      "needs.changes.outputs.docs_only != 'true'",
-    );
-    assertNoActionReferencesInvariant(
-      testCi24Job,
-      'test-ci-24',
-      ['actions/upload-artifact'],
-      'CI staged Node 24 full gate must not duplicate canonical Node 20 reporting artifacts',
+      'CI canonical full gate installs the .nvmrc toolchain through the setup composite',
+      testCiSetup.with,
+      undefined,
     );
     assertExpressionContainsInvariant(
       'CI unit matrix skips expensive setup for docs-only changes',

--- a/tests/unit/scripts/github/promoteToProduction.test.js
+++ b/tests/unit/scripts/github/promoteToProduction.test.js
@@ -54,6 +54,36 @@ describe('Unit | Scripts | GitHub | Promote To Production', () => {
         requiredChecks: ['actionlint', 'lint'],
       })).toEqual(['actionlint', 'lint']);
     });
+
+    it('derives required checks from live branch protection when none are provided', () => {
+      jest.isolateModules(() => {
+        jest.doMock('node:child_process', () => ({
+          execFileSync: jest.fn((command, args) => {
+            expect(command).toBe('gh');
+            expect(args).toEqual([
+              'api',
+              'repos/jsugg/alt-text-generator/branches/main/protection',
+            ]);
+
+            return JSON.stringify({
+              required_status_checks: {
+                contexts: ['actionlint', 'test:ci (24)'],
+              },
+            });
+          }),
+        }));
+
+        const promotion = require('../../../../scripts/github/promote-to-production');
+
+        expect(promotion.resolveRequiredChecks({
+          repo: 'jsugg/alt-text-generator',
+          sourceBranch: 'main',
+          requiredChecks: null,
+        })).toEqual(['actionlint', 'test:ci (24)']);
+      });
+
+      jest.dontMock('node:child_process');
+    });
   });
 
   describe('ensureRequiredChecksGreen', () => {

--- a/tests/unit/scripts/github/promoteToProductionWorkflow.test.js
+++ b/tests/unit/scripts/github/promoteToProductionWorkflow.test.js
@@ -1,0 +1,119 @@
+const {
+  assertDeepEqualInvariant,
+  assertEqualInvariant,
+  assertExpressionContainsInvariant,
+  assertNoRunCommandContainsInvariant,
+  assertStringContainsInvariant,
+  findStepByName,
+  getJob,
+  loadWorkflow,
+} = require('../../../helpers/workflowAssertions');
+
+describe('Unit | Scripts | GitHub | Promote To Production Workflow', () => {
+  const workflow = loadWorkflow('promote-to-production.yml');
+  const promoteJob = getJob(workflow, 'promote');
+  const validationJob = getJob(workflow, 'pre-production-provider-validation');
+
+  it('runs only on manual dispatch with non-cancelable serialized promotion', () => {
+    assertDeepEqualInvariant(
+      'Promotion triggers on workflow_dispatch only',
+      workflow.on,
+      { workflow_dispatch: null },
+    );
+    assertDeepEqualInvariant(
+      'Promotion serializes runs without canceling in-flight releases',
+      workflow.concurrency,
+      {
+        group: 'promote-to-production',
+        'cancel-in-progress': false,
+      },
+    );
+  });
+
+  it('derives required checks from live main branch protection, never a hardcoded list', () => {
+    assertNoRunCommandContainsInvariant(
+      workflow,
+      '--required-checks',
+      'Promotion must not hardcode required checks; the script derives them from branch protection',
+    );
+
+    const promoteStep = findStepByName(
+      promoteJob,
+      'promote',
+      'Promote main into production with GitHub App token',
+    );
+
+    assertStringContainsInvariant(
+      'Promotion invokes the promotion script',
+      promoteStep.run,
+      'node scripts/github/promote-to-production.js',
+    );
+    assertStringContainsInvariant(
+      'Promotion sources from main',
+      promoteStep.run,
+      '--source-branch "main"',
+    );
+    assertStringContainsInvariant(
+      'Promotion targets production',
+      promoteStep.run,
+      '--target-branch "production"',
+    );
+  });
+
+  it('promotes only with the repository automation GitHub App token', () => {
+    const promoteStep = findStepByName(
+      promoteJob,
+      'promote',
+      'Promote main into production with GitHub App token',
+    );
+    const requireAppStep = findStepByName(
+      promoteJob,
+      'promote',
+      'Require repository automation GitHub App',
+    );
+
+    assertExpressionContainsInvariant(
+      'Promotion runs only when the GitHub App auth strategy resolves',
+      promoteStep.if,
+      "steps.promotion-auth.outputs.use_github_app == 'true'",
+    );
+    assertEqualInvariant(
+      'Promotion uses the App installation token as GH_TOKEN',
+      promoteStep.env.GH_TOKEN,
+      '${{ steps.promotion-app-token.outputs.token }}',
+    );
+    assertExpressionContainsInvariant(
+      'Promotion fails closed when the GitHub App is not configured (no PAT fallback)',
+      requireAppStep.if,
+      "steps.promotion-auth.outputs.use_github_app != 'true'",
+    );
+  });
+
+  it('keeps environment-scoped validation and bounded runtimes', () => {
+    assertEqualInvariant(
+      'Pre-production provider validation runs in the prod-validation environment',
+      validationJob.environment,
+      'prod-validation',
+    );
+    assertEqualInvariant(
+      'Promotion job runs in the prod-validation environment',
+      promoteJob.environment,
+      'prod-validation',
+    );
+    assertEqualInvariant(
+      'Provider validation declares a timeout',
+      validationJob['timeout-minutes'],
+      20,
+    );
+    assertEqualInvariant(
+      'Promotion declares a timeout',
+      promoteJob['timeout-minutes'],
+      15,
+    );
+    assertDeepEqualInvariant(
+      'Promotion workflow permissions stay limited to contents write',
+      workflow.permissions,
+      { contents: 'write' },
+    );
+  });
+});

--- a/tests/unit/scripts/github/requiredCheckPolicy.test.js
+++ b/tests/unit/scripts/github/requiredCheckPolicy.test.js
@@ -1,0 +1,138 @@
+const {
+  collectEmittedCheckNames,
+  expandJobCheckNames,
+  loadPolicy,
+  parsePromotionRequiredChecks,
+  verifyOfflinePolicy,
+  verifyPromotionAlignment,
+} = require('../../../../scripts/github/verify-required-checks');
+
+describe('Unit | Scripts | GitHub | Required Check Policy', () => {
+  const policy = loadPolicy();
+  const collected = collectEmittedCheckNames();
+
+  it('accepts the committed policy against the real workflow job names', () => {
+    expect(verifyOfflinePolicy(policy, collected)).toEqual([]);
+  });
+
+  it('resolves every branch-protection context from a real workflow job', () => {
+    expect([...collected.checkNames.keys()]).toEqual(expect.arrayContaining([
+      'actionlint',
+      'codeql',
+      'dependency-review',
+      'docs',
+      'lint',
+      'newman',
+      'openapi',
+      'test:ci (20)',
+      'test:unit (20)',
+      'test:unit (22)',
+      'test:unit (24)',
+    ]));
+    expect(collected.failures).toEqual([]);
+  });
+
+  it('expands matrix job name templates into concrete check names', () => {
+    expect(expandJobCheckNames('test-unit', {
+      name: 'test:unit (${{ matrix.node-version }})',
+      strategy: { matrix: { 'node-version': ['20', '22', '24'] } },
+    })).toEqual({
+      names: ['test:unit (20)', 'test:unit (22)', 'test:unit (24)'],
+      failures: [],
+    });
+  });
+
+  it('fails matrix name templates the verifier cannot resolve', () => {
+    const expansion = expandJobCheckNames('mystery', {
+      name: 'mystery (${{ matrix.other }})',
+      strategy: { matrix: { 'node-version': ['20'] } },
+    });
+
+    expect(expansion.names).toEqual([]);
+    expect(expansion.failures[0]).toContain('cannot resolve');
+  });
+
+  it('rejects policy contexts that no push/pull_request workflow publishes', () => {
+    const brokenPolicy = {
+      ...policy,
+      mainBranchProtection: {
+        ...policy.mainBranchProtection,
+        contexts: [...policy.mainBranchProtection.contexts, 'typecheck'],
+      },
+    };
+
+    expect(verifyOfflinePolicy(brokenPolicy, collected)).toEqual([
+      expect.stringContaining('"typecheck" is not published by any push/pull_request workflow job'),
+    ]);
+  });
+
+  it('rejects retired check names so stale contexts cannot come back', () => {
+    const brokenPolicy = {
+      ...policy,
+      productionRuleset: {
+        ...policy.productionRuleset,
+        contexts: [...policy.productionRuleset.contexts, 'test (20)'],
+      },
+    };
+    const failures = verifyOfflinePolicy(brokenPolicy, collected);
+
+    expect(failures).toEqual(expect.arrayContaining([
+      expect.stringContaining('matches retired pattern'),
+    ]));
+  });
+
+  it('rejects duplicate contexts inside a policy list', () => {
+    const brokenPolicy = {
+      ...policy,
+      mainBranchProtection: {
+        ...policy.mainBranchProtection,
+        contexts: [...policy.mainBranchProtection.contexts, 'lint'],
+      },
+    };
+
+    expect(verifyOfflinePolicy(brokenPolicy, collected)).toEqual(expect.arrayContaining([
+      expect.stringContaining('duplicate context "lint"'),
+    ]));
+  });
+
+  it('rejects check names published by more than one workflow job', () => {
+    const ambiguous = {
+      checkNames: new Map([
+        ['lint', ['ci.yml#lint', 'other.yml#lint']],
+      ]),
+      failures: [],
+    };
+    const minimalPolicy = {
+      mainBranchProtection: { branch: 'main', contexts: ['lint'] },
+      productionRuleset: { id: 1, contexts: ['lint'], bypassActors: [] },
+      retiredContextPatterns: [],
+    };
+
+    expect(verifyOfflinePolicy(minimalPolicy, ambiguous)).toEqual([
+      expect.stringContaining('published by multiple jobs'),
+    ]);
+  });
+
+  it('keeps the production ruleset policy within the main branch policy', () => {
+    const brokenPolicy = {
+      ...policy,
+      productionRuleset: {
+        ...policy.productionRuleset,
+        contexts: [...policy.productionRuleset.contexts, 'newman-full'],
+      },
+    };
+    const failures = verifyOfflinePolicy(brokenPolicy, collected);
+
+    expect(failures).toEqual(expect.arrayContaining([
+      expect.stringContaining('is not part of the main branch policy'),
+    ]));
+  });
+
+  it('keeps the promotion workflow hardcoded checks aligned with the policy', () => {
+    expect(verifyPromotionAlignment(policy, parsePromotionRequiredChecks())).toEqual([]);
+  });
+
+  it('treats a promotion workflow without hardcoded checks as aligned by derivation', () => {
+    expect(verifyPromotionAlignment(policy, null)).toEqual([]);
+  });
+});

--- a/tests/unit/scripts/github/requiredCheckPolicy.test.js
+++ b/tests/unit/scripts/github/requiredCheckPolicy.test.js
@@ -24,8 +24,7 @@ describe('Unit | Scripts | GitHub | Required Check Policy', () => {
       'lint',
       'newman',
       'openapi',
-      'test:ci (20)',
-      'test:unit (20)',
+      'test:ci (24)',
       'test:unit (22)',
       'test:unit (24)',
     ]));

--- a/tests/unit/scripts/runPostmanDeploy.test.js
+++ b/tests/unit/scripts/runPostmanDeploy.test.js
@@ -22,7 +22,6 @@ const {
   assertNoEnvKeysInvariant,
   assertNoRunCommandContainsInvariant,
   assertStepUsesAction,
-  assertStringContainsInvariant,
   findStepByName,
   getJob,
   loadWorkflow,
@@ -544,11 +543,9 @@ describe('Unit | Scripts | Run Postman Deploy', () => {
         promoteJob.needs,
         ['pre-production-provider-validation'],
       );
-      assertStringContainsInvariant(
-        'Promotion required checks exactly match the documented release policy',
-        promoteStep.run,
-        '--required-checks "actionlint,codeql,dependency-review,docs,lint,openapi,newman,test:ci (20),test:unit (20),test:unit (22),test:unit (24)"',
-      );
+      // Promotion derives required checks from live main branch protection;
+      // a hardcoded list would silently drift from the real release policy.
+      expect(promoteStep.run).not.toContain('--required-checks');
       assertEnvContainsInvariant(
         'Post Deploy provider scope resolver reads only approved release provider secrets',
         postDeployResolveStep.env,


### PR DESCRIPTION
## ⚠️ Stacked draft — merge order and admin window

Stacked on #209 (base: `ci/node24-staging`, also folds in #208's scaffolding). **Do not merge until:**
1. #208 and #209 are merged (GitHub will retarget this PR to `main`).
2. Runbook step 2 executed (add `test:ci (24)` to live required contexts — additive).
3. This PR's CI is green on the retargeted base.
4. **Runbook step 3a executed** (patch `main` required contexts to the final 9-context baseline) — then merge immediately (short window; see `.local/ci-cd-evidence/LIVE-RUNBOOK.md`).
5. After merge: runbook step 4 (production ruleset patch R07/R08), step 5 (promotion dry-run R09 + after-export R10).

## Scope (plan PR-2: W01 cutover + W02 completion, R03)

- Canonical full gate renamed `test:ci (24)` (artifacts `*-node-24`); staged transition job removed; unit matrix `22/24` (22 = non-required compatibility signal, documented decision).
- Every workflow now installs the `.nvmrc` toolchain via the setup composite default (raw setup-node steps use `node-version-file: .nvmrc`); `engines.node` narrowed to `>=22 <25` (Render resolves 24).
- **Promotion derives required checks from live `main` protection**: `--required-checks` removed (script fallback already existed; now covered by a mocked-gh unit test).
- Policy file → final 9-context baseline; `test:ci (20)`/`test:unit (20)` added to retired patterns (verifier + tests reject reintroduction).
- New `promoteToProductionWorkflow.test.js` (C02): no hardcoded checks, App-token-only promotion (G11), prod-validation env (G12), non-cancel concurrency (G05), timeouts (G03), contents-write-only permissions.
- README/DEVELOPMENT finalized for Node 24.

## Guardrails
G01 pins unchanged · G04/G05 concurrency semantics unchanged · G06 lanes unchanged · G07 Redis pin asserted · G08 ratchets untouched (new tests only add coverage) · G09/G10 untouched · G11/G12 invariant-asserted · G13 reporting single-source restored on Node 24 · G14 docs-only skips replicated.

## Validation
actionlint OK · offline `checks:verify` OK against final baseline · full unit lane 711/711 (89 suites) · lint clean · docs OK. Live verify (`--live`) will pass only after runbook steps 3a+4 — that ordering is the point.