### PR TITLE
ci: zizmor + harden-runner audit mode (PR-8 / W09 advisory half)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,13 @@ jobs:
       - name: Run actionlint
         run: /tmp/actionlint -color
 
+      # Advisory workflow SAST: findings warn, never block, until the signal
+      # proves low-noise (plan W09/F09 promotion criteria).
+      - name: Run zizmor workflow audit (advisory)
+        run: |
+          pipx install zizmor==1.26.1 >/dev/null
+          zizmor .github/workflows/ || echo "::warning::zizmor reported workflow findings (advisory; see job log)"
+
   lint:
     name: lint
     needs:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -33,6 +33,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Harden runner (audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/live-provider-validation.yml
+++ b/.github/workflows/live-provider-validation.yml
@@ -52,6 +52,11 @@ jobs:
     environment: prod-validation
     timeout-minutes: 20
     steps:
+      - name: Harden runner (audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/post-deploy-verification.yml
+++ b/.github/workflows/post-deploy-verification.yml
@@ -51,6 +51,11 @@ jobs:
       PRODUCTION_DEPLOY_VALIDATION_API_TOKEN: ${{ secrets.PRODUCTION_DEPLOY_VALIDATION_API_TOKEN }}
       PRODUCTION_DEPLOY_VALIDATION_API_TOKEN_CONFIGURED: ${{ secrets.PRODUCTION_DEPLOY_VALIDATION_API_TOKEN != '' && 'true' || 'false' }}
     steps:
+      - name: Harden runner (audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -17,6 +17,11 @@ jobs:
     environment: prod-validation
     timeout-minutes: 20
     steps:
+      - name: Harden runner (audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -68,6 +73,11 @@ jobs:
     environment: prod-validation
     timeout-minutes: 15
     steps:
+      - name: Harden runner (audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -33,6 +33,11 @@ jobs:
     environment: prod-validation
     timeout-minutes: 10
     steps:
+      - name: Harden runner (audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -18,6 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Harden runner (audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/tests/unit/scripts/github/workflowHardening.test.js
+++ b/tests/unit/scripts/github/workflowHardening.test.js
@@ -1,0 +1,122 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+const {
+  assertDeepEqualInvariant,
+  assertEqualInvariant,
+  assertStringContainsInvariant,
+  findStepByName,
+  getJob,
+  loadWorkflow,
+} = require('../../../helpers/workflowAssertions');
+
+const WORKFLOWS_DIR = path.resolve(__dirname, '..', '..', '..', '..', '.github', 'workflows');
+const COMPOSITE_ACTION_PATH = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  '.github',
+  'actions',
+  'setup-node-project',
+  'action.yml',
+);
+const FULL_SHA_USES_PATTERN = /^[^@]+@[0-9a-f]{40}$/u;
+const HARDENED_JOBS = [
+  ['promote-to-production.yml', 'pre-production-provider-validation'],
+  ['promote-to-production.yml', 'promote'],
+  ['post-deploy-verification.yml', 'smoke'],
+  ['security-audit.yml', 'npm-audit'],
+  ['dependency-review.yml', 'dependency-review'],
+  ['live-provider-validation.yml', 'live-provider'],
+  ['rollback-production.yml', 'rollback'],
+];
+
+function collectUses(document) {
+  const jobs = document.jobs || { composite: document.runs };
+
+  return Object.values(jobs).flatMap((job) => (
+    Array.isArray(job.steps)
+      ? job.steps.filter((step) => typeof step.uses === 'string').map((step) => step.uses)
+      : []
+  ));
+}
+
+describe('Unit | Scripts | GitHub | Workflow Hardening', () => {
+  it('pins every external action to a full-length commit SHA', () => {
+    const workflowUses = fs.readdirSync(WORKFLOWS_DIR)
+      .filter((fileName) => fileName.endsWith('.yml'))
+      .flatMap((fileName) => collectUses(loadWorkflow(fileName)));
+    const compositeUses = collectUses(
+      yaml.load(fs.readFileSync(COMPOSITE_ACTION_PATH, 'utf8')),
+    );
+    const unpinned = workflowUses.concat(compositeUses).filter((uses) => (
+      !uses.startsWith('./') && !FULL_SHA_USES_PATTERN.test(uses)
+    ));
+
+    // jest-native equality: node assert.deepStrictEqual trips on realm
+    // differences for the yaml-derived strings under the jest vm context.
+    expect(unpinned).toEqual([]);
+    expect(workflowUses.length).toBeGreaterThan(50);
+  });
+
+  it('audits workflow definitions with advisory zizmor in the actionlint job', () => {
+    const workflow = loadWorkflow('ci.yml');
+    const actionlintJob = getJob(workflow, 'actionlint');
+    const zizmorStep = findStepByName(
+      actionlintJob,
+      'actionlint',
+      'Run zizmor workflow audit (advisory)',
+    );
+
+    assertStringContainsInvariant(
+      'zizmor installs a pinned version',
+      zizmorStep.run,
+      'pipx install zizmor==1.26.1',
+    );
+    assertStringContainsInvariant(
+      'zizmor findings warn instead of blocking',
+      zizmorStep.run,
+      '|| echo "::warning::',
+    );
+  });
+
+  it('runs harden-runner in audit mode as the first step of secret-bearing jobs', () => {
+    HARDENED_JOBS.forEach(([fileName, jobId]) => {
+      const job = getJob(loadWorkflow(fileName), jobId);
+      const [firstStep] = job.steps;
+
+      assertEqualInvariant(
+        `${fileName}#${jobId} starts with the harden-runner audit step`,
+        firstStep.name,
+        'Harden runner (audit)',
+      );
+      assertStringContainsInvariant(
+        `${fileName}#${jobId} pins harden-runner to a full SHA`,
+        firstStep.uses,
+        'step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411',
+      );
+      assertDeepEqualInvariant(
+        `${fileName}#${jobId} keeps harden-runner in audit (non-blocking) mode`,
+        firstStep.with,
+        { 'egress-policy': 'audit' },
+      );
+    });
+  });
+
+  it('keeps harden-runner out of fork-facing CI jobs', () => {
+    const ciWorkflow = loadWorkflow('ci.yml');
+    const references = Object.entries(ciWorkflow.jobs).flatMap(([jobId, job]) => (
+      (job.steps || [])
+        .filter((step) => typeof step.uses === 'string' && step.uses.includes('harden-runner'))
+        .map(() => jobId)
+    ));
+
+    assertDeepEqualInvariant(
+      'CI pull_request-facing jobs must not carry harden-runner telemetry',
+      references,
+      [],
+    );
+  });
+});


### PR DESCRIPTION
## Stacked draft on #216 (merge LAST in the chain)

## Scope (plan W09/F09 advisory, C08; S01 codified)
- **zizmor 1.26.1 (pinned)** in the `actionlint` job: warning-only workflow SAST; promotion to blocking only after a low-noise track record.
- **harden-runner v2.19.4 (full-SHA pin) in `egress-policy: audit`** as the FIRST step of secret-bearing jobs: `promote-to-production` (validation + promote), `post-deploy-verification#smoke`, `security-audit#npm-audit`, `dependency-review`, `live-provider-validation#live-provider`, `rollback-production`. Audit only — egress reports reviewed before any blocking policy (K08 rollback: remove step/allowlist hosts).
- Fork-facing CI jobs intentionally excluded (C08 unsafe-context rule), invariant-enforced.
- **New invariant: every external `uses:` across all workflows + composite action must be a 40-hex SHA pin** (S01/G01 now regression-tested, complements the live `sha_pinning_required` runbook step).

## Validation
actionlint OK · 21 suites / 181 tests green (all github-script + lane + deploy suites) · eslint clean · docs OK.

## Promotion criteria
zizmor → blocking after clean/noise-triaged runs; harden-runner → block policy per-workflow only after egress baselines are reviewed.