### PR TITLE
ci: advisory strict typecheck gate + debt ledger (PR-4 / W05)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,34 @@ jobs:
         if: needs.changes.outputs.docs_only == 'true'
         run: echo "Docs-only change; OpenAPI gate satisfied by docs validation."
 
+  # Advisory JSDoc type gate: strict checkJs carries known debt
+  # (docs/typecheck-debt.md), so the job may fail without blocking the run.
+  # Drop continue-on-error and add the context to required checks only when
+  # the debt reaches zero.
+  typecheck:
+    name: typecheck
+    needs:
+      - changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        if: needs.changes.outputs.docs_only != 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup project
+        if: needs.changes.outputs.docs_only != 'true'
+        uses: ./.github/actions/setup-node-project
+
+      - name: Run typecheck
+        if: needs.changes.outputs.docs_only != 'true'
+        run: npm run typecheck
+
+      - name: Skip typecheck for docs-only change
+        if: needs.changes.outputs.docs_only == 'true'
+        run: echo "Docs-only change; typecheck gate satisfied by docs validation."
+
   test-unit:
     name: test:unit (${{ matrix.node-version }})
     runs-on: ubuntu-latest

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -59,6 +59,7 @@ npm run validate:fast      # lint + openapi:validate/check + unit lane (pre-comm
 npm run validate:contract  # openapi:diff + postman:lint + postman:smoke (HTTP contract)
 npm run validate:ci        # lint + openapi gates + test:ci + contract (CI repro; needs Redis)
 npm run lint
+npm run typecheck          # strict JSDoc typecheck (advisory in CI; docs/typecheck-debt.md)
 
 # openapi contract
 npm run openapi:generate   # regenerate docs/openapi.base.json from JSDoc sources

--- a/docs/typecheck-debt.md
+++ b/docs/typecheck-debt.md
@@ -1,0 +1,40 @@
+# Typecheck debt ledger
+
+`npm run typecheck` runs strict JSDoc type checking (`tsconfig.checkjs.json`:
+`checkJs` + `strict`, TypeScript 6) over `src/`, `config/`, and `scripts/`.
+The CI `typecheck` job is **advisory** (`continue-on-error: true`) until this
+ledger reaches zero; it is intentionally not a required status check.
+
+Owner: @jsugg. Baseline measured 2026-07-02 (TypeScript 6.0.3).
+
+| Profile | Errors |
+|---|---:|
+| `strict: true` (committed config, target) | 1409 |
+| `strict: false` (reference only) | 170 |
+
+Top strict-error areas:
+
+| Area | Errors |
+|---|---:|
+| `src/services` | 273 |
+| `scripts/postman` | 185 |
+| `scripts/github` | 142 |
+| `src/providers` | 112 |
+| `src/infrastructure` | 112 |
+| `src/api` | 87 |
+| `src/server` | 82 |
+| `scripts/run-postman-harness.js` | 68 |
+| `scripts/openapi` | 64 |
+| `scripts/perf` | 45 |
+
+## Promotion criteria (advisory → required)
+
+1. `npm run typecheck` exits 0 on `main`.
+2. Remove `continue-on-error: true` from the CI `typecheck` job (update the
+   `jestLaneConfigs` invariant in the same PR).
+3. Add `typecheck` to `config/github/required-checks.json` contexts and patch
+   live branch protection per `docs/required-checks.md`.
+
+Burn down by area (highest counts first); do not weaken the committed strict
+profile to make the number smaller — the strict profile is the target the
+editor `config/jsconfig.json` already assumes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,10 +46,11 @@
         "newman": "^6.2.2",
         "newman-reporter-allure": "^3.6.0",
         "nodemon": "^3.1.14",
-        "supertest": "^6.3.4"
+        "supertest": "^6.3.4",
+        "typescript": "^6.0.3"
       },
       "engines": {
-        "node": ">=20 <25"
+        "node": ">=22 <25"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -10057,6 +10058,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uglify-js": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:coverage": "REDIS_INTEGRATION_MODE=required jest --config config/jest/jest.coverage.cjs",
     "test:allure": "ALLURE_RESULTS_DIR=reports/allure-results jest --config config/jest/jest.reporting.cjs",
     "test:ci": "REDIS_INTEGRATION_MODE=required jest --config config/jest/jest.ci.cjs --ci",
+    "typecheck": "tsc -p tsconfig.checkjs.json",
     "validate:fast": "npm run lint && npm run openapi:validate && npm run openapi:check && NODE_ENV=test REPLICATE_API_TOKEN=test-token npm test",
     "validate:contract": "npm run openapi:diff && npm run postman:lint && npm run postman:smoke",
     "validate:ci": "npm run lint && npm run openapi:validate && npm run openapi:check && NODE_ENV=test REPLICATE_API_TOKEN=test-token npm run test:ci && npm run validate:contract",
@@ -98,7 +99,8 @@
     "newman": "^6.2.2",
     "newman-reporter-allure": "^3.6.0",
     "nodemon": "^3.1.14",
-    "supertest": "^6.3.4"
+    "supertest": "^6.3.4",
+    "typescript": "^6.0.3"
   },
   "nodemonConfig": {
     "ignore": [

--- a/tests/unit/jestLaneConfigs.test.js
+++ b/tests/unit/jestLaneConfigs.test.js
@@ -342,6 +342,7 @@ describe('Unit | Jest Lane Configs', () => {
         'actionlint',
         'lint',
         'openapi',
+        'typecheck',
         'test-unit',
         'test-ci',
         'newman',
@@ -416,6 +417,45 @@ describe('Unit | Jest Lane Configs', () => {
       'CI canonical full gate installs the .nvmrc toolchain through the setup composite',
       testCiSetup.with,
       undefined,
+    );
+
+    const typecheckJob = getJob(workflow, 'typecheck');
+    const typecheckStep = findStepByName(typecheckJob, 'typecheck', 'Run typecheck');
+    const typecheckSkipStep = findStepByName(
+      typecheckJob,
+      'typecheck',
+      'Skip typecheck for docs-only change',
+    );
+
+    assertEqualInvariant(
+      'CI typecheck publishes the stable check name for later required promotion',
+      typecheckJob.name,
+      'typecheck',
+    );
+    assertEqualInvariant(
+      'CI typecheck stays advisory until the debt ledger reaches zero',
+      typecheckJob['continue-on-error'],
+      true,
+    );
+    assertEqualInvariant(
+      'CI typecheck declares a timeout',
+      typecheckJob['timeout-minutes'],
+      10,
+    );
+    assertEqualInvariant(
+      'CI typecheck runs the package script',
+      typecheckStep.run,
+      'npm run typecheck',
+    );
+    assertExpressionContainsInvariant(
+      'CI typecheck skips expensive setup for docs-only changes',
+      typecheckStep.if,
+      "needs.changes.outputs.docs_only != 'true'",
+    );
+    assertExpressionContainsInvariant(
+      'CI typecheck publishes a no-op success for docs-only changes',
+      typecheckSkipStep.if,
+      "needs.changes.outputs.docs_only == 'true'",
     );
     assertExpressionContainsInvariant(
       'CI unit matrix skips expensive setup for docs-only changes',

--- a/tests/unit/scripts/github/requiredCheckPolicy.test.js
+++ b/tests/unit/scripts/github/requiredCheckPolicy.test.js
@@ -56,12 +56,12 @@ describe('Unit | Scripts | GitHub | Required Check Policy', () => {
       ...policy,
       mainBranchProtection: {
         ...policy.mainBranchProtection,
-        contexts: [...policy.mainBranchProtection.contexts, 'typecheck'],
+        contexts: [...policy.mainBranchProtection.contexts, 'mutation-tests'],
       },
     };
 
     expect(verifyOfflinePolicy(brokenPolicy, collected)).toEqual([
-      expect.stringContaining('"typecheck" is not published by any push/pull_request workflow job'),
+      expect.stringContaining('"mutation-tests" is not published by any push/pull_request workflow job'),
     ]);
   });
 

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "module": "node20",
+    "target": "ES2022",
+    "lib": ["ESNext"],
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "src/**/*.js",
+    "config/**/*.js",
+    "scripts/**/*.js"
+  ],
+  "exclude": [
+    "node_modules",
+    "coverage",
+    "reports",
+    "tests"
+  ]
+}


### PR DESCRIPTION
## Stacked draft on #215

## Scope (plan PR-4: W05, C04; Q10 resolved = advisory path)
- `tsconfig.checkjs.json`: TypeScript 6, `checkJs` + **strict** (matches editor `config/jsconfig.json` assumptions), `noEmit`, scoped to `src/` + `config/` + `scripts/`, tests excluded.
- `npm run typecheck`; measured debt: **1409 strict** (170 non-strict, reference) → advisory per plan F05/K04.
- CI `typecheck` job: `continue-on-error: true` (honest failure state, non-blocking, NOT in required contexts), stable check name for later promotion, docs-only skip semantics, 10m timeout.
- `docs/typecheck-debt.md`: baseline by area + explicit promotion criteria (zero errors → drop continue-on-error → policy+live context add per runbook).
- Lane invariants (C04): job graph, advisory mechanics, script wiring, skip conditions.
- Note: package.json also carries maintainer-made range bumps (brace-expansion ^5.0.7, qs ^6.15.3) picked up from the working tree; lockfile refreshed, unit lane green.

## Guardrails
Advisory stays advisory (plan promotion criteria documented); no required-context change; G03 timeout; G14 skip semantics replicated; ratchets untouched.

## Validation
actionlint OK · lane invariants + policy suite green · full eslint clean · docs OK · typecheck run itself exercised (exit 2 with 1409 errors, captured in ledger).