### PR TITLE
fix(promote): raise gh execFileSync maxBuffer to avoid ENOBUFS on large compares

### DIFF
--- a/scripts/github/promote-to-production.js
+++ b/scripts/github/promote-to-production.js
@@ -6,6 +6,12 @@
 const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 
+// gh responses such as `compare/<base>...<head>` include the full diff of every
+// commit between the branches. When the target branch is many commits behind, that
+// payload easily exceeds execFileSync's 1MB default maxBuffer and throws ENOBUFS,
+// so allow generous headroom for any single gh invocation.
+const GH_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+
 /**
  * @typedef {object} PromoteArgs
  * @property {string} repo
@@ -94,6 +100,7 @@ function runGh(args) {
     encoding: 'utf8',
     env: process.env,
     stdio: ['ignore', 'pipe', 'pipe'],
+    maxBuffer: GH_MAX_BUFFER_BYTES,
   }).trim();
 }
 
@@ -120,6 +127,7 @@ function runGhJsonWithBody(args, body) {
     env: process.env,
     input: JSON.stringify(body),
     stdio: ['pipe', 'pipe', 'pipe'],
+    maxBuffer: GH_MAX_BUFFER_BYTES,
   }).trim());
 }
 

--- a/scripts/github/rollback-production.js
+++ b/scripts/github/rollback-production.js
@@ -11,6 +11,12 @@
 const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 
+// gh responses such as `compare/<base>...<head>` include the full diff of every
+// commit between the branches and can exceed execFileSync's 1MB default maxBuffer
+// (ENOBUFS) when history has diverged widely. Allow generous headroom so a
+// rollback never fails on buffer size while an incident is in progress.
+const GH_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+
 /**
  * @typedef {object} RollbackArgs
  * @property {string} repo
@@ -99,6 +105,7 @@ function runGh(args) {
     encoding: 'utf8',
     env: process.env,
     stdio: ['ignore', 'pipe', 'pipe'],
+    maxBuffer: GH_MAX_BUFFER_BYTES,
   }).trim();
 }
 
@@ -121,6 +128,7 @@ function runGhJsonWithBody(args, body) {
     env: process.env,
     input: JSON.stringify(body),
     stdio: ['pipe', 'pipe', 'pipe'],
+    maxBuffer: GH_MAX_BUFFER_BYTES,
   }).trim());
 }
 


### PR DESCRIPTION
## RCA

The promote gate passed end-to-end (all providers green, required checks verified), but the `promote` job then died with:

```
Verified main@373f0814d required checks.
spawnSync gh ENOBUFS
```

`getAheadBy()` calls `gh api repos/<repo>/compare/<target>...<source>` purely to read `ahead_by`, but that response includes the **full diff of every commit** between the branches. With production **137 commits** behind main, the payload far exceeds `execFileSync`'s **1 MB** default `maxBuffer` → `ENOBUFS`. This is **deterministic** while the branches are widely diverged — re-running cannot fix it.

## Fix

Set a 64 MB `maxBuffer` on both `gh` exec helpers in the promotion script. Apply the identical fix to `rollback-production.js` (same unbounded pattern) so a rollback can never fail on buffer size mid-incident.