### PR TITLE
ci(security): enforce action SHA-pinning in CI

### DIFF
--- a/docs/action-pinning.md
+++ b/docs/action-pinning.md
@@ -1,0 +1,68 @@
+# GitHub Actions pinning policy
+
+**Third-party actions must be pinned to a full-length commit SHA. First-party
+`actions/*` and `github/*` actions may be referenced by tag (trusted by
+publisher).** You pin what you reference; you do not try to pin what GitHub
+nests inside its own actions.
+
+## Why this shape
+
+SHA-pinning defends against tag mutation — the class of attack where a popular
+action's tag is repointed at malicious code (e.g. the `tj-actions/changed-files`
+compromise). The threat is real for **third-party** actions, so those are pinned
+to an immutable commit.
+
+The repo previously enforced this with the runner-level setting
+`sha_pinning_required`, which also validated **transitive** references — the
+`uses:` lines *inside* the actions we call. GitHub's own actions reference their
+dependencies by tag (`actions/upload-pages-artifact@v3` calls
+`actions/upload-artifact@v4` internally), so that setting rejected the Pages
+publish at "Set up job" and would break any future first-party toolchain the
+same way. See [allure-pages] history.
+
+We resolve the clash by enforcing pinning at the layer we actually control —
+our own direct `uses:` — and trusting GitHub as a publisher for `actions/*` and
+`github/*`. This is the OpenSSF "pin what you use" guidance: pin third-party to
+a SHA, trust the platform for what it nests.
+
+## How it is enforced
+
+- **`scripts/github/verify-action-pins.js`** classifies every `uses:` in
+  `.github/workflows/*.yml` and `.github/actions/**/action.yml`. Run locally
+  with `npm run verify:action-pins`.
+- **`tests/unit/scripts/github/actionPinPolicy.test.js`** asserts the policy has
+  zero violations. It runs in the required `test:unit` / `test:ci` lanes, so an
+  unpinned third-party action fails a **required** check on the PR — the gate
+  binds without a new branch-protection context.
+
+Local composite actions (`./…`) and `docker://` images are out of scope for this
+check (the former is our own code; container images are pinned separately).
+
+## Trusted publishers
+
+| Publisher | Referenced by | Rationale |
+|---|---|---|
+| `actions/*` | tag or SHA | GitHub-authored; internals are GitHub's to pin. |
+| `github/*` | tag or SHA | GitHub-authored (e.g. `github/codeql-action`). |
+
+Every other publisher must pin to a commit SHA. There are currently no
+third-party exceptions — both third-party actions in use
+(`EnricoMi/publish-unit-test-result-action`, `step-security/harden-runner`) are
+SHA-pinned. To add a publisher to the trusted set, edit `TRUSTED_PUBLISHERS` in
+the verifier and record the rationale here.
+
+## Keeping pins current
+
+A pin with no update pipeline rots into a stale, vulnerable version. Dependabot
+(`github-actions` ecosystem, weekly) bumps the SHA pins and keeps the readable
+`# vX.Y.Z` comment. Never hand-freeze an action without letting Dependabot track
+it.
+
+## Relationship to `sha_pinning_required`
+
+The runner-level `sha_pinning_required` is intentionally **off**: it over-reached
+by policing GitHub's transitive references. Enforcement now lives in CI (the
+policy test above). If the setting is ever re-enabled, the Pages publish will
+break again at "Set up job" — that is the expected symptom, not a regression.
+
+[allure-pages]: ../.github/workflows/allure-pages-publish.yml

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "allure:generate": "allure generate reports/allure-results --clean -o reports/allure-report",
     "allure:open": "allure open reports/allure-report",
     "checks:verify": "node scripts/github/verify-required-checks.js",
+    "verify:action-pins": "node scripts/github/verify-action-pins.js",
     "doctor:tls": "node scripts/doctor-tls.js",
     "docs:validate": "node scripts/docs/validate-docs.js",
     "dev:test-env": "ENV_FILE=.env.test NODE_ENV=development nodemon src/app.js | pino-pretty -i streams,options",

--- a/scripts/github/verify-action-pins.js
+++ b/scripts/github/verify-action-pins.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+// Enforces the GitHub Actions pinning policy in CI (see docs/action-pinning.md):
+// third-party actions must be pinned to a full-length commit SHA; first-party
+// actions/* and github/* may be referenced by tag (trusted by publisher). This
+// is the enforcement layer we control — our own `uses:` — after moving off the
+// runner-level `sha_pinning_required`, which also policed GitHub's own nested
+// (transitive) references and broke the Pages toolchain.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+/** Publishers trusted to be referenced by tag (GitHub's own first-party actions). */
+const TRUSTED_PUBLISHERS = new Set(['actions', 'github']);
+
+/** A full-length git commit SHA: 40 hex (SHA-1) or 64 hex (SHA-256). */
+const SHA_PATTERN = /^[0-9a-f]{40}$|^[0-9a-f]{64}$/;
+
+/**
+ * @typedef {{
+ *   kind: 'local' | 'docker' | 'trusted' | 'pinned' | 'unpinned',
+ *   owner?: string,
+ *   ref?: string,
+ * }} UsesClassification
+ */
+
+/**
+ * Classifies a single `uses:` reference against the pinning policy.
+ *
+ * @param {string} reference the value after `uses:` (e.g. `owner/repo/sub@ref`)
+ * @returns {UsesClassification}
+ */
+function classifyUses(reference) {
+  const value = reference.trim().replace(/^["']|["']$/g, '');
+
+  if (value.startsWith('./') || value.startsWith('../') || value.startsWith('.\\')) {
+    return { kind: 'local' };
+  }
+
+  if (value.startsWith('docker://')) {
+    return { kind: 'docker' };
+  }
+
+  const atIndex = value.lastIndexOf('@');
+  const owner = value.split('/')[0] || '';
+
+  if (atIndex === -1) {
+    return { kind: 'unpinned', owner, ref: '' };
+  }
+
+  const gitRef = value.slice(atIndex + 1);
+
+  if (TRUSTED_PUBLISHERS.has(owner)) {
+    return { kind: 'trusted', owner, ref: gitRef };
+  }
+
+  if (SHA_PATTERN.test(gitRef)) {
+    return { kind: 'pinned', owner, ref: gitRef };
+  }
+
+  return { kind: 'unpinned', owner, ref: gitRef };
+}
+
+/**
+ * @typedef {{ file: string, line: number, ref: string }} PinViolation
+ */
+
+/**
+ * Collects policy violations (unpinned third-party actions) across the files.
+ *
+ * @param {string[]} files
+ * @returns {PinViolation[]}
+ */
+function collectPinViolations(files) {
+  /** @type {PinViolation[]} */
+  const violations = [];
+  const usesPattern = /^\s*(?:-\s*)?uses:\s*(\S+)/;
+
+  files.forEach((file) => {
+    const lines = fs.readFileSync(file, 'utf8').split('\n');
+
+    lines.forEach((text, index) => {
+      const match = usesPattern.exec(text);
+      const reference = match ? match[1] : undefined;
+
+      if (!reference) {
+        return;
+      }
+
+      if (classifyUses(reference).kind === 'unpinned') {
+        violations.push({ file, line: index + 1, ref: reference });
+      }
+    });
+  });
+
+  return violations;
+}
+
+/**
+ * Lists the workflow and composite-action definition files under `.github`.
+ *
+ * @param {string} [root]
+ * @returns {string[]}
+ */
+function listWorkflowFiles(root = '.github') {
+  /** @type {string[]} */
+  const files = [];
+
+  const workflowsDir = path.join(root, 'workflows');
+  if (fs.existsSync(workflowsDir)) {
+    fs.readdirSync(workflowsDir)
+      .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+      .forEach((name) => files.push(path.join(workflowsDir, name)));
+  }
+
+  const actionsDir = path.join(root, 'actions');
+  if (fs.existsSync(actionsDir)) {
+    fs.readdirSync(actionsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .forEach((entry) => {
+        ['action.yml', 'action.yaml'].forEach((candidate) => {
+          const candidatePath = path.join(actionsDir, entry.name, candidate);
+          if (fs.existsSync(candidatePath)) {
+            files.push(candidatePath);
+          }
+        });
+      });
+  }
+
+  return files;
+}
+
+function main() {
+  const files = listWorkflowFiles();
+  const violations = collectPinViolations(files);
+
+  if (violations.length > 0) {
+    process.stderr.write('Unpinned third-party actions (pin to a full-length commit SHA):\n');
+    violations.forEach((violation) => {
+      process.stderr.write(`  ${violation.file}:${violation.line}  ${violation.ref}\n`);
+    });
+    process.stderr.write(
+      '\nPolicy: third-party actions must pin to a commit SHA; actions/* and github/* may use a tag.\n'
+      + 'See docs/action-pinning.md.\n',
+    );
+    process.exit(1);
+  }
+
+  process.stdout.write(`Action-pin policy OK (${files.length} files scanned).\n`);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  classifyUses,
+  collectPinViolations,
+  listWorkflowFiles,
+  TRUSTED_PUBLISHERS,
+};

--- a/tests/unit/scripts/github/actionPinPolicy.test.js
+++ b/tests/unit/scripts/github/actionPinPolicy.test.js
@@ -1,0 +1,59 @@
+const {
+  classifyUses,
+  collectPinViolations,
+  listWorkflowFiles,
+} = require('../../../../scripts/github/verify-action-pins');
+
+describe('Unit | GitHub Action Pin Policy', () => {
+  it('requires third-party actions to be pinned to a commit SHA', () => {
+    expect(classifyUses(
+      'EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3',
+    ).kind).toBe('pinned');
+    expect(classifyUses('some-org/some-action@v1').kind).toBe('unpinned');
+    expect(classifyUses('some-org/some-action@main').kind).toBe('unpinned');
+    expect(classifyUses('some-org/some-action').kind).toBe('unpinned');
+  });
+
+  it('trusts actions/* and github/* by publisher (tag or SHA allowed)', () => {
+    expect(classifyUses('actions/checkout@v4').kind).toBe('trusted');
+    expect(classifyUses('github/codeql-action/init@v3').kind).toBe('trusted');
+    expect(classifyUses(
+      'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0',
+    ).kind).toBe('trusted');
+  });
+
+  it('ignores local and docker references', () => {
+    expect(classifyUses('./.github/actions/setup-node-project').kind).toBe('local');
+    expect(classifyUses('docker://alpine:3.20').kind).toBe('docker');
+  });
+
+  it('flags an unpinned third-party action with its file and line', () => {
+    const os = require('node:os');
+    const fs = require('node:fs');
+    const path = require('node:path');
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pin-policy-'));
+    const workflowsDir = path.join(dir, 'workflows');
+    fs.mkdirSync(workflowsDir, { recursive: true });
+    const file = path.join(workflowsDir, 'sample.yml');
+    fs.writeFileSync(
+      file,
+      ['jobs:', '  build:', '    steps:', '      - uses: evil/action@v1'].join('\n'),
+      'utf8',
+    );
+
+    try {
+      const violations = collectPinViolations(listWorkflowFiles(dir));
+      expect(violations).toEqual([{ file, line: 4, ref: 'evil/action@v1' }]);
+    } finally {
+      fs.rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it('every action referenced in .github satisfies the pinning policy', () => {
+    const files = listWorkflowFiles();
+
+    expect(files.length).toBeGreaterThan(0);
+    expect(collectPinViolations(files)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Shifts GitHub Actions SHA-pinning enforcement from the runner-level `sha_pinning_required` setting to a CI policy check we control (S3). That setting validated **transitive** references too — GitHub's own `actions/upload-pages-artifact@v3` calls `actions/upload-artifact@v4` by tag internally — which rejected the Allure Pages publish at "Set up job". We enforce pinning on our own direct `uses:` and trust `actions/*` / `github/*` by publisher.

## Changes
- `scripts/github/verify-action-pins.js`: third-party actions must pin to a commit SHA; `actions/*` + `github/*` may use a tag. Local (`./`) and `docker://` are out of scope.
- `tests/unit/scripts/github/actionPinPolicy.test.js`: asserts zero violations in `.github`; runs in the required test lane, so an unpinned third-party action fails a **required** check — binds without a new branch-protection context.
- `docs/action-pinning.md`: policy, rationale, trusted publishers, keeping pins current, relationship to `sha_pinning_required`.
- `package.json`: `npm run verify:action-pins`.

## Verification
- `typecheck` 0, ESLint clean, new suite 5/5, `verify:action-pins` OK (13 files), `docs:validate` OK.
- All current `uses:` already satisfy the policy (both third-party actions SHA-pinned).

## Follow-up (repo settings, after merge)
Disable runner-level `sha_pinning_required` — sequenced **after** this lands so enforcement stays continuous. That also unblocks Allure Pages (the transitive `@v4` stops being runner-rejected).