### PR TITLE
fix(providers): repoint Together default model to serverless Qwen3.5-9B

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,7 +114,7 @@ TLS_PORT=8443
 # Optional Together provider settings.
 # TOGETHER_API_KEY=
 # TOGETHER_BASE_URL=https://api.together.xyz/v1
-# TOGETHER_MODEL=Qwen/Qwen3-VL-8B-Instruct
+# TOGETHER_MODEL=Qwen/Qwen3.5-9B
 # TOGETHER_MAX_TOKENS=160
 # TOGETHER_PROMPT=Write concise alt text for this image.
 

--- a/.github/workflows/post-deploy-verification.yml
+++ b/.github/workflows/post-deploy-verification.yml
@@ -82,6 +82,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: gpt-4.1-nano
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
+          TOGETHER_MODEL: Qwen/Qwen3.5-9B
           PROVIDER_VALIDATION_PUBLIC_REF: production
 
       # Only production pushes correspond to a real deployment; manual runs

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -47,6 +47,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: gpt-4.1-nano
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
+          TOGETHER_MODEL: Qwen/Qwen3.5-9B
           PROVIDER_VALIDATION_PUBLIC_REF: ${{ github.sha }}
 
       - name: Upload pre-production provider artifacts

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -526,7 +526,7 @@ At least one provider must be configured at startup: `REPLICATE_API_TOKEN`, Azur
 | `OPENROUTER_TITLE` | No | unset | Optional OpenRouter application title header. |
 | `TOGETHER_API_KEY` | No | none | Together AI API key. Registers `together`. |
 | `TOGETHER_BASE_URL` | No | `https://api.together.xyz/v1` | Together AI base URL. |
-| `TOGETHER_MODEL` | No | `Qwen/Qwen3-VL-8B-Instruct` | Default Together multimodal model. |
+| `TOGETHER_MODEL` | No | `Qwen/Qwen3.5-9B` | Default Together multimodal model. |
 | `TOGETHER_MAX_TOKENS` | No | `160` | Max completion tokens for `together`. |
 | `TOGETHER_PROMPT` | No | shared alt-text prompt | Prompt sent with the image. |
 

--- a/src/providers/definitions/together.js
+++ b/src/providers/definitions/together.js
@@ -8,7 +8,7 @@ module.exports = buildOpenAiCompatibleProvider({
   baseUrlEnvName: 'TOGETHER_BASE_URL',
   defaultBaseUrl: 'https://api.together.xyz/v1',
   modelEnvName: 'TOGETHER_MODEL',
-  defaultModel: 'Qwen/Qwen3-VL-8B-Instruct',
+  defaultModel: 'Qwen/Qwen3.5-9B',
   maxTokensEnvName: 'TOGETHER_MAX_TOKENS',
   promptEnvName: 'TOGETHER_PROMPT',
   providerValidation: {

--- a/tests/unit/config/providerCatalog.test.js
+++ b/tests/unit/config/providerCatalog.test.js
@@ -90,7 +90,7 @@ describe('Unit | Config | Provider Catalog', () => {
       together: {
         apiKey: 'together-key',
         baseUrl: 'https://api.together.xyz/v1',
-        model: 'Qwen/Qwen3-VL-8B-Instruct',
+        model: 'Qwen/Qwen3.5-9B',
         maxTokens: 160,
         prompt: expect.any(String),
         headers: {},
@@ -163,7 +163,7 @@ describe('Unit | Config | Provider Catalog', () => {
       OPENROUTER_TITLE: 'Alt Text 4 All',
     })[0]).toMatch(/OPENROUTER_API_KEY/);
     expect(validateProviderEnv({
-      TOGETHER_MODEL: 'Qwen/Qwen3-VL-8B-Instruct',
+      TOGETHER_MODEL: 'Qwen/Qwen3.5-9B',
     })[0]).toMatch(/TOGETHER_API_KEY/);
     expect(getProviderCatalog().map((provider) => provider.key)).toEqual([
       'replicate',


### PR DESCRIPTION
## Problem

The `together` provider's default model `Qwen/Qwen3-VL-8B-Instruct` was made **non-serverless** upstream. Every call now returns `HTTP 400 model_not_available`, which:

1. **Blocks promotion to production.** `promote-to-production.yml` → `pre-production-provider-validation` exercises the real Together API and asserts `200`; the dead model makes it `500`, so the gate fails and the `promote` job is skipped. Production has therefore been unable to advance (currently ~136 commits behind `main`, still on March code with `npm install`/pre-Node-24).
2. **Would 500 live traffic** routed to `together`: the production service sets no `TOGETHER_MODEL`, so it resolves this same default.

## Fix

- **`src/providers/definitions/together.js`** — `defaultModel` → `Qwen/Qwen3.5-9B` (Together's current recommended serverless vision model). This alone fixes live runtime and the two validation workflows that rely on the code default.
- **`promote-to-production.yml` + `post-deploy-verification.yml`** — pin `TOGETHER_MODEL` explicitly alongside the existing `HF_MODEL` / `OPENAI_MODEL` pins, so the validated model is intentional, visible, and rotatable without a code release.
- **`.env.example`, `DEVELOPMENT.md`, `providerCatalog` unit test** — updated to match.

## Why this model is safe to merge even though it can't be verified offline

The provider-validation gate calls the **real** Together API. If `Qwen/Qwen3.5-9B` is not serverless for this account, the gate fails fast and blocks promotion — it cannot ship a broken default. So the gate is the authoritative validator; this change makes it testable again.

## Verification

- `providerCatalog` unit test: **5/5 pass** with the new default.
- Both workflow files parse as valid YAML.
- No remaining references to the old model string anywhere in the repo.

## After merge

Re-dispatch **Promote to Production**. If the gate goes green, `production` fast-forwards to `main` and Render auto-deploys the full Node 24 / `npm ci` / dependency-hardening chain. If it still 400s, the model string is the only knob to turn (single constant + two workflow lines).
