### PR TITLE
chore(ci): promote typecheck from advisory to required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,17 +178,15 @@ jobs:
         if: needs.changes.outputs.docs_only == 'true'
         run: echo "Docs-only change; OpenAPI gate satisfied by docs validation."
 
-  # Advisory JSDoc type gate: strict checkJs carries known debt
-  # (docs/typecheck-debt.md), so the job may fail without blocking the run.
-  # Drop continue-on-error and add the context to required checks only when
-  # the debt reaches zero.
+  # Blocking JSDoc type gate: strict checkJs (docs/typecheck-debt.md) is at
+  # zero, so a regression fails the run. This is a required status check; keep
+  # the job name stable ("typecheck") so branch protection keeps matching it.
   typecheck:
     name: typecheck
     needs:
       - changes
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true
     steps:
       - name: Checkout
         if: needs.changes.outputs.docs_only != 'true'

--- a/config/github/required-checks.json
+++ b/config/github/required-checks.json
@@ -11,7 +11,8 @@
       "newman",
       "openapi",
       "test:ci (24)",
-      "test:unit (24)"
+      "test:unit (24)",
+      "typecheck"
     ]
   },
   "productionRuleset": {
@@ -26,7 +27,8 @@
       "newman",
       "openapi",
       "test:ci (24)",
-      "test:unit (24)"
+      "test:unit (24)",
+      "typecheck"
     ],
     "bypassActors": [
       {

--- a/tests/unit/jestLaneConfigs.test.js
+++ b/tests/unit/jestLaneConfigs.test.js
@@ -433,9 +433,9 @@ describe('Unit | Jest Lane Configs', () => {
       'typecheck',
     );
     assertEqualInvariant(
-      'CI typecheck stays advisory until the debt ledger reaches zero',
+      'CI typecheck is a blocking gate now that the debt ledger is zero',
       typecheckJob['continue-on-error'],
-      true,
+      undefined,
     );
     assertEqualInvariant(
       'CI typecheck declares a timeout',


### PR DESCRIPTION
## Summary

Promotes the strict checkJs `typecheck` gate from advisory to required, now
that the debt ledger is at zero and on `main` (#232).

## Changes

- `.github/workflows/ci.yml`: drop `continue-on-error: true` from the
  `typecheck` job (comment refreshed). The docs-only skip step still publishes
  a no-op success, so the required check never hangs on docs-only PRs.
- `config/github/required-checks.json`: add the `typecheck` context to
  `mainBranchProtection` and `productionRuleset` (kept mirrored).
- `tests/unit/jestLaneConfigs.test.js`: flip the invariant to assert the job
  is blocking (no `continue-on-error`).

## Verification

- `npm run checks:verify` (offline) → OK.
- `requiredCheckPolicy` + `jestLaneConfigs` suites green (29 tests).
- Rebuilt on top of current `main`, so the diff is exactly the promotion; the
  security hardening from #232 is retained, not reverted.

## Live step (maintainer, after merge)

Apply the live change per `docs/required-checks.md`: export the current `main`
protection and production ruleset first, then add the `typecheck` context to
both. Verify with `npm run checks:verify -- --live`.
