### PR TITLE
chore(dependabot): group all updates per stream, keep merge manual

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,14 @@
 # Dependency-update policy (see tests/unit/dependabotPolicy.test.js).
 #
+# Posture: GROUP ALL, MERGE MANUALLY. Each ecosystem gets one grouped
+# version-update PR and one grouped security-update PR — every update type
+# (major/minor/patch) and both production and development dependencies land in
+# the same PR. Nothing auto-merges: after the recent wave of supply-chain
+# compromises of popular, widely-trusted packages, a human reviews the whole
+# batch (diff + changelog + provenance) before it merges. There is deliberately
+# no auto-merge workflow, and grouping majors keeps peer-coupled bumps (e.g.
+# pino / pino-http) together in one reviewable PR.
+#
 # Ignore rules suppress the known out-of-scope majors only:
 #   - ESLint stays on 9.x: the flat-config toolchain decision pins ESLint 9;
 #     ESLint 10 migration is a deliberate project, not a routine bump.
@@ -10,7 +19,7 @@
 # updates for the matched majors. If a security advisory is only fixed in a
 # suppressed major, remove the ignore entry for that package (or apply the fix
 # manually) — never leave a known-vulnerable version pinned because of noise
-# policy. Security fixes within the current majors flow normally, and
+# policy. Security fixes within the current majors flow normally (grouped), and
 # Dependabot security updates are enabled repo-side.
 version: 2
 updates:
@@ -20,18 +29,14 @@ updates:
       interval: weekly
     open-pull-requests-limit: 5
     groups:
-      npm-production:
-        dependency-type: production
+      npm-all:
         applies-to: version-updates
-        update-types:
-          - minor
-          - patch
-      npm-development:
-        dependency-type: development
-        applies-to: version-updates
-        update-types:
-          - minor
-          - patch
+        patterns:
+          - "*"
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
     ignore:
       - dependency-name: eslint
         update-types:
@@ -50,5 +55,9 @@ updates:
     groups:
       github-actions-all:
         applies-to: version-updates
+        patterns:
+          - "*"
+      github-actions-security:
+        applies-to: security-updates
         patterns:
           - "*"

--- a/tests/unit/dependabotPolicy.test.js
+++ b/tests/unit/dependabotPolicy.test.js
@@ -2,7 +2,9 @@ const fs = require('node:fs');
 const path = require('node:path');
 const yaml = require('js-yaml');
 
-const DEPENDABOT_CONFIG_PATH = path.resolve(__dirname, '..', '..', '.github', 'dependabot.yml');
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const DEPENDABOT_CONFIG_PATH = path.join(REPO_ROOT, '.github', 'dependabot.yml');
+const WORKFLOWS_DIR = path.join(REPO_ROOT, '.github', 'workflows');
 
 describe('Unit | Dependabot Policy', () => {
   const raw = fs.readFileSync(DEPENDABOT_CONFIG_PATH, 'utf8');
@@ -39,19 +41,49 @@ describe('Unit | Dependabot Policy', () => {
     });
   });
 
-  it('groups version updates to cut PR noise without hiding security updates', () => {
-    expect(Object.keys(npmUpdate.groups)).toEqual(['npm-production', 'npm-development']);
-    Object.values(npmUpdate.groups).forEach((group) => {
-      expect(group['applies-to']).toBe('version-updates');
-      expect(group['update-types']).toEqual(['minor', 'patch']);
-    });
-    expect(actionsUpdate.groups['github-actions-all']).toEqual({
-      'applies-to': 'version-updates',
-      patterns: ['*'],
-    });
+  it('groups every update — all types, prod and dev — into one PR per stream', () => {
+    // "Group all": one catch-all group per applies-to stream. No update-types
+    // filter, so majors are included; no dependency-type filter, so production
+    // and development dependencies land in the same PR.
+    /**
+     * @param {unknown} group
+     * @param {string} appliesTo
+     */
+    const assertCatchAll = (group, appliesTo) => {
+      expect(group).toEqual({ 'applies-to': appliesTo, patterns: ['*'] });
+    };
+
+    expect(Object.keys(npmUpdate.groups)).toEqual(['npm-all', 'npm-security']);
+    assertCatchAll(npmUpdate.groups['npm-all'], 'version-updates');
+    assertCatchAll(npmUpdate.groups['npm-security'], 'security-updates');
+
+    expect(Object.keys(actionsUpdate.groups)).toEqual([
+      'github-actions-all',
+      'github-actions-security',
+    ]);
+    assertCatchAll(actionsUpdate.groups['github-actions-all'], 'version-updates');
+    assertCatchAll(actionsUpdate.groups['github-actions-security'], 'security-updates');
   });
 
-  it('documents the security-update override for suppressed majors', () => {
+  it('does not auto-merge dependabot PRs (manual-review posture)', () => {
+    const dependabotSignal = /dependabot/i;
+    const mergeAction = /(gh pr merge|pull-request-merge|auto-?merge|merge-action)/i;
+
+    /** @type {string[]} */
+    const offenders = fs
+      .readdirSync(WORKFLOWS_DIR)
+      .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+      .filter((name) => {
+        const body = fs.readFileSync(path.join(WORKFLOWS_DIR, name), 'utf8');
+        return dependabotSignal.test(body) && mergeAction.test(body);
+      });
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('documents the group-all, manual-merge posture and the security-update override', () => {
+    expect(raw).toContain('GROUP ALL');
+    expect(raw).toContain('no auto-merge');
     expect(raw).toContain('Security-update override');
     expect(raw).toContain('remove the ignore entry');
   });


### PR DESCRIPTION
## What

Adopt a **group all, merge manually** dependency-update posture.

- Each ecosystem (npm, github-actions) now emits **one grouped version-update PR** and **one grouped security-update PR**.
- A grouped PR spans **all update types** (major/minor/patch) and **both prod and dev** dependencies — replacing the old split of `npm-production` / `npm-development` minor+patch groups plus individual major PRs.
- **No auto-merge.** After the recent wave of supply-chain compromises of popular packages, every dependency change gets human review (diff + changelog + provenance) before it merges. There is deliberately no auto-merge workflow.

## Why

- Fewer, batched PRs → one review of the whole batch instead of N separate reviews.
- Grouping majors keeps peer-coupled bumps together (e.g. `pino` / `pino-http`), which previously had to be merged in lockstep across separate PRs.
- Manual merge is the deliberate safety valve against compromised-release attacks that a version range alone can't stop.

## Guardrails

- `tests/unit/dependabotPolicy.test.js` asserts the group-all shape, both `applies-to` streams, and a **new** regression guard that no workflow auto-merges Dependabot PRs. Runs in the required `test:unit` / `test:ci` lanes.
- ESLint 9 / Jest 29 major-version ignores unchanged; the security-update override for suppressed majors stays documented.

## Note

Existing open Dependabot PRs are not retroactively regrouped — the next weekly run (or a manual trigger) supersedes them with grouped PRs.
