### PR TITLE
fix(providers): disable Qwen thinking mode for Together vision calls

### DIFF
--- a/src/providers/definitions/together.js
+++ b/src/providers/definitions/together.js
@@ -11,6 +11,15 @@ module.exports = buildOpenAiCompatibleProvider({
   defaultModel: 'Qwen/Qwen3.5-9B',
   maxTokensEnvName: 'TOGETHER_MAX_TOKENS',
   promptEnvName: 'TOGETHER_PROMPT',
+  // Qwen3.x models default to "thinking" mode. With a small max_tokens the model
+  // spends the entire completion budget on reasoning and is cut off before it
+  // emits any caption (finish_reason=length, content=""). Disable thinking so the
+  // caption is produced directly in `content` and no reasoning tokens are billed.
+  buildAdditionalConfig: () => ({
+    requestParams: {
+      chat_template_kwargs: { enable_thinking: false },
+    },
+  }),
   providerValidation: {
     scopeKey: 'together',
     autoPriority: 60,

--- a/src/services/OpenAiCompatibleVisionDescriberService.js
+++ b/src/services/OpenAiCompatibleVisionDescriberService.js
@@ -41,6 +41,9 @@ const RETRY_JITTER_MS = 250;
  * @property {string} [prompt]
  * @property {Record<string, string>} [headers]
  * @property {number} [requestAttempts]
+ * @property {Record<string, unknown>} [requestParams] - extra top-level request-body
+ *   params merged into every chat request (e.g. provider-specific flags). Cannot
+ *   override the core `model`/`messages`/`max_tokens`/`stream` fields.
  */
 
 /**
@@ -264,6 +267,7 @@ class OpenAiCompatibleVisionDescriberService {
     this.maxTokens = providerConfig.maxTokens;
     this.prompt = providerConfig.prompt;
     this.headers = providerConfig.headers ?? {};
+    this.requestParams = providerConfig.requestParams ?? {};
     this.requestOptions = requestOptions;
     this.requestAttempts = providerConfig.requestAttempts ?? DEFAULT_REQUEST_ATTEMPTS;
     this.sleep = wait;
@@ -284,6 +288,7 @@ class OpenAiCompatibleVisionDescriberService {
    */
   buildRequestBody(imageInput) {
     return {
+      ...this.requestParams,
       model: this.model,
       messages: [
         {

--- a/tests/unit/config/providerCatalog.test.js
+++ b/tests/unit/config/providerCatalog.test.js
@@ -94,6 +94,9 @@ describe('Unit | Config | Provider Catalog', () => {
         maxTokens: 160,
         prompt: expect.any(String),
         headers: {},
+        requestParams: {
+          chat_template_kwargs: { enable_thinking: false },
+        },
       },
     });
     expect(buildProviderConfigSections({


### PR DESCRIPTION
## RCA (from the #244 gate diagnostics)

The pre-production provider gate fails on Together. The captured diagnostics show, across all attempts:

```
finishReason: "length"   contentLength: 0
messageKeys: [role, content, tool_calls, reasoning]
usage: { prompt_tokens: 115, completion_tokens: 160, total_tokens: 275 }
```

`Qwen/Qwen3.5-9B` defaults to **thinking mode**. With `max_tokens=160`, the model spends the entire completion budget reasoning and is cut off (`finish_reason=length`) **before** emitting any caption, so `content` is empty and extraction returns nothing. Not a model incompatibility — a thinking-mode/budget interaction.

## Fix

Send `chat_template_kwargs: { enable_thinking: false }` for Together so the caption is produced directly in `content`. Keeps `max_tokens=160` and bills **no reasoning tokens** (cost-neutral).

Mechanism: threads an optional `providerConfig.requestParams` through the shared vision-describer service — merged into the chat request body, **cannot override** the core `model`/`messages`/`max_tokens`/`stream` fields — and is set only for Together via its `buildAdditionalConfig`.