### PR TITLE
ci(security): extend pinning posture to app deps, publish safety, installers

### DIFF
--- a/docs/action-pinning.md
+++ b/docs/action-pinning.md
@@ -58,6 +58,22 @@ A pin with no update pipeline rots into a stale, vulnerable version. Dependabot
 `# vX.Y.Z` comment. Never hand-freeze an action without letting Dependabot track
 it.
 
+## Adjacent pinning surfaces
+
+The same posture — pin what you own, trust the platform for what you don't,
+automate the bumps — applies beyond Actions. These are enforced by
+`tests/unit/supplyChainPolicy.test.js`:
+
+- **App dependencies** — `package-lock.json` is committed and installed frozen
+  with `npm ci`; the manifest keeps semver ranges, and Dependabot bumps the
+  lockfile (never hand-pin exact versions in `package.json`).
+- **Publish safety** — `package.json` is `"private": true`. This is a service,
+  not a published library, so it must never be `npm publish`ed by accident; a
+  library, by contrast, would ship ranges and stay publishable.
+- **Installer scripts** — no `curl … | bash` / `wget … | sh`. The one binary we
+  fetch (`scripts/github/install-actionlint.sh`) pins a version and verifies a
+  `sha256sum` before executing.
+
 ## Relationship to `sha_pinning_required`
 
 The runner-level `sha_pinning_required` is intentionally **off**: it over-reached

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "alt-text-generator",
   "version": "1.0.0",
+  "private": true,
   "description": "A simple service that uses AI services to propose Alt Text descriptions for your website images.",
   "keywords": [
     "alt",

--- a/tests/unit/supplyChainPolicy.test.js
+++ b/tests/unit/supplyChainPolicy.test.js
@@ -1,0 +1,62 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.join(__dirname, '..', '..');
+
+/** @param {string} relativePath */
+const read = (relativePath) => fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+
+/**
+ * Collects files under `dir` whose name matches `pattern`, recursively.
+ *
+ * @param {string} dir
+ * @param {RegExp} pattern
+ * @returns {string[]}
+ */
+function collectFiles(dir, pattern) {
+  /** @type {string[]} */
+  const found = [];
+
+  if (!fs.existsSync(dir)) {
+    return found;
+  }
+
+  fs.readdirSync(dir, { withFileTypes: true }).forEach((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      found.push(...collectFiles(full, pattern));
+    } else if (pattern.test(entry.name)) {
+      found.push(full);
+    }
+  });
+
+  return found;
+}
+
+describe('Unit | Supply-chain pinning posture', () => {
+  it('marks the package private so the service is never accidentally published', () => {
+    const pkg = JSON.parse(read('package.json'));
+
+    expect(pkg.private).toBe(true);
+  });
+
+  it('commits a lockfile and installs it frozen (npm ci) in CI', () => {
+    expect(fs.existsSync(path.join(repoRoot, 'package-lock.json'))).toBe(true);
+
+    const setup = read(path.join('.github', 'actions', 'setup-node-project', 'action.yml'));
+    expect(setup).toMatch(/\bnpm ci\b/);
+  });
+
+  it('never pipes a network download straight into a shell', () => {
+    const files = [
+      ...collectFiles(path.join(repoRoot, '.github'), /\.(sh|ya?ml|bash)$/),
+      ...collectFiles(path.join(repoRoot, 'scripts'), /\.(sh|ya?ml|bash)$/),
+    ];
+    const pipeToShell = /\b(curl|wget)\b[^\n|]*\|[^\n]*\b(bash|sh)\b/;
+
+    /** @type {string[]} */
+    const offenders = files.filter((file) => pipeToShell.test(fs.readFileSync(file, 'utf8')));
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Extends the S3 pinning posture (see #235) to the adjacent supply-chain surfaces you flagged, each locked in by a policy test in the required test lane.

| Surface | Repo status | This PR |
|---|---|---|
| 3rd-party Actions | SHA-pin enforced (#235) | — |
| First-party `actions/*`,`github/*` | trusted by publisher (#235) | — |
| App language deps | `package-lock.json` committed + `npm ci` frozen | guard test |
| Published libraries | it's an app, not a lib | **`private: true`** (was unset → publish risk) |
| `curl\|bash` installers | none; actionlint dl pins version + verifies sha256 | guard test |

## Changes
- `package.json`: `"private": true`.
- `tests/unit/supplyChainPolicy.test.js`: asserts private, frozen `npm ci` + lockfile, and no `curl\|bash`/`wget\|sh` pipe-to-shell under `.github`/`scripts`.
- `docs/action-pinning.md`: documents the adjacent surfaces.