### PR TITLE
ci: deployment evidence + manual rollback (PR-7 / W10, reopened)

### DIFF
--- a/.github/workflows/post-deploy-verification.yml
+++ b/.github/workflows/post-deploy-verification.yml
@@ -41,6 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: prod-validation
     timeout-minutes: 10
+    permissions:
+      contents: read
+      deployments: write
     env:
       ALLURE_RESULTS_DIR: reports/allure-results
       BASE_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.base_url || 'https://wcag.qcraft.com.br' }}
@@ -65,6 +68,7 @@ jobs:
         run: node scripts/github/resolve-provider-validation-scope.js
 
       - name: Run post-deploy Newman verification
+        id: newman-verify
         run: npm run postman:post-deploy -- --base-url "${BASE_URL}"
         env:
           LIVE_PROVIDER_SCOPE: ${{ env.LIVE_PROVIDER_SCOPE }}
@@ -74,6 +78,21 @@ jobs:
           OPENAI_MODEL: gpt-4.1-nano
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
           PROVIDER_VALIDATION_PUBLIC_REF: production
+
+      # Only production pushes correspond to a real deployment; manual runs
+      # against custom base URLs must not flip the production deployment state.
+      - name: Update production deployment status
+        if: always() && github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOY_STATE: ${{ steps.newman-verify.outcome == 'success' && 'success' || 'failure' }}
+        run: >-
+          node scripts/github/update-deployment-status.js
+          --repo "${GITHUB_REPOSITORY}"
+          --sha "${GITHUB_SHA}"
+          --state "${DEPLOY_STATE}"
+          --environment-url "https://wcag.qcraft.com.br"
+          --log-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
       - name: Write deploy summary
         if: always()

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -1,0 +1,82 @@
+name: Rollback Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      to_sha:
+        description: Commit SHA to reset production to (previous known-good production SHA).
+        required: true
+        type: string
+      reason:
+        description: Why production is being rolled back (recorded in the deployment).
+        required: true
+        type: string
+      dry_run:
+        description: Plan only; do not move the production ref.
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+# Shares the promotion group so a rollback can never interleave with a
+# promotion; both serialize on the same production ref.
+concurrency:
+  group: promote-to-production
+  cancel-in-progress: false
+
+jobs:
+  rollback:
+    name: rollback
+    runs-on: ubuntu-latest
+    environment: prod-validation
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Resolve rollback auth strategy
+        id: promotion-auth
+        env:
+          REPO_TOOLING_GITHUB_APP_ID: ${{ vars.REPO_TOOLING_GITHUB_APP_ID }}
+          REPO_TOOLING_GITHUB_APP_PRIVATE_KEY: ${{ secrets.REPO_TOOLING_GITHUB_APP_PRIVATE_KEY }}
+        run: bash scripts/github/resolve-promotion-auth.sh
+
+      - name: Create rollback GitHub App token
+        id: promotion-app-token
+        if: steps.promotion-auth.outputs.use_github_app == 'true'
+        env:
+          REPO_TOOLING_GITHUB_APP_PRIVATE_KEY: ${{ secrets.REPO_TOOLING_GITHUB_APP_PRIVATE_KEY }}
+        run: >-
+          node scripts/github/create-github-app-installation-token.js
+          --app-id "${{ vars.REPO_TOOLING_GITHUB_APP_ID }}"
+          --owner "${{ github.repository_owner }}"
+          --repo "${{ github.event.repository.name }}"
+          --output-file "${GITHUB_OUTPUT}"
+
+      - name: Require repository automation GitHub App
+        if: steps.promotion-auth.outputs.use_github_app != 'true'
+        run: bash scripts/github/require-promotion-github-app.sh
+
+      - name: Roll back production with GitHub App token
+        if: steps.promotion-auth.outputs.use_github_app == 'true'
+        env:
+          GH_TOKEN: ${{ steps.promotion-app-token.outputs.token }}
+          ROLLBACK_TO_SHA: ${{ inputs.to_sha }}
+          ROLLBACK_REASON: ${{ inputs.reason }}
+          ROLLBACK_DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
+        run: |
+          node scripts/github/rollback-production.js \
+            --repo "${GITHUB_REPOSITORY}" \
+            --target-branch "production" \
+            --to-sha "${ROLLBACK_TO_SHA}" \
+            --reason "${ROLLBACK_REASON}" \
+            --dry-run "${ROLLBACK_DRY_RUN}" \
+            --output-file "${GITHUB_OUTPUT}" \
+            --summary-file "${GITHUB_STEP_SUMMARY}"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -561,6 +561,12 @@ At least one provider must be configured at startup: `REPLICATE_API_TOKEN`, Azur
 
 - The Render web service shape is versioned in [`render.yaml`](./render.yaml).
 - Render reads the Node runtime version from [`package.json`](./package.json) `engines.node`.
+
+### Deployment evidence and rollback
+
+- Promotion creates a GitHub Deployment (environment `production`) recording the promotion mode, source/target SHAs, and the required checks it verified; post-deploy verification marks it `success`/`failure` with run and environment URLs. Inspect with `gh api repos/jsugg/alt-text-generator/deployments --jq 'map(select(.environment=="production"))[:5]'`.
+- Rollback is manual and dry-run-first: dispatch the `Rollback Production` workflow with the previous known-good production SHA (promotion prints it as `Target SHA before`), a reason, and `dry_run=true`; re-dispatch with `dry_run=false` only after the printed plan is confirmed. The workflow uses the repository automation GitHub App (same trust boundary as promotion), shares the promotion concurrency group so releases and rollbacks never interleave, and records a rollback deployment. Render redeploys the rollback commit from the production push and post-deploy verification sets the final status.
+- Automated rollback stays deferred until a manual rollback drill has passed, failure classification can distinguish a deploy regression from a transient provider outage, and the blast radius is accepted.
 - Secrets such as `REPLICATE_API_TOKEN`, `TLS_KEY`, and `TLS_CERT` stay dashboard-managed and are represented in the Blueprint with `sync: false`.
 
 ## Quality Gates

--- a/scripts/github/promote-to-production.js
+++ b/scripts/github/promote-to-production.js
@@ -104,6 +104,22 @@ function runGhJson(args) {
 }
 
 /**
+ * Runs a gh api command with a JSON request body on stdin and parses the response.
+ *
+ * @param {string[]} args
+ * @param {Record<string, unknown>} body
+ * @returns {any}
+ */
+function runGhJsonWithBody(args, body) {
+  return JSON.parse(execFileSync('gh', args.concat(['--input', '-']), {
+    encoding: 'utf8',
+    env: process.env,
+    input: JSON.stringify(body),
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim());
+}
+
+/**
  * @param {unknown} error
  * @returns {boolean}
  */
@@ -340,6 +356,166 @@ function updateBranchRef(
 }
 
 /**
+ * Builds the deployment payload that records how a promotion happened.
+ *
+ * @param {{
+ *   plan: ReturnType<typeof derivePromotionPlan>,
+ *   requiredChecks: string[],
+ *   sourceBranch: string,
+ *   sourceSha: string,
+ *   targetShaBefore: string,
+ * }} options
+ * @returns {Record<string, unknown>}
+ */
+function buildPromotionDeploymentPayload({
+  plan,
+  requiredChecks,
+  sourceBranch,
+  sourceSha,
+  targetShaBefore,
+}) {
+  return {
+    promotion_mode: plan.mode,
+    required_checks: requiredChecks,
+    source_branch: sourceBranch,
+    source_sha: sourceSha,
+    target_sha_before: targetShaBefore,
+  };
+}
+
+/**
+ * Creates a GitHub Deployment record for the promoted commit.
+ *
+ * @param {{
+ *   repo: string,
+ *   sha: string,
+ *   description: string,
+ *   payload: Record<string, unknown>,
+ * }} options
+ * @returns {number} deployment id
+ */
+function createProductionDeployment({
+  repo,
+  sha,
+  description,
+  payload,
+}) {
+  const deployment = runGhJsonWithBody(
+    ['api', '--method', 'POST', `repos/${repo}/deployments`],
+    {
+      ref: sha,
+      environment: 'production',
+      auto_merge: false,
+      required_contexts: [],
+      description,
+      payload,
+    },
+  );
+
+  return deployment.id;
+}
+
+/**
+ * Sets the status of a GitHub Deployment.
+ *
+ * @param {{
+ *   repo: string,
+ *   deploymentId: number,
+ *   state: string,
+ *   description: string,
+ *   logUrl: string|null,
+ * }} options
+ */
+function setDeploymentStatus({
+  repo,
+  deploymentId,
+  state,
+  description,
+  logUrl,
+}) {
+  runGhJsonWithBody(
+    ['api', '--method', 'POST', `repos/${repo}/deployments/${deploymentId}/statuses`],
+    {
+      state,
+      description,
+      ...(logUrl ? { log_url: logUrl } : {}),
+    },
+  );
+}
+
+/**
+ * Resolves the current workflow run URL when running inside GitHub Actions.
+ *
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {string|null}
+ */
+function resolveRunLogUrl(env) {
+  const { GITHUB_REPOSITORY, GITHUB_RUN_ID, GITHUB_SERVER_URL } = env;
+
+  if (!GITHUB_SERVER_URL || !GITHUB_REPOSITORY || !GITHUB_RUN_ID) {
+    return null;
+  }
+
+  return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
+}
+
+/**
+ * Records promotion deployment evidence; failures must not undo a completed
+ * ref update, so errors degrade to a warning and an empty output value.
+ *
+ * @param {{
+ *   repo: string,
+ *   plan: ReturnType<typeof derivePromotionPlan>,
+ *   requiredChecks: string[],
+ *   sourceBranch: string,
+ *   sourceSha: string,
+ *   targetBranch: string,
+ *   targetShaBefore: string,
+ * }} options
+ * @returns {number|null} deployment id, or null when evidence recording failed
+ */
+function recordPromotionDeployment({
+  repo,
+  plan,
+  requiredChecks,
+  sourceBranch,
+  sourceSha,
+  targetBranch,
+  targetShaBefore,
+}) {
+  try {
+    const deploymentId = createProductionDeployment({
+      repo,
+      sha: sourceSha,
+      description: `Promote ${sourceBranch}@${sourceSha.slice(0, 8)} to ${targetBranch}`,
+      payload: buildPromotionDeploymentPayload({
+        plan,
+        requiredChecks,
+        sourceBranch,
+        sourceSha,
+        targetShaBefore,
+      }),
+    });
+
+    setDeploymentStatus({
+      repo,
+      deploymentId,
+      state: 'in_progress',
+      description: 'Render deploy triggered by production ref update.',
+      logUrl: resolveRunLogUrl(process.env),
+    });
+
+    return deploymentId;
+  } catch (error) {
+    console.error(
+      `Warning: promotion succeeded but deployment evidence failed: ${error instanceof Error ? error.message : error}`,
+    );
+
+    return null;
+  }
+}
+
+/**
  * Main entry point.
  */
 async function main() {
@@ -389,8 +565,19 @@ async function main() {
     );
   }
 
+  const deploymentId = recordPromotionDeployment({
+    repo: options.repo,
+    plan,
+    requiredChecks,
+    sourceBranch: options.sourceBranch,
+    sourceSha,
+    targetBranch: options.targetBranch,
+    targetShaBefore: targetSha,
+  });
+
   appendOutput(options.outputFile, 'up_to_date', false);
   appendOutput(options.outputFile, 'target_sha_after', targetShaAfter);
+  appendOutput(options.outputFile, 'deployment_id', deploymentId === null ? '' : deploymentId);
   appendSummary(options.summaryFile, [
     '## Promote to Production',
     '',
@@ -400,6 +587,8 @@ async function main() {
     `- Target SHA before: ${targetSha}`,
     `- Target SHA after: ${targetShaAfter}`,
     `- Mode: ${plan.mode}`,
+    `- Required checks: ${requiredChecks.join(', ')}`,
+    `- GitHub Deployment: ${deploymentId === null ? 'evidence recording failed (see log)' : deploymentId}`,
     `- ${plan.reason}`,
   ]);
 
@@ -417,9 +606,14 @@ if (require.main === module) {
 }
 
 module.exports = {
+  buildPromotionDeploymentPayload,
+  createProductionDeployment,
   derivePromotionPlan,
   ensureRequiredChecksGreen,
   isProtectedBranchRefUpdateError,
   parseArgs,
+  recordPromotionDeployment,
   resolveRequiredChecks,
+  resolveRunLogUrl,
+  setDeploymentStatus,
 };

--- a/scripts/github/rollback-production.js
+++ b/scripts/github/rollback-production.js
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+/**
+ * Rolls the production branch back to a previous known-good commit.
+ * Dry-run by default: prints the plan without moving the ref. The real run
+ * force-updates the production ref through the GitHub App token (the same
+ * trust boundary as promotion) and records a rollback deployment.
+ */
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+
+/**
+ * Parses command-line arguments.
+ *
+ * @param {string[]} argv
+ * @returns {{
+ *   repo: string,
+ *   targetBranch: string,
+ *   toSha: string,
+ *   reason: string,
+ *   dryRun: boolean,
+ *   outputFile: string|null,
+ *   summaryFile: string|null,
+ * }}
+ */
+function parseArgs(argv) {
+  const args = {
+    dryRun: true,
+    outputFile: null,
+    summaryFile: null,
+    targetBranch: 'production',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+
+    if (!token.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${token}`);
+    }
+
+    const key = token.slice(2);
+    const value = argv[index + 1];
+    index += 1;
+
+    if (value === undefined) {
+      throw new Error(`Missing value for --${key}`);
+    }
+
+    switch (key) {
+      case 'repo':
+        args.repo = value;
+        break;
+      case 'target-branch':
+        args.targetBranch = value;
+        break;
+      case 'to-sha':
+        args.toSha = value;
+        break;
+      case 'reason':
+        args.reason = value;
+        break;
+      case 'dry-run':
+        if (value !== 'true' && value !== 'false') {
+          throw new Error('--dry-run must be "true" or "false"');
+        }
+
+        args.dryRun = value === 'true';
+        break;
+      case 'output-file':
+        args.outputFile = value;
+        break;
+      case 'summary-file':
+        args.summaryFile = value;
+        break;
+      default:
+        throw new Error(`Unsupported argument: --${key}`);
+    }
+  }
+
+  if (!args.repo || !args.toSha || !args.reason) {
+    throw new Error('--repo, --to-sha, and --reason are required');
+  }
+
+  return args;
+}
+
+/**
+ * @param {string[]} args
+ * @returns {string}
+ */
+function runGh(args) {
+  return execFileSync('gh', args, {
+    encoding: 'utf8',
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+/**
+ * @param {string[]} args
+ * @returns {any}
+ */
+function runGhJson(args) {
+  return JSON.parse(runGh(args));
+}
+
+/**
+ * @param {string[]} args
+ * @param {Record<string, unknown>} body
+ * @returns {any}
+ */
+function runGhJsonWithBody(args, body) {
+  return JSON.parse(execFileSync('gh', args.concat(['--input', '-']), {
+    encoding: 'utf8',
+    env: process.env,
+    input: JSON.stringify(body),
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim());
+}
+
+/**
+ * Derives the rollback plan from branch state.
+ *
+ * @param {{
+ *   currentSha: string,
+ *   targetBranch: string,
+ *   toSha: string,
+ * }} options
+ * @returns {{ needsUpdate: boolean, reason: string }}
+ */
+function deriveRollbackPlan({ currentSha, targetBranch, toSha }) {
+  if (currentSha === toSha) {
+    return {
+      needsUpdate: false,
+      reason: `${targetBranch} already points to ${toSha}; nothing to roll back.`,
+    };
+  }
+
+  return {
+    needsUpdate: true,
+    reason: `Force-resetting ${targetBranch} from ${currentSha} to ${toSha}.`,
+  };
+}
+
+/**
+ * @param {string|null} outputFile
+ * @param {string} key
+ * @param {string|number|boolean} value
+ */
+function appendOutput(outputFile, key, value) {
+  if (!outputFile) {
+    return;
+  }
+
+  fs.appendFileSync(outputFile, `${key}=${value}\n`, 'utf8');
+}
+
+/**
+ * @param {string|null} summaryFile
+ * @param {string[]} lines
+ */
+function appendSummary(summaryFile, lines) {
+  if (!summaryFile) {
+    return;
+  }
+
+  fs.appendFileSync(summaryFile, `${lines.join('\n')}\n`, 'utf8');
+}
+
+/**
+ * Main entry point.
+ */
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  // Resolves short SHAs and fails fast when the commit is not in this repo.
+  const commit = runGhJson(['api', `repos/${options.repo}/commits/${options.toSha}`]);
+  const toSha = commit.sha;
+  const branch = runGhJson(['api', `repos/${options.repo}/branches/${options.targetBranch}`]);
+  const currentSha = branch.commit.sha;
+  const plan = deriveRollbackPlan({
+    currentSha,
+    targetBranch: options.targetBranch,
+    toSha,
+  });
+
+  appendOutput(options.outputFile, 'dry_run', options.dryRun);
+  appendOutput(options.outputFile, 'target_sha_before', currentSha);
+  appendOutput(options.outputFile, 'rollback_to_sha', toSha);
+
+  const summaryHeader = [
+    '## Rollback Production',
+    '',
+    `- Target branch: ${options.targetBranch}`,
+    `- Current SHA: ${currentSha}`,
+    `- Rollback SHA: ${toSha}`,
+    `- Reason: ${options.reason}`,
+    `- Dry run: ${options.dryRun}`,
+  ];
+
+  if (!plan.needsUpdate) {
+    appendOutput(options.outputFile, 'rolled_back', false);
+    appendSummary(options.summaryFile, summaryHeader.concat([`- ${plan.reason}`]));
+    console.log(plan.reason);
+    return;
+  }
+
+  if (options.dryRun) {
+    appendOutput(options.outputFile, 'rolled_back', false);
+    appendSummary(options.summaryFile, summaryHeader.concat([
+      '- DRY RUN: the production ref was NOT moved. Re-run with dry_run=false to execute.',
+    ]));
+    console.log(`DRY RUN: would execute — ${plan.reason}`);
+    return;
+  }
+
+  runGh([
+    'api',
+    '--method',
+    'PATCH',
+    `repos/${options.repo}/git/refs/heads/${options.targetBranch}`,
+    '-f',
+    `sha=${toSha}`,
+    '-F',
+    'force=true',
+  ]);
+
+  const afterSha = runGhJson(
+    ['api', `repos/${options.repo}/branches/${options.targetBranch}`],
+  ).commit.sha;
+
+  if (afterSha !== toSha) {
+    throw new Error(
+      `Rollback verification failed: expected ${options.targetBranch} at ${toSha}, found ${afterSha}.`,
+    );
+  }
+
+  const deployment = runGhJsonWithBody(
+    ['api', '--method', 'POST', `repos/${options.repo}/deployments`],
+    {
+      ref: toSha,
+      environment: 'production',
+      auto_merge: false,
+      required_contexts: [],
+      description: `Rollback: ${options.reason}`.slice(0, 140),
+      payload: {
+        reason: options.reason,
+        rollback: true,
+        rolled_back_from: currentSha,
+      },
+    },
+  );
+
+  appendOutput(options.outputFile, 'rolled_back', true);
+  appendOutput(options.outputFile, 'deployment_id', deployment.id);
+  appendSummary(options.summaryFile, summaryHeader.concat([
+    `- Production ref moved: ${currentSha} → ${toSha}`,
+    `- Rollback deployment: ${deployment.id}`,
+    '- Render redeploys the rollback commit from the production push; post-deploy verification will set the final deployment status.',
+  ]));
+  console.log(`Rolled back ${options.targetBranch} to ${toSha} (deployment ${deployment.id}).`);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  deriveRollbackPlan,
+  parseArgs,
+};

--- a/scripts/github/update-deployment-status.js
+++ b/scripts/github/update-deployment-status.js
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+/**
+ * Updates the GitHub Deployment status for a deployed production commit.
+ * Post-deploy verification calls this to mark the deployment created by the
+ * promotion workflow as success/failure; when no deployment record exists
+ * (for example a direct production push), one is created first so every
+ * production deploy stays observable.
+ */
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+
+const VALID_STATES = ['success', 'failure'];
+
+/**
+ * Parses command-line arguments.
+ *
+ * @param {string[]} argv
+ * @returns {{
+ *   repo: string,
+ *   sha: string,
+ *   state: string,
+ *   environmentUrl: string|null,
+ *   logUrl: string|null,
+ *   outputFile: string|null,
+ * }}
+ */
+function parseArgs(argv) {
+  const args = {
+    environmentUrl: null,
+    logUrl: null,
+    outputFile: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+
+    if (!token.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${token}`);
+    }
+
+    const key = token.slice(2);
+    const value = argv[index + 1];
+    index += 1;
+
+    if (value === undefined) {
+      throw new Error(`Missing value for --${key}`);
+    }
+
+    switch (key) {
+      case 'repo':
+        args.repo = value;
+        break;
+      case 'sha':
+        args.sha = value;
+        break;
+      case 'state':
+        args.state = value;
+        break;
+      case 'environment-url':
+        args.environmentUrl = value;
+        break;
+      case 'log-url':
+        args.logUrl = value;
+        break;
+      case 'output-file':
+        args.outputFile = value;
+        break;
+      default:
+        throw new Error(`Unsupported argument: --${key}`);
+    }
+  }
+
+  if (!args.repo || !args.sha || !args.state) {
+    throw new Error('--repo, --sha, and --state are required');
+  }
+
+  if (!VALID_STATES.includes(args.state)) {
+    throw new Error(`--state must be one of: ${VALID_STATES.join(', ')}`);
+  }
+
+  return args;
+}
+
+/**
+ * @param {string[]} args
+ * @returns {any}
+ */
+function runGhJson(args) {
+  return JSON.parse(execFileSync('gh', args, {
+    encoding: 'utf8',
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim());
+}
+
+/**
+ * @param {string[]} args
+ * @param {Record<string, unknown>} body
+ * @returns {any}
+ */
+function runGhJsonWithBody(args, body) {
+  return JSON.parse(execFileSync('gh', args.concat(['--input', '-']), {
+    encoding: 'utf8',
+    env: process.env,
+    input: JSON.stringify(body),
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim());
+}
+
+/**
+ * Picks the most recent deployment record from a deployments listing.
+ *
+ * @param {{ id: number, created_at: string }[]} deployments
+ * @returns {{ id: number, created_at: string }|null}
+ */
+function pickLatestDeployment(deployments) {
+  if (!Array.isArray(deployments) || deployments.length === 0) {
+    return null;
+  }
+
+  return deployments.reduce((latest, candidate) => (
+    new Date(candidate.created_at).getTime() > new Date(latest.created_at).getTime()
+      ? candidate
+      : latest
+  ));
+}
+
+/**
+ * Finds the production deployment for a commit, creating one when missing.
+ *
+ * @param {{ repo: string, sha: string }} options
+ * @returns {{ id: number, created: boolean }}
+ */
+function findOrCreateDeployment({ repo, sha }) {
+  const deployments = runGhJson([
+    'api',
+    `repos/${repo}/deployments?sha=${sha}&environment=production&per_page=100`,
+  ]);
+  const latest = pickLatestDeployment(deployments);
+
+  if (latest) {
+    return { id: latest.id, created: false };
+  }
+
+  const deployment = runGhJsonWithBody(
+    ['api', '--method', 'POST', `repos/${repo}/deployments`],
+    {
+      ref: sha,
+      environment: 'production',
+      auto_merge: false,
+      required_contexts: [],
+      description: 'Deployment record created by post-deploy verification.',
+      payload: { source: 'post-deploy-verification' },
+    },
+  );
+
+  return { id: deployment.id, created: true };
+}
+
+/**
+ * Builds the deployment-status request body.
+ *
+ * @param {{
+ *   state: string,
+ *   environmentUrl: string|null,
+ *   logUrl: string|null,
+ * }} options
+ * @returns {Record<string, unknown>}
+ */
+function buildStatusBody({ state, environmentUrl, logUrl }) {
+  return {
+    state,
+    description: state === 'success'
+      ? 'Post-deploy Newman verification passed.'
+      : 'Post-deploy Newman verification failed.',
+    auto_inactive: state === 'success',
+    ...(environmentUrl ? { environment_url: environmentUrl } : {}),
+    ...(logUrl ? { log_url: logUrl } : {}),
+  };
+}
+
+/**
+ * @param {string|null} outputFile
+ * @param {string} key
+ * @param {string|number|boolean} value
+ */
+function appendOutput(outputFile, key, value) {
+  if (!outputFile) {
+    return;
+  }
+
+  fs.appendFileSync(outputFile, `${key}=${value}\n`, 'utf8');
+}
+
+/**
+ * Main entry point.
+ */
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const { id, created } = findOrCreateDeployment({ repo: options.repo, sha: options.sha });
+
+  runGhJsonWithBody(
+    ['api', '--method', 'POST', `repos/${options.repo}/deployments/${id}/statuses`],
+    buildStatusBody(options),
+  );
+
+  appendOutput(options.outputFile, 'deployment_id', id);
+  appendOutput(options.outputFile, 'deployment_created', created);
+  console.log(
+    `Marked production deployment ${id} (${created ? 'created here' : 'from promotion'}) `
+    + `as ${options.state} for ${options.sha}.`,
+  );
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  buildStatusBody,
+  findOrCreateDeployment,
+  parseArgs,
+  pickLatestDeployment,
+};

--- a/tests/unit/scripts/github/promoteToProduction.test.js
+++ b/tests/unit/scripts/github/promoteToProduction.test.js
@@ -1,9 +1,11 @@
 const {
+  buildPromotionDeploymentPayload,
   derivePromotionPlan,
   ensureRequiredChecksGreen,
   isProtectedBranchRefUpdateError,
   parseArgs,
   resolveRequiredChecks,
+  resolveRunLogUrl,
 } = require('../../../../scripts/github/promote-to-production');
 
 describe('Unit | Scripts | GitHub | Promote To Production', () => {
@@ -176,6 +178,104 @@ describe('Unit | Scripts | GitHub | Promote To Production', () => {
         needsUpdate: true,
         reason: 'production contains branch-only history. Resetting it to main@abc123 keeps both branches on the exact same commit.',
       });
+    });
+  });
+
+  describe('deployment evidence', () => {
+    it('records how the promotion happened in the deployment payload', () => {
+      expect(buildPromotionDeploymentPayload({
+        plan: { mode: 'fast-forward' },
+        requiredChecks: ['actionlint', 'test:ci (24)'],
+        sourceBranch: 'main',
+        sourceSha: 'abc123',
+        targetShaBefore: 'def456',
+      })).toEqual({
+        promotion_mode: 'fast-forward',
+        required_checks: ['actionlint', 'test:ci (24)'],
+        source_branch: 'main',
+        source_sha: 'abc123',
+        target_sha_before: 'def456',
+      });
+    });
+
+    it('resolves the Actions run log URL only when the env is complete', () => {
+      expect(resolveRunLogUrl({
+        GITHUB_REPOSITORY: 'jsugg/alt-text-generator',
+        GITHUB_RUN_ID: '7',
+        GITHUB_SERVER_URL: 'https://github.com',
+      })).toBe('https://github.com/jsugg/alt-text-generator/actions/runs/7');
+      expect(resolveRunLogUrl({})).toBeNull();
+    });
+
+    it('creates the production deployment and marks it in progress through gh', () => {
+      jest.isolateModules(() => {
+        const calls = [];
+
+        jest.doMock('node:child_process', () => ({
+          execFileSync: jest.fn((command, args, options) => {
+            calls.push({ args, input: options.input ? JSON.parse(options.input) : null });
+
+            return calls.length === 1 ? '{"id": 42}' : '{"state": "in_progress"}';
+          }),
+        }));
+
+        const promotion = require('../../../../scripts/github/promote-to-production');
+        const deploymentId = promotion.recordPromotionDeployment({
+          repo: 'jsugg/alt-text-generator',
+          plan: { mode: 'fast-forward' },
+          requiredChecks: ['actionlint'],
+          sourceBranch: 'main',
+          sourceSha: 'abc123def',
+          targetBranch: 'production',
+          targetShaBefore: 'def456',
+        });
+
+        expect(deploymentId).toBe(42);
+        expect(calls[0].args).toEqual([
+          'api', '--method', 'POST',
+          'repos/jsugg/alt-text-generator/deployments',
+          '--input', '-',
+        ]);
+        expect(calls[0].input).toMatchObject({
+          ref: 'abc123def',
+          environment: 'production',
+          auto_merge: false,
+          required_contexts: [],
+          payload: { promotion_mode: 'fast-forward', target_sha_before: 'def456' },
+        });
+        expect(calls[1].args).toEqual([
+          'api', '--method', 'POST',
+          'repos/jsugg/alt-text-generator/deployments/42/statuses',
+          '--input', '-',
+        ]);
+        expect(calls[1].input).toMatchObject({ state: 'in_progress' });
+      });
+
+      jest.dontMock('node:child_process');
+    });
+
+    it('degrades deployment evidence failures to a null id without throwing', () => {
+      jest.isolateModules(() => {
+        jest.doMock('node:child_process', () => ({
+          execFileSync: jest.fn(() => {
+            throw new Error('gh: Not Found (HTTP 404)');
+          }),
+        }));
+
+        const promotion = require('../../../../scripts/github/promote-to-production');
+
+        expect(promotion.recordPromotionDeployment({
+          repo: 'jsugg/alt-text-generator',
+          plan: { mode: 'fast-forward' },
+          requiredChecks: [],
+          sourceBranch: 'main',
+          sourceSha: 'abc123',
+          targetBranch: 'production',
+          targetShaBefore: 'def456',
+        })).toBeNull();
+      });
+
+      jest.dontMock('node:child_process');
     });
   });
 

--- a/tests/unit/scripts/github/rollbackProduction.test.js
+++ b/tests/unit/scripts/github/rollbackProduction.test.js
@@ -1,0 +1,70 @@
+const { deriveRollbackPlan, parseArgs } = require('../../../../scripts/github/rollback-production');
+
+describe('Unit | Scripts | GitHub | Rollback Production', () => {
+  describe('parseArgs', () => {
+    it('parses supported arguments with dry-run defaulting to true', () => {
+      expect(parseArgs([
+        '--repo', 'jsugg/alt-text-generator',
+        '--to-sha', 'abc123',
+        '--reason', 'deploy regression',
+      ])).toEqual({
+        repo: 'jsugg/alt-text-generator',
+        targetBranch: 'production',
+        toSha: 'abc123',
+        reason: 'deploy regression',
+        dryRun: true,
+        outputFile: null,
+        summaryFile: null,
+      });
+    });
+
+    it('parses an explicit real run', () => {
+      expect(parseArgs([
+        '--repo', 'jsugg/alt-text-generator',
+        '--to-sha', 'abc123',
+        '--reason', 'deploy regression',
+        '--dry-run', 'false',
+      ]).dryRun).toBe(false);
+    });
+
+    it('rejects non-boolean dry-run values', () => {
+      expect(() => parseArgs([
+        '--repo', 'r/r', '--to-sha', 'a', '--reason', 'x', '--dry-run', 'yes',
+      ])).toThrow('--dry-run must be "true" or "false"');
+    });
+
+    it('requires repo, to-sha, and reason', () => {
+      expect(() => parseArgs(['--repo', 'r/r'])).toThrow(
+        '--repo, --to-sha, and --reason are required',
+      );
+    });
+
+    it('rejects unsupported flags', () => {
+      expect(() => parseArgs(['--force', 'true'])).toThrow('Unsupported argument: --force');
+    });
+  });
+
+  describe('deriveRollbackPlan', () => {
+    it('is a no-op when production already points to the rollback SHA', () => {
+      expect(deriveRollbackPlan({
+        currentSha: 'abc123',
+        targetBranch: 'production',
+        toSha: 'abc123',
+      })).toEqual({
+        needsUpdate: false,
+        reason: 'production already points to abc123; nothing to roll back.',
+      });
+    });
+
+    it('plans a force reset when the SHAs differ', () => {
+      expect(deriveRollbackPlan({
+        currentSha: 'def456',
+        targetBranch: 'production',
+        toSha: 'abc123',
+      })).toEqual({
+        needsUpdate: true,
+        reason: 'Force-resetting production from def456 to abc123.',
+      });
+    });
+  });
+});

--- a/tests/unit/scripts/github/rollbackProductionWorkflow.test.js
+++ b/tests/unit/scripts/github/rollbackProductionWorkflow.test.js
@@ -1,0 +1,100 @@
+const {
+  assertDeepEqualInvariant,
+  assertEqualInvariant,
+  assertExpressionContainsInvariant,
+  assertNoRunCommandContainsInvariant,
+  assertStringContainsInvariant,
+  findStepByName,
+  getJob,
+  loadWorkflow,
+} = require('../../../helpers/workflowAssertions');
+
+describe('Unit | Scripts | GitHub | Rollback Production Workflow', () => {
+  const workflow = loadWorkflow('rollback-production.yml');
+  const job = getJob(workflow, 'rollback');
+
+  it('runs only on manual dispatch with a dry-run default of true', () => {
+    const { inputs } = workflow.on.workflow_dispatch;
+
+    assertDeepEqualInvariant(
+      'Rollback exposes exactly the to_sha, reason, and dry_run inputs',
+      Object.keys(inputs),
+      ['to_sha', 'reason', 'dry_run'],
+    );
+    assertEqualInvariant('Rollback requires a target SHA', inputs.to_sha.required, true);
+    assertEqualInvariant('Rollback requires a reason', inputs.reason.required, true);
+    assertEqualInvariant(
+      'Rollback defaults to a dry run so a mistaken dispatch cannot move production',
+      inputs.dry_run.default,
+      true,
+    );
+  });
+
+  it('serializes with promotion so a rollback never interleaves with a release', () => {
+    assertDeepEqualInvariant(
+      'Rollback shares the promotion concurrency group without cancellation',
+      workflow.concurrency,
+      {
+        group: 'promote-to-production',
+        'cancel-in-progress': false,
+      },
+    );
+  });
+
+  it('keeps the promotion trust boundary: App token only, prod-validation environment', () => {
+    const rollbackStep = findStepByName(job, 'rollback', 'Roll back production with GitHub App token');
+    const requireAppStep = findStepByName(job, 'rollback', 'Require repository automation GitHub App');
+
+    assertEqualInvariant(
+      'Rollback runs in the prod-validation environment',
+      job.environment,
+      'prod-validation',
+    );
+    assertExpressionContainsInvariant(
+      'Rollback executes only when the GitHub App auth strategy resolves',
+      rollbackStep.if,
+      "steps.promotion-auth.outputs.use_github_app == 'true'",
+    );
+    assertEqualInvariant(
+      'Rollback uses the App installation token as GH_TOKEN',
+      rollbackStep.env.GH_TOKEN,
+      '${{ steps.promotion-app-token.outputs.token }}',
+    );
+    assertExpressionContainsInvariant(
+      'Rollback fails closed without the GitHub App (no PAT fallback)',
+      requireAppStep.if,
+      "steps.promotion-auth.outputs.use_github_app != 'true'",
+    );
+    assertDeepEqualInvariant(
+      'Rollback workflow permissions stay limited to contents write',
+      workflow.permissions,
+      { contents: 'write' },
+    );
+    assertEqualInvariant('Rollback declares a timeout', job['timeout-minutes'], 10);
+  });
+
+  it('passes free-text inputs through environment indirection', () => {
+    const rollbackStep = findStepByName(job, 'rollback', 'Roll back production with GitHub App token');
+
+    assertEqualInvariant(
+      'Rollback reason flows through an env var, never inline shell interpolation',
+      rollbackStep.env.ROLLBACK_REASON,
+      '${{ inputs.reason }}',
+    );
+    assertStringContainsInvariant(
+      'Rollback script reads the reason from the environment',
+      rollbackStep.run,
+      '--reason "${ROLLBACK_REASON}"',
+    );
+    assertStringContainsInvariant(
+      'Rollback script reads the dry-run flag from the environment',
+      rollbackStep.run,
+      '--dry-run "${ROLLBACK_DRY_RUN}"',
+    );
+    assertNoRunCommandContainsInvariant(
+      workflow,
+      '${{ inputs.',
+      'Rollback run commands must not inline dispatch inputs',
+    );
+  });
+});

--- a/tests/unit/scripts/github/updateDeploymentStatus.test.js
+++ b/tests/unit/scripts/github/updateDeploymentStatus.test.js
@@ -1,0 +1,82 @@
+const {
+  buildStatusBody,
+  parseArgs,
+  pickLatestDeployment,
+} = require('../../../../scripts/github/update-deployment-status');
+
+describe('Unit | Scripts | GitHub | Update Deployment Status', () => {
+  describe('parseArgs', () => {
+    it('parses supported arguments', () => {
+      expect(parseArgs([
+        '--repo', 'jsugg/alt-text-generator',
+        '--sha', 'abc123',
+        '--state', 'success',
+        '--environment-url', 'https://wcag.qcraft.com.br',
+        '--log-url', 'https://github.com/run/1',
+        '--output-file', '/tmp/out.txt',
+      ])).toEqual({
+        repo: 'jsugg/alt-text-generator',
+        sha: 'abc123',
+        state: 'success',
+        environmentUrl: 'https://wcag.qcraft.com.br',
+        logUrl: 'https://github.com/run/1',
+        outputFile: '/tmp/out.txt',
+      });
+    });
+
+    it('rejects invalid states', () => {
+      expect(() => parseArgs([
+        '--repo', 'r/r', '--sha', 'abc', '--state', 'in_progress',
+      ])).toThrow('--state must be one of: success, failure');
+    });
+
+    it('requires repo, sha, and state', () => {
+      expect(() => parseArgs(['--repo', 'r/r'])).toThrow(
+        '--repo, --sha, and --state are required',
+      );
+    });
+  });
+
+  describe('pickLatestDeployment', () => {
+    it('picks the newest deployment by creation time', () => {
+      expect(pickLatestDeployment([
+        { id: 1, created_at: '2026-07-01T00:00:00Z' },
+        { id: 3, created_at: '2026-07-02T12:00:00Z' },
+        { id: 2, created_at: '2026-07-02T00:00:00Z' },
+      ])).toEqual({ id: 3, created_at: '2026-07-02T12:00:00Z' });
+    });
+
+    it('returns null for empty listings', () => {
+      expect(pickLatestDeployment([])).toBeNull();
+      expect(pickLatestDeployment(undefined)).toBeNull();
+    });
+  });
+
+  describe('buildStatusBody', () => {
+    it('marks successes with auto_inactive and URLs', () => {
+      expect(buildStatusBody({
+        state: 'success',
+        environmentUrl: 'https://wcag.qcraft.com.br',
+        logUrl: 'https://github.com/run/1',
+      })).toEqual({
+        state: 'success',
+        description: 'Post-deploy Newman verification passed.',
+        auto_inactive: true,
+        environment_url: 'https://wcag.qcraft.com.br',
+        log_url: 'https://github.com/run/1',
+      });
+    });
+
+    it('keeps failed deployments active and omits absent URLs', () => {
+      expect(buildStatusBody({
+        state: 'failure',
+        environmentUrl: null,
+        logUrl: null,
+      })).toEqual({
+        state: 'failure',
+        description: 'Post-deploy Newman verification failed.',
+        auto_inactive: false,
+      });
+    });
+  });
+});

--- a/tests/unit/scripts/runPostmanDeploy.test.js
+++ b/tests/unit/scripts/runPostmanDeploy.test.js
@@ -22,6 +22,7 @@ const {
   assertNoEnvKeysInvariant,
   assertNoRunCommandContainsInvariant,
   assertStepUsesAction,
+  assertStringContainsInvariant,
   findStepByName,
   getJob,
   loadWorkflow,
@@ -493,6 +494,39 @@ describe('Unit | Scripts | Run Postman Deploy', () => {
         workflow,
         'postman:deploy',
         'Post Deploy workflow must not call the removed postman:deploy script',
+      );
+
+      const statusStep = findStepByName(smokeJob, 'smoke', 'Update production deployment status');
+
+      assertDeepEqualInvariant(
+        'Post Deploy smoke job escalates only to deployments write',
+        smokeJob.permissions,
+        { contents: 'read', deployments: 'write' },
+      );
+      assertEqualInvariant(
+        'Post Deploy Newman step exposes an outcome id for the deployment status',
+        postDeployStep.id,
+        'newman-verify',
+      );
+      assertEqualInvariant(
+        'Deployment status updates run only for real production pushes',
+        statusStep.if,
+        "always() && github.event_name == 'push'",
+      );
+      assertEqualInvariant(
+        'Deployment status derives success or failure from the Newman outcome',
+        statusStep.env.DEPLOY_STATE,
+        "${{ steps.newman-verify.outcome == 'success' && 'success' || 'failure' }}",
+      );
+      assertStringContainsInvariant(
+        'Deployment status updates go through the repository script',
+        statusStep.run,
+        'node scripts/github/update-deployment-status.js',
+      );
+      assertStringContainsInvariant(
+        'Deployment status reports the canonical production environment URL',
+        statusStep.run,
+        '--environment-url "https://wcag.qcraft.com.br"',
       );
     });
 


### PR DESCRIPTION
Recreates #216 (auto-closed when its stacked base branch was deleted after the cutover merge). Same content, synced with post-cutover main. Full description, guardrails, C09 test inventory, and rollback-drill instructions in #216.