### PR TITLE
docs(deploy): demote render.yaml to a reference manifest and fix TLS prose

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -446,7 +446,7 @@ Development TLS behavior (applies when `TLS_ENABLED` is not `false`):
 - If `TLS_KEY` and `TLS_CERT` are set, they are used.
 - If unset and `NODE_ENV` is not `production`, the app tries `certs/localhost-key.pem` and `certs/localhost.pem`.
 - If those files are absent, the app generates a short-lived self-signed localhost certificate in-process.
-- In production, explicit TLS credentials are required — unless `TLS_ENABLED=false`, in which case no certificates are loaded at all.
+- In production, explicit TLS credentials are required — unless `TLS_ENABLED=false`, in which case they are neither required nor loaded.
 
 The in-process HTTPS listener is covered end-to-end by `tests/integration/httpsListener.test.js`, which stands up `createHttpsServer` with the loaded credentials and asserts a real TLS handshake (`socket.encrypted === true`).
 
@@ -588,11 +588,12 @@ At least one provider must be configured at startup: `REPLICATE_API_TOKEN`, Azur
 
 ## Render Deployment Contract
 
-- The Render web service shape is versioned in [`render.yaml`](./render.yaml).
+- [`render.yaml`](./render.yaml) is a **reference manifest, not applied configuration.** No Blueprint is registered for this account and the service predates the file, so nothing syncs it: editing `render.yaml` changes nothing on the running service. It exists to document the intended shape and to rebuild the service if it ever has to be recreated. The **Render dashboard is the source of truth for environment variables** — read it there, not here.
+- The service *shape* does match the manifest: plan `free`, region `oregon`, `numInstances: 1`, health check `/api/health`, build `npm ci`, start `npm run prod`, runtime `node`, branch `production`, auto-deploy on commit. The environment differs by design — the dashboard also carries the provider credentials, which the manifest does not represent.
 - Render reads the Node runtime version from [`package.json`](./package.json) `engines.node`.
 - Render builds with `npm ci` so production installs are lockfile-exact and reproducible; never revert to `npm install` except as a temporary escape hatch while repairing a broken lockfile.
-- Secrets such as `REPLICATE_API_TOKEN`, `TLS_KEY`, and `TLS_CERT` stay dashboard-managed and are represented in the Blueprint with `sync: false`.
-- Inbound TLS terminates at Render's edge, so the service runs with `TLS_ENABLED=false` and serves HTTP-only on the injected `$PORT`; `TLS_KEY`/`TLS_CERT` are therefore not required on the service. This is a deliberate edge-termination choice, not a downgrade of the project's HTTPS-first default — see [Inbound TLS posture](#inbound-tls-posture-https-first-vs-edge-termination). Public traffic stays HTTPS via the edge certificate.
+- Secrets such as `REPLICATE_API_TOKEN` stay dashboard-managed; the manifest lists them with `sync: false` so it never carries a value.
+- Inbound TLS terminates at Render's edge, so the service runs with `TLS_ENABLED=false` and serves HTTP-only on `PORT`, which is pinned explicitly to `8080` on the dashboard rather than left to Render's injected default. `TLS_KEY`/`TLS_CERT` are therefore not required on the service — `validateEnvVars` asks for them only when TLS is actually enabled. This is a deliberate edge-termination choice, not a downgrade of the project's HTTPS-first default — see [Inbound TLS posture](#inbound-tls-posture-https-first-vs-edge-termination). Public traffic stays HTTPS via the edge certificate.
 - Set `TRUST_PROXY_HOPS=1` explicitly on the service (Render is a single ingress hop) so `req.secure`, the HTTP→HTTPS redirect, secure cookies, and HSTS remain correct behind the edge. Raise it if a further proxy/CDN is added in front.
 
 ### Deployment evidence and rollback

--- a/render.yaml
+++ b/render.yaml
@@ -25,11 +25,11 @@ services:
         value: external
       - key: TRUST_PROXY_HOPS
         value: 1
-      - key: TLS_PORT
-        value: 8443
+      # Inbound TLS terminates at Render's edge, so the app serves HTTP-only on
+      # PORT and never loads certificates. TLS_KEY/TLS_CERT are deliberately
+      # absent: since the conditional-validation fix they are not required to
+      # boot, and they were never read.
+      - key: TLS_ENABLED
+        value: false
       - key: REPLICATE_API_TOKEN
-        sync: false
-      - key: TLS_KEY
-        sync: false
-      - key: TLS_CERT
         sync: false

--- a/render.yaml
+++ b/render.yaml
@@ -30,6 +30,6 @@ services:
       # absent: since the conditional-validation fix they are not required to
       # boot, and they were never read.
       - key: TLS_ENABLED
-        value: false
+        value: "false"
       - key: REPLICATE_API_TOKEN
         sync: false

--- a/tests/unit/renderConfig.test.js
+++ b/tests/unit/renderConfig.test.js
@@ -24,9 +24,32 @@ describe('Unit | Render Deploy Config', () => {
   it('keeps secret-bearing environment variables unsynced from the repo', () => {
     const envVars = new Map(service.envVars.map((entry) => [entry.key, entry]));
 
-    ['REPLICATE_API_TOKEN', 'TLS_KEY', 'TLS_CERT'].forEach((key) => {
-      expect(envVars.get(key)).toEqual({ key, sync: false });
+    expect(envVars.get('REPLICATE_API_TOKEN')).toEqual({
+      key: 'REPLICATE_API_TOKEN',
+      sync: false,
     });
     expect(envVars.get('NODE_ENV')).toEqual({ key: 'NODE_ENV', value: 'production' });
+  });
+
+  it('declares the edge-termination TLS posture as a string', () => {
+    const envVars = new Map(service.envVars.map((entry) => [entry.key, entry]));
+
+    // config/index.js keys off `TLS_ENABLED !== 'false'`, so the value has to be
+    // the string "false" — bare `false` is a YAML boolean and would not match.
+    expect(envVars.get('TLS_ENABLED')).toEqual({ key: 'TLS_ENABLED', value: 'false' });
+  });
+
+  it('does not declare TLS credentials the service never reads', () => {
+    const declaredKeys = service.envVars.map((entry) => entry.key);
+
+    // TLS terminates at the edge, so the app skips certificate loading entirely
+    // and the validator no longer requires the credentials to boot. Re-declaring
+    // them here would reintroduce the belief that production depends on them.
+    expect(declaredKeys).not.toContain('TLS_KEY');
+    expect(declaredKeys).not.toContain('TLS_CERT');
+
+    // TLS_PORT is inert while TLS is off, and the file and the live service
+    // disagreed on its value for as long as it was declared.
+    expect(declaredKeys).not.toContain('TLS_PORT');
   });
 });


### PR DESCRIPTION
Follows #257, which had to be live before the manifest could drop the
certificate entries. It is: deploy `dep-d9bjcdcvikkc73e42vjg` is live on
`b5fca356c` and `/api/health` returns `200 {"ready":true}`.

## `render.yaml` is applied to nothing

`DEVELOPMENT.md` said the service shape was *"versioned in `render.yaml`"*.
It is not:

```
GET /v1/blueprints  ->  []          # no Blueprint exists on the account
service createdAt   ->  2023-03-26  # predates the file
TLS_PORT            ->  8443 in the file | 4443 live
```

The empty Blueprint list and the `TLS_PORT` mismatch are jointly conclusive —
if anything were syncing, `TLS_PORT` could not differ. The service is
dashboard-managed. The file now says so, and names the dashboard as the source
of truth for environment variables.

The service *shape* does match the file exactly (plan, region, instances,
health check, build, start, runtime, branch, auto-deploy), so that is now
stated rather than left ambiguous. No Blueprint is registered by this PR, and
none should be: a sync would reset `TLS_PORT` to 8443 and could strip the
provider credentials the service actually runs on.

## Manifest vs. live

Added `TLS_ENABLED=false` — it drives the entire TLS posture and was
undeclared. Removed `TLS_PORT` — dead (TLS is off) *and* contradicted.
Removed `TLS_KEY`/`TLS_CERT`, which is safe only now that #257 is live: the
service no longer needs them to boot. They are still set on the dashboard;
retiring them there is a separate step.

## TLS prose

`PORT` is pinned to `8080` on the dashboard, not injected by Render. The doc
claimed injected. Anyone standing up a second service from this document would
have inherited a wrong assumption, so the doc now matches the dashboard.

The certificate statements were false when the audit was written and are true
now that #257 is live — they are kept and sharpened rather than rewritten:
when TLS is disabled the credentials are *neither required nor loaded*, where
the doc previously said only "not loaded", which was the exact ambiguity that
made removing them look safe when it was not.

## Verification

`render.yaml` parses and resolves to `TLS_ENABLED=false` with no `TLS_PORT`,
`TLS_KEY` or `TLS_CERT`. `docs:validate` passes. The
`#inbound-tls-posture-...` anchor still resolves. No live configuration is
touched by this PR.