### PR TITLE
ci: stop treating everything under docs/ as documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,29 +48,7 @@ jobs:
             git ls-tree -r --name-only "${HEAD_SHA}" > changed-files.txt
           fi
 
-          node <<'NODE'
-          const fs = require('node:fs');
-
-          const changedFiles = fs.readFileSync('changed-files.txt', 'utf8')
-            .split('\n')
-            .map((line) => line.trim())
-            .filter(Boolean);
-
-          const isDocsPath = (filePath) => (
-            filePath === 'LICENSE'
-            || filePath.endsWith('.md')
-            || filePath.startsWith('docs/')
-            || filePath.startsWith('.github/assets/')
-          );
-          const docsChanged = changedFiles.some(isDocsPath);
-          const docsOnly = changedFiles.length > 0 && changedFiles.every(isDocsPath);
-          const outputs = [
-            ['docs_changed', String(docsChanged)],
-            ['docs_only', String(docsOnly)],
-          ];
-
-          fs.appendFileSync(process.env.GITHUB_OUTPUT, `${outputs.map(([key, value]) => `${key}=${value}`).join('\n')}\n`);
-          NODE
+          node scripts/ci/classify-changed-paths.js --input changed-files.txt
 
   docs:
     name: docs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,23 +56,7 @@ jobs:
             git ls-tree -r --name-only "${HEAD_SHA}" > changed-files.txt
           fi
 
-          node <<'NODE'
-          const fs = require('node:fs');
-
-          const changedFiles = fs.readFileSync('changed-files.txt', 'utf8')
-            .split('\n')
-            .map((line) => line.trim())
-            .filter(Boolean);
-          const isDocsPath = (filePath) => (
-            filePath === 'LICENSE'
-            || filePath.endsWith('.md')
-            || filePath.startsWith('docs/')
-            || filePath.startsWith('.github/assets/')
-          );
-          const docsOnly = changedFiles.length > 0 && changedFiles.every(isDocsPath);
-
-          fs.appendFileSync(process.env.GITHUB_OUTPUT, `docs_only=${docsOnly}\n`);
-          NODE
+          node scripts/ci/classify-changed-paths.js --input changed-files.txt
 
   analyze:
     name: codeql

--- a/scripts/ci/classify-changed-paths.js
+++ b/scripts/ci/classify-changed-paths.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+
+// Single source of truth for the docs-only CI classification.
+//
+// `docs_only` lets a pull request skip lint, OpenAPI, typecheck, the unit
+// matrix, the full Jest lane, and Newman — six required checks that then report
+// themselves satisfied by `docs:validate`. That is only honest for files
+// `docs:validate` can actually inspect, so the predicate must stay narrow:
+// anything executable, generated, or contract-bearing has to run the real gates.
+//
+// `docs/openapi.base.json` is the case that motivated extracting this. It lived
+// under `docs/`, so a prefix match classified the published HTTP contract as
+// documentation and waved it through every gate — while `docs:validate` filters
+// to Markdown and therefore validated nothing about the change at all. Matching
+// on the `.md` extension (plus LICENSE and image assets) keeps `docs/*.md`
+// skippable without handing that exemption to whatever else lands under `docs/`.
+//
+// This module is imported by .github/workflows/ci.yml and codeql.yml so the two
+// cannot drift apart. It gates every required check, so it is unit-tested:
+// tests/unit/scripts/ci/classifyChangedPaths.test.js.
+
+const fs = require('node:fs');
+
+/**
+ * True when a path is documentation that `docs:validate` can meaningfully check.
+ *
+ * Deliberately extension-based rather than directory-based — see the note above.
+ *
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+function isDocsPath(filePath) {
+  return (
+    filePath === 'LICENSE'
+    || filePath.endsWith('.md')
+    || filePath.startsWith('.github/assets/')
+  );
+}
+
+/**
+ * @param {string[]} changedFiles
+ * @returns {{ docsChanged: boolean, docsOnly: boolean }}
+ */
+function classifyChangedPaths(changedFiles) {
+  // An empty list is never docs-only: with no evidence of what changed, the
+  // safe answer is to run the gates rather than skip them.
+  return {
+    docsChanged: changedFiles.some(isDocsPath),
+    docsOnly: changedFiles.length > 0 && changedFiles.every(isDocsPath),
+  };
+}
+
+/**
+ * @param {string} contents
+ * @returns {string[]}
+ */
+function parseChangedFiles(contents) {
+  return contents
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+/**
+ * @param {string[]} argv
+ * @returns {{ input: string, json: boolean }}
+ */
+function parseArgs(argv) {
+  const args = { input: 'changed-files.txt', json: false };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--json') {
+      args.json = true;
+    } else if (arg === '--input') {
+      index += 1;
+
+      if (typeof argv[index] !== 'string') {
+        throw new Error('--input requires a file argument');
+      }
+
+      args.input = argv[index];
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return args;
+}
+
+function main(argv = process.argv.slice(2)) {
+  let args;
+
+  try {
+    args = parseArgs(argv);
+  } catch (error) {
+    process.stderr.write(`classify-changed-paths ${error instanceof Error ? error.message : error}\n`);
+    return 2;
+  }
+
+  const changedFiles = parseChangedFiles(fs.readFileSync(args.input, 'utf8'));
+  const { docsChanged, docsOnly } = classifyChangedPaths(changedFiles);
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify({ changedFiles, docsChanged, docsOnly }, null, 2)}\n`);
+  } else {
+    process.stdout.write(`docs_changed=${docsChanged} docs_only=${docsOnly} (${changedFiles.length} changed file(s))\n`);
+  }
+
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `docs_changed=${docsChanged}\ndocs_only=${docsOnly}\n`,
+    );
+  }
+
+  return 0;
+}
+
+if (require.main === module) {
+  process.exitCode = main();
+}
+
+module.exports = {
+  classifyChangedPaths,
+  isDocsPath,
+  main,
+  parseArgs,
+  parseChangedFiles,
+};

--- a/tests/unit/scripts/ci/classifyChangedPaths.test.js
+++ b/tests/unit/scripts/ci/classifyChangedPaths.test.js
@@ -1,0 +1,105 @@
+const {
+  classifyChangedPaths,
+  isDocsPath,
+  parseChangedFiles,
+} = require('../../../../scripts/ci/classify-changed-paths');
+
+describe('Unit | Scripts | CI | Classify Changed Paths', () => {
+  describe('isDocsPath', () => {
+    it.each([
+      ['LICENSE'],
+      ['README.md'],
+      ['DEVELOPMENT.md'],
+      ['docs/required-checks.md'],
+      ['docs/postman-standards.md'],
+      ['.github/assets/alt-text-generator.png'],
+    ])('treats %s as documentation', (filePath) => {
+      expect(isDocsPath(filePath)).toBe(true);
+    });
+
+    it.each([
+      ['docs/openapi.base.json'],
+      ['src/api/v1/routes/health.js'],
+      ['package.json'],
+      ['render.yaml'],
+      ['.github/workflows/ci.yml'],
+      ['config/index.js'],
+      ['scripts/ci/classify-changed-paths.js'],
+    ])('does not treat %s as documentation', (filePath) => {
+      expect(isDocsPath(filePath)).toBe(false);
+    });
+
+    // The regression this module exists for: docs/ is not a blanket exemption,
+    // but Markdown under docs/ is still documentation.
+    it('classifies by extension rather than by the docs/ directory', () => {
+      expect(isDocsPath('docs/openapi.base.json')).toBe(false);
+      expect(isDocsPath('docs/coverage-thresholds.md')).toBe(true);
+    });
+
+    it('does not treat a LICENSE-suffixed path as the LICENSE file', () => {
+      expect(isDocsPath('vendor/LICENSE')).toBe(false);
+    });
+
+    it('does not exempt .github paths outside assets/', () => {
+      expect(isDocsPath('.github/workflows/codeql.yml')).toBe(false);
+    });
+  });
+
+  describe('classifyChangedPaths', () => {
+    it('runs the gates for a spec-only change', () => {
+      expect(classifyChangedPaths(['docs/openapi.base.json'])).toEqual({
+        docsChanged: false,
+        docsOnly: false,
+      });
+    });
+
+    it('runs the gates when a spec change is bundled with documentation', () => {
+      expect(classifyChangedPaths(['docs/openapi.base.json', 'README.md'])).toEqual({
+        docsChanged: true,
+        docsOnly: false,
+      });
+    });
+
+    it('runs the gates for a source-only change', () => {
+      expect(classifyChangedPaths(['src/api/v1/routes/health.js'])).toEqual({
+        docsChanged: false,
+        docsOnly: false,
+      });
+    });
+
+    it('skips the gates for a genuinely docs-only change', () => {
+      expect(classifyChangedPaths(['README.md', 'docs/required-checks.md', 'LICENSE'])).toEqual({
+        docsChanged: true,
+        docsOnly: true,
+      });
+    });
+
+    it('reports docs changed but not docs-only for a mixed change', () => {
+      expect(classifyChangedPaths(['README.md', 'src/app.js'])).toEqual({
+        docsChanged: true,
+        docsOnly: false,
+      });
+    });
+
+    // No evidence of what changed must never mean "safe to skip".
+    it('never reports docs-only for an empty change set', () => {
+      expect(classifyChangedPaths([])).toEqual({
+        docsChanged: false,
+        docsOnly: false,
+      });
+    });
+  });
+
+  describe('parseChangedFiles', () => {
+    it('trims entries and drops blank lines', () => {
+      expect(parseChangedFiles('README.md\n\n  src/app.js  \n')).toEqual([
+        'README.md',
+        'src/app.js',
+      ]);
+    });
+
+    it('returns an empty list for empty input', () => {
+      expect(parseChangedFiles('')).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## The hole

`isDocsPath` matched any path under `docs/`. That directory contains
`docs/openapi.base.json` — the published HTTP contract that `config/swagger.js`
serves verbatim and that downstream codegen consumes. Changing it was
classified as a documentation edit.

Six required checks then skipped and announced themselves satisfied:

```
ci.yml:140 lint · :179 OpenAPI · :205 typecheck · :239 unit matrix · :282 full Jest · :339 Newman
           -> "Docs-only change; <X> gate satisfied by docs validation."
```

The claim is not true. `docs:validate` filters to `.md`, so on a spec-only PR it
validated **zero files related to the change**, re-checked eight unrelated
documents, and passed green. That also contradicted `DEVELOPMENT.md:113`:
*"Three standalone gates keep it honest, and the CI `openapi` job runs all
three."* They did not run.

## Scope, honestly

Not a permanent hole: `openapi:check` regenerates from the JSDoc sources, so
drift surfaces on the next non-docs-only PR. The cost is delayed detection and a
failure landing on an innocent author's PR rather than the one that caused it.

## Fix

Classify by extension, not directory:

```js
filePath === 'LICENSE' || filePath.endsWith('.md') || filePath.startsWith('.github/assets/')
```

`docs/*.md` stays skippable; `docs/openapi.base.json` no longer inherits an
exemption it was never entitled to.

Verified against the real step contract (writing `GITHUB_OUTPUT` and reading
`docs_only` back, exactly as the workflow does):

```
runs  gates  <- docs/openapi.base.json          (was: SKIPS)
runs  gates  <- docs/openapi.base.json,README.md (was: SKIPS)
runs  gates  <- src/api/v1/routes/health.js
SKIPS gates  <- README.md
SKIPS gates  <- docs/required-checks.md
SKIPS gates  <- LICENSE
SKIPS gates  <- .github/assets/banner.png
```

## Why it is now a module

The predicate was inline heredoc JavaScript duplicated across `ci.yml` and
`codeql.yml`. It gates every required check in the repository and had no test —
the two copies could drift silently, and one had already been edited without the
other. It now lives in `scripts/ci/classify-changed-paths.js`, is imported by
both workflows, and is covered by 24 unit tests.

Two of those tests are the ones that matter beyond this fix: `docs/` is not a
blanket exemption but `docs/*.md` still is, and an **empty change set is never
docs-only** — with no evidence of what changed, the safe answer is to run the
gates, not skip them.

This PR touches workflows and `scripts/`, so it is not docs-only and runs the
full gate set itself.