### PR TITLE
fix(config): require TLS credentials only when TLS_ENABLED is not false

### DIFF
--- a/src/utils/validateEnvVars.js
+++ b/src/utils/validateEnvVars.js
@@ -50,15 +50,27 @@ const envVarsSchema = Joi.object({
   CLUSTER_SHUTDOWN_TIMEOUT_MS: Joi.number().integer().min(1).optional(),
   REDIS_URL: Joi.string().pattern(/^rediss?:\/\//).optional(),
 
-  // TLS certs are required in production
+  // Mirrors config/index.js: any value other than 'false' enables TLS.
+  TLS_ENABLED: Joi.string().valid('true', 'false').optional(),
+
+  // TLS certs are required in production unless TLS terminates at the platform
+  // edge (TLS_ENABLED=false), where startApplicationRuntime never loads them.
   TLS_KEY: Joi.string().when('NODE_ENV', {
     is: 'production',
-    then: Joi.required(),
+    then: Joi.when('TLS_ENABLED', {
+      is: 'false',
+      then: Joi.optional(),
+      otherwise: Joi.required(),
+    }),
     otherwise: Joi.optional(),
   }),
   TLS_CERT: Joi.string().when('NODE_ENV', {
     is: 'production',
-    then: Joi.required(),
+    then: Joi.when('TLS_ENABLED', {
+      is: 'false',
+      then: Joi.optional(),
+      otherwise: Joi.required(),
+    }),
     otherwise: Joi.optional(),
   }),
   OUTBOUND_CA_BUNDLE_FILE: Joi.string().optional(),

--- a/tests/unit/utils/validateEnvVars.test.js
+++ b/tests/unit/utils/validateEnvVars.test.js
@@ -174,10 +174,90 @@ describe('Unit | Utils | Validate Env Vars', () => {
         NODE_ENV: 'production',
         REPLICATE_API_TOKEN: 'test-token',
       },
+      remove: ['TLS_KEY', 'TLS_CERT', 'TLS_ENABLED'],
+    });
+
+    expect(() => validateEnvVars()).toThrow(/TLS_KEY/);
+  });
+
+  it('does not require production TLS credentials when TLS_ENABLED=false', () => {
+    const validateEnvVars = loadValidator({
+      overrides: {
+        NODE_ENV: 'production',
+        TLS_ENABLED: 'false',
+        REPLICATE_API_TOKEN: 'test-token',
+      },
+      remove: ['TLS_KEY', 'TLS_CERT'],
+    });
+
+    expect(() => validateEnvVars()).not.toThrow();
+  });
+
+  it('requires production TLS credentials when TLS_ENABLED=true', () => {
+    const validateEnvVars = loadValidator({
+      overrides: {
+        NODE_ENV: 'production',
+        TLS_ENABLED: 'true',
+        REPLICATE_API_TOKEN: 'test-token',
+      },
       remove: ['TLS_KEY', 'TLS_CERT'],
     });
 
     expect(() => validateEnvVars()).toThrow(/TLS_KEY/);
+  });
+
+  it('requires TLS_CERT in production when only TLS_KEY is supplied', () => {
+    const validateEnvVars = loadValidator({
+      overrides: {
+        NODE_ENV: 'production',
+        REPLICATE_API_TOKEN: 'test-token',
+        TLS_KEY: 'tls-key',
+      },
+      remove: ['TLS_CERT', 'TLS_ENABLED'],
+    });
+
+    expect(() => validateEnvVars()).toThrow(/TLS_CERT/);
+  });
+
+  it('accepts TLS_ENABLED=false in production alongside unused TLS credentials', () => {
+    const validateEnvVars = loadValidator({
+      overrides: {
+        NODE_ENV: 'production',
+        TLS_ENABLED: 'false',
+        REPLICATE_API_TOKEN: 'test-token',
+        TLS_KEY: 'tls-key',
+        TLS_CERT: 'tls-cert',
+      },
+    });
+
+    expect(() => validateEnvVars()).not.toThrow();
+  });
+
+  it('rejects a TLS_ENABLED value other than true or false', () => {
+    const validateEnvVars = loadValidator({
+      overrides: {
+        NODE_ENV: 'production',
+        TLS_ENABLED: 'disabled',
+        REPLICATE_API_TOKEN: 'test-token',
+        TLS_KEY: 'tls-key',
+        TLS_CERT: 'tls-cert',
+      },
+    });
+
+    expect(() => validateEnvVars()).toThrow(/TLS_ENABLED/);
+  });
+
+  it('leaves TLS credentials optional outside production when TLS_ENABLED=true', () => {
+    const validateEnvVars = loadValidator({
+      overrides: {
+        NODE_ENV: 'development',
+        TLS_ENABLED: 'true',
+        REPLICATE_API_TOKEN: 'test-token',
+      },
+      remove: ['TLS_KEY', 'TLS_CERT'],
+    });
+
+    expect(() => validateEnvVars()).not.toThrow();
   });
 
   it('accepts a non-negative TRUST_PROXY_HOPS override', () => {


### PR DESCRIPTION
## Problem

`src/utils/validateEnvVars.js` required `TLS_KEY` and `TLS_CERT` whenever
`NODE_ENV=production`, with no `TLS_ENABLED` condition. `src/app.js:14` runs the
validator before `startApplication`, so it could not be bypassed.

Meanwhile `src/server/startApplicationRuntime.js:87-101` already skips
certificate loading and the HTTPS listener entirely when TLS terminates at the
platform edge. The result: production carries two real certificates that are
**never read**, solely to satisfy a validator that should not be asking.

Reproduced on `main` before this change:

```
REJECTED: Config validation error: "TLS_KEY" is required   <- production, TLS_ENABLED=false, no certs
BOOTS                                                      <- production, TLS_ENABLED=false, GARBAGE certs
```

The second line is the tell: the validator only checks that the strings exist,
never that they are usable. It was buying no safety.

## Change

Add `TLS_ENABLED` to the schema and gate the certificate requirement on it,
mirroring `config/index.js:84` (`process.env.TLS_ENABLED !== 'false'`), so the
validator and the runtime finally agree. The runtime is unchanged — it was
already correct.

`TLS_ENABLED` is constrained to `true`/`false`, matching the existing
`API_AUTH_ENABLED` convention in the same schema, so a typo like
`TLS_ENABLED=disabled` fails fast at boot instead of silently enabling TLS.

## Verification

```
NODE_ENV=production TLS_ENABLED=false REPLICATE_API_TOKEN=t ... -> OK
NODE_ENV=production REPLICATE_API_TOKEN=t ...                   -> OK rejected
```

Both contracts are pinned by unit tests. Six cases added: certs not required
when disabled; required when enabled; required when unset; `TLS_CERT` required
independently of `TLS_KEY`; invalid `TLS_ENABLED` rejected; non-production
unaffected.

Full unit lane 808/808, lint and typecheck clean.

## Safety

Additive only. No environment variable is added, removed or changed on the
service by this PR — the live certificates stay exactly where they are and the
service keeps booting whether or not they are present. Retiring them is a
separate, later step that depends on this being live and healthy first.