### PR TITLE
fix(deploy): raise rollout stabilization timeout and add capped backoff

### DIFF
--- a/scripts/run-postman-deploy.js
+++ b/scripts/run-postman-deploy.js
@@ -419,7 +419,9 @@ function collectDeployStabilizationIssues({
  * }} authConfig
  * @param {{
  *   fetchFn?: typeof fetch,
+ *   maxPollIntervalMs?: number,
  *   nowFn?: () => number,
+ *   pollBackoffFactor?: number,
  *   pollIntervalMs?: number,
  *   requiredConsecutiveSuccesses?: number,
  *   sleepFn?: (durationMs: number) => Promise<void>,
@@ -446,7 +448,7 @@ async function waitForStableDeploy(
   const deadline = nowFn() + timeoutMs;
   const probeUrls = buildDeployProbeUrls(baseUrl, authConfig);
   /**
-   * @param {{ attemptCount: number, consecutiveSuccesses: number, lastIssues: string[] }} input
+   * @param {{ attemptCount: number, consecutiveSuccesses: number, currentPollIntervalMs: number, lastIssues: string[] }} input
    * @returns {Promise<void>}
    */
   const attempt = async ({

--- a/scripts/run-postman-deploy.js
+++ b/scripts/run-postman-deploy.js
@@ -52,8 +52,17 @@ const REPORTS_DIR = path.join(ROOT, 'reports', 'newman');
 const PUBLIC_DEPLOY_FOLDER = '95 Post Deploy Verification';
 const PROTECTED_DEPLOY_FOLDER = '96 Post Deploy Protected Verification';
 const DEPLOY_STABILIZATION_POLL_INTERVAL_MS = 3_000;
+// While the rollout is not yet healthy, grow the poll interval (capped) so a slow
+// deploy is tolerated without hammering the endpoint; the interval resets to the
+// base once probes start succeeding so the required streak is confirmed quickly.
+const DEPLOY_STABILIZATION_MAX_POLL_INTERVAL_MS = 20_000;
+const DEPLOY_STABILIZATION_POLL_BACKOFF_FACTOR = 1.5;
 const DEPLOY_STABILIZATION_REQUIRED_SUCCESSES = 3;
-const DEPLOY_STABILIZATION_TIMEOUT_MS = 90_000;
+// Total budget to wait for the deployed rollout to become healthy. Overridable
+// via env so a slow (e.g. cold-provisioned free-tier) deploy can be given more
+// room without a code change. Raised from 90s to 5min.
+const DEPLOY_STABILIZATION_TIMEOUT_MS = Number(process.env.DEPLOY_STABILIZATION_TIMEOUT_MS)
+  || 300_000;
 const DEPLOY_STABILIZATION_REQUEST_TIMEOUT_MS = 15_000;
 const NPX = process.platform === 'win32' ? 'npx.cmd' : 'npx';
 
@@ -424,7 +433,9 @@ async function waitForStableDeploy(
   authConfig,
   {
     fetchFn = fetch,
+    maxPollIntervalMs = DEPLOY_STABILIZATION_MAX_POLL_INTERVAL_MS,
     nowFn = Date.now,
+    pollBackoffFactor = DEPLOY_STABILIZATION_POLL_BACKOFF_FACTOR,
     pollIntervalMs = DEPLOY_STABILIZATION_POLL_INTERVAL_MS,
     requiredConsecutiveSuccesses = DEPLOY_STABILIZATION_REQUIRED_SUCCESSES,
     sleepFn = sleep,
@@ -441,6 +452,7 @@ async function waitForStableDeploy(
   const attempt = async ({
     attemptCount,
     consecutiveSuccesses,
+    currentPollIntervalMs,
     lastIssues,
   }) => {
     if (nowFn() >= deadline) {
@@ -492,16 +504,21 @@ async function waitForStableDeploy(
       await attempt({
         attemptCount: nextAttemptCount,
         consecutiveSuccesses: nextConsecutiveSuccesses,
+        currentPollIntervalMs: pollIntervalMs,
         lastIssues,
       });
       return;
     }
 
     writeLog(`[deploy] waiting for stable deploy rollout: ${issues.join('; ')}`);
-    await sleepFn(pollIntervalMs);
+    await sleepFn(currentPollIntervalMs);
     await attempt({
       attemptCount: nextAttemptCount,
       consecutiveSuccesses: 0,
+      currentPollIntervalMs: Math.min(
+        Math.round(currentPollIntervalMs * pollBackoffFactor),
+        maxPollIntervalMs,
+      ),
       lastIssues: issues,
     });
   };
@@ -509,6 +526,7 @@ async function waitForStableDeploy(
   await attempt({
     attemptCount: 0,
     consecutiveSuccesses: 0,
+    currentPollIntervalMs: pollIntervalMs,
     lastIssues: ['no rollout probes executed'],
   });
 }


### PR DESCRIPTION
Post-deploy verification false-failed on a slow rollout: the stabilization wait timed out after 90s (fixed 3s poll). Raise the default budget to 5min (env-overridable via `DEPLOY_STABILIZATION_TIMEOUT_MS`) and add capped exponential backoff (x1.5, max 20s) while not-yet-healthy, resetting to base once probes succeed. typecheck/eslint/24 deploy tests pass.