### PR TITLE
fix(promote): retry branch verification to tolerate read-after-write staleness

### DIFF
--- a/scripts/github/promote-to-production.js
+++ b/scripts/github/promote-to-production.js
@@ -132,6 +132,38 @@ function runGhJsonWithBody(args, body) {
 }
 
 /**
+ * Blocks synchronously for the given duration, so this sync CLI script can back
+ * off between retries without being rewritten as async.
+ *
+ * @param {number} ms
+ * @returns {void}
+ */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Math.max(0, ms));
+}
+
+/**
+ * Re-reads a branch head SHA until it matches the expected value or attempts run
+ * out. GitHub's REST API can briefly return a stale ref immediately after an
+ * update (read-after-write), so a short bounded retry prevents a false
+ * "verification failed" after a ref update that actually succeeded.
+ *
+ * @param {string} repo
+ * @param {string} branch
+ * @param {string} expectedSha
+ * @returns {string} the last observed head SHA
+ */
+function verifyBranchHeadSha(repo, branch, expectedSha) {
+  const maxAttempts = 5;
+  let latestSha = getBranchHeadSha(repo, branch);
+  for (let attempt = 1; latestSha !== expectedSha && attempt < maxAttempts; attempt += 1) {
+    sleepSync(1000 * attempt);
+    latestSha = getBranchHeadSha(repo, branch);
+  }
+  return latestSha;
+}
+
+/**
  * @param {unknown} error
  * @returns {boolean}
  */
@@ -569,7 +601,7 @@ async function main() {
   }
 
   updateBranchRef(options.repo, options.targetBranch, sourceSha, { force: plan.force });
-  const targetShaAfter = getBranchHeadSha(options.repo, options.targetBranch);
+  const targetShaAfter = verifyBranchHeadSha(options.repo, options.targetBranch, sourceSha);
   if (targetShaAfter !== sourceSha) {
     throw new Error(
       `Promotion verification failed: expected ${options.targetBranch} to point to ${sourceSha}, `


### PR DESCRIPTION
## Problem

Promoting to 98ba8958a succeeded (the ref update worked), but the job reported failure:

```
Promotion verification failed: expected production to point to 98ba8958a, but found 9a730db1.
```

The script re-read the branch ref **immediately** after updating it, and GitHub's REST API returned a **stale** SHA (read-after-write). Every promotion would report a false failure this way.

## Fix

`verifyBranchHeadSha` re-reads the head SHA up to 5 times with linear backoff (1s, 2s, 3s, 4s), returning as soon as it matches the expected SHA. A genuine mismatch still throws after the retries. Uses a synchronous `Atomics.wait` sleep to keep the CLI script sync.