### PR TITLE
fix(providers): log raw response when vision caption extraction is empty

### DIFF
--- a/src/services/OpenAiCompatibleVisionDescriberService.js
+++ b/src/services/OpenAiCompatibleVisionDescriberService.js
@@ -331,6 +331,7 @@ class OpenAiCompatibleVisionDescriberService {
       const description = extractCaptionText(response?.data);
 
       if (!description) {
+        this.logEmptyCaptionDiagnostics(response?.data);
         throw new Error(`${this.providerName} provider returned no caption text`);
       }
 
@@ -354,6 +355,40 @@ class OpenAiCompatibleVisionDescriberService {
 
       return this.requestCaption(imageInput, imageUrl, attemptNumber + 1);
     }
+  }
+
+  /**
+   * Logs the raw provider response shape when caption extraction yields nothing.
+   * Diagnoses empty-content cases such as hybrid-thinking models that emit only
+   * `reasoning_content`, or that truncate the answer once `max_tokens` is spent.
+   * @param {any} data - the provider response body
+   * @returns {void}
+   */
+  logEmptyCaptionDiagnostics(data) {
+    const choice = Array.isArray(data?.choices) ? data.choices[0] : undefined;
+    const message = choice?.message;
+    const content = message?.content;
+    const reasoning = message?.reasoning_content;
+    let rawSample = null;
+    try {
+      rawSample = JSON.stringify(data)?.slice(0, 1500) ?? null;
+    } catch {
+      rawSample = null;
+    }
+    this.logger.warn?.({
+      provider: this.providerKey,
+      model: this.model,
+      finishReason: choice?.finish_reason,
+      messageKeys: message && typeof message === 'object' ? Object.keys(message) : null,
+      contentType: Array.isArray(content) ? 'array' : typeof content,
+      contentLength: typeof content === 'string'
+        ? content.length
+        : (Array.isArray(content) ? content.length : null),
+      reasoningType: typeof reasoning,
+      reasoningLength: typeof reasoning === 'string' ? reasoning.length : null,
+      usage: data?.usage,
+      rawSample,
+    }, `${this.providerName} returned no caption text (diagnostics)`);
   }
 
   /**


### PR DESCRIPTION
## Why

The pre-production provider gate fails on Together: `Qwen/Qwen3.5-9B` is served (no 4xx) but returns empty caption text, so `extractCaptionText` finds nothing and we throw a generic `no caption text` error. That error path logged nothing about the upstream response, making the root cause invisible.

## What

Add `logEmptyCaptionDiagnostics` on the empty-extraction path. It records `finish_reason`, `content` type/length, presence/length of `reasoning_content`, `usage`, and a truncated raw body — enough to distinguish:

- a hybrid-thinking model that spends the `max_tokens` budget on reasoning and returns empty final content, vs.
- output arriving in an unexpected field, vs.
- a genuine model incompatibility.

Additive, error-path only. No behavior change on success. Enables a targeted compatibility fix (or a justified model fallback) once the gate surfaces the real response shape.