### PR TITLE
ci(docs): enumerate tracked files instead of walking the filesystem

### DIFF
--- a/scripts/docs/validate-docs.js
+++ b/scripts/docs/validate-docs.js
@@ -1,52 +1,37 @@
 #!/usr/bin/env node
 
+const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 
 const ROOT = path.resolve(__dirname, '../..');
-const SKIPPED_DIRS = new Set([
-  '.git',
-  'coverage',
-  'node_modules',
-  'reports',
-]);
 
 /**
  * @typedef {{ file: string, line: number, message: string }} DocViolation
  */
 
-/** @param {string} filePath */
-function isMarkdownFile(filePath) {
-  return filePath.toLowerCase().endsWith('.md');
-}
-
 /**
- * @param {string} dirPath
- * @param {string[]} [files]
+ * Enumerates the Markdown files git tracks under `rootDir`.
+ *
+ * This deliberately asks git rather than walking the filesystem. A walk with a
+ * hardcoded skip list saw whatever happened to be on the developer's disk, so
+ * the gate's verdict depended on untracked local state: it validated scratch
+ * notes under `.local/`, and a note saved with CRLF failed the gate locally
+ * while CI — which only ever has the tracked files — passed. Asking git makes
+ * the local result and the clean-checkout result the same set by construction.
+ *
+ * @param {string} [rootDir]
  * @returns {string[]}
  */
-function walkFiles(dirPath, files = []) {
-  fs.readdirSync(dirPath, { withFileTypes: true }).forEach((entry) => {
-    const entryPath = path.join(dirPath, entry.name);
-
-    if (entry.isDirectory()) {
-      if (!SKIPPED_DIRS.has(entry.name)) {
-        walkFiles(entryPath, files);
-      }
-      return;
-    }
-
-    if (entry.isFile()) {
-      files.push(entryPath);
-    }
+function listMarkdownFiles(rootDir = ROOT) {
+  const stdout = execFileSync('git', ['-C', rootDir, 'ls-files', '-z', '--', '*.md'], {
+    encoding: 'utf8',
   });
 
-  return files;
-}
-
-function listMarkdownFiles(rootDir = ROOT) {
-  return walkFiles(rootDir)
-    .filter(isMarkdownFile)
+  return stdout
+    .split('\0')
+    .filter(Boolean)
+    .map((relativePath) => path.join(rootDir, relativePath))
     .sort((left, right) => left.localeCompare(right));
 }
 

--- a/tests/unit/scripts/docs/validateDocs.test.js
+++ b/tests/unit/scripts/docs/validateDocs.test.js
@@ -1,3 +1,4 @@
+const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -9,32 +10,93 @@ const {
   validateMarkdownFile,
 } = require('../../../../scripts/docs/validate-docs');
 
-const createTempDocsDir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'docs-validate-'));
+// The gate enumerates git-tracked files, so a fixture has to be a real
+// repository — writing a file to disk is no longer enough to make it visible.
+// That is the property under test, not an inconvenience of the harness.
+const createTempDocsRepo = () => {
+  const rootDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'docs-validate-')));
+
+  execFileSync('git', ['-C', rootDir, 'init', '--quiet']);
+  execFileSync('git', ['-C', rootDir, 'config', 'user.email', 'docs-gate@example.test']);
+  execFileSync('git', ['-C', rootDir, 'config', 'user.name', 'Docs Gate']);
+
+  return rootDir;
+};
+
+/**
+ * @param {string} rootDir
+ * @param {string} relativePath
+ * @param {string} contents
+ * @param {{ track?: boolean }} [options]
+ */
+const writeDoc = (rootDir, relativePath, contents, { track = true } = {}) => {
+  const filePath = path.join(rootDir, relativePath);
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, contents);
+
+  if (track) {
+    execFileSync('git', ['-C', rootDir, 'add', '--', relativePath]);
+  }
+
+  return filePath;
+};
+
+const relativeTo = (rootDir) => (filePath) => path.relative(rootDir, filePath);
 
 describe('Unit | Scripts | Docs | Validate Docs', () => {
-  it('lists Markdown files while ignoring generated dependency/report directories', () => {
-    const rootDir = createTempDocsDir();
+  it('lists the Markdown files git tracks', () => {
+    const rootDir = createTempDocsRepo();
 
     try {
-      fs.mkdirSync(path.join(rootDir, 'docs'), { recursive: true });
-      fs.mkdirSync(path.join(rootDir, 'node_modules', 'pkg'), { recursive: true });
-      fs.writeFileSync(path.join(rootDir, 'README.md'), '# Readme\n');
-      fs.writeFileSync(path.join(rootDir, 'docs', 'guide.md'), '# Guide\n');
-      fs.writeFileSync(path.join(rootDir, 'node_modules', 'pkg', 'README.md'), '# Package\n');
+      writeDoc(rootDir, 'README.md', '# Readme\n');
+      writeDoc(rootDir, 'docs/guide.md', '# Guide\n');
 
-      expect(listMarkdownFiles(rootDir).map((filePath) => path.relative(rootDir, filePath)))
+      expect(listMarkdownFiles(rootDir).map(relativeTo(rootDir)))
         .toEqual(['docs/guide.md', 'README.md']);
     } finally {
       fs.rmSync(rootDir, { force: true, recursive: true });
     }
   });
 
-  it('accepts non-empty LF Markdown without merge-conflict markers', () => {
-    const rootDir = createTempDocsDir();
-    const docsPath = path.join(rootDir, 'README.md');
+  it('ignores Markdown that is present on disk but untracked', () => {
+    const rootDir = createTempDocsRepo();
 
     try {
-      fs.writeFileSync(docsPath, '# Valid\n\nContent.\n');
+      writeDoc(rootDir, 'README.md', '# Readme\n');
+      writeDoc(rootDir, '.local/scratch.md', '# Scratch note\n', { track: false });
+      writeDoc(rootDir, 'node_modules/pkg/README.md', '# Package\n', { track: false });
+
+      expect(listMarkdownFiles(rootDir).map(relativeTo(rootDir))).toEqual(['README.md']);
+    } finally {
+      fs.rmSync(rootDir, { force: true, recursive: true });
+    }
+  });
+
+  // The concrete local failure this replaces: a scratch note saved with CRLF
+  // failed docs:validate on the developer's machine while CI passed, because CI
+  // never had the file. The gate must not see it at all.
+  it('does not fail on violations in untracked local notes', () => {
+    const rootDir = createTempDocsRepo();
+
+    try {
+      writeDoc(rootDir, 'README.md', '# Readme\n');
+      writeDoc(rootDir, '.local/notes.md', '# Notes\r\n<<<<<<< HEAD\r\n', { track: false });
+
+      expect(validateDocs({ rootDir })).toEqual({
+        files: ['README.md'],
+        violations: [],
+      });
+    } finally {
+      fs.rmSync(rootDir, { force: true, recursive: true });
+    }
+  });
+
+  it('accepts non-empty LF Markdown without merge-conflict markers', () => {
+    const rootDir = createTempDocsRepo();
+
+    try {
+      const docsPath = writeDoc(rootDir, 'README.md', '# Valid\n\nContent.\n');
 
       expect(validateMarkdownFile(docsPath, rootDir)).toEqual([]);
       expect(validateDocs({ rootDir })).toEqual({
@@ -47,13 +109,11 @@ describe('Unit | Scripts | Docs | Validate Docs', () => {
   });
 
   it('reports empty files, CRLF, and merge-conflict markers', () => {
-    const rootDir = createTempDocsDir();
-    const emptyPath = path.join(rootDir, 'empty.md');
-    const conflictPath = path.join(rootDir, 'conflict.md');
+    const rootDir = createTempDocsRepo();
 
     try {
-      fs.writeFileSync(emptyPath, '  \n');
-      fs.writeFileSync(conflictPath, '# Title\r\n<<<<<<< HEAD\r\n');
+      writeDoc(rootDir, 'empty.md', '  \n');
+      writeDoc(rootDir, 'conflict.md', '# Title\r\n<<<<<<< HEAD\r\n');
 
       expect(validateDocs({ rootDir }).violations).toEqual([
         {


### PR DESCRIPTION
## Problem

`docs:validate` walked the filesystem with a hardcoded skip list (`.git`,
`coverage`, `node_modules`, `reports`) and never consulted `.gitignore`. A
required check therefore returned a different answer depending on the
developer's disk:

```
docs:validate OK (12 Markdown files)   <- locally
docs:validate OK  (8 Markdown files)   <- CI, clean checkout
```

The extras were scratch notes under `.local/`, deliberately untracked.

Three consequences, in increasing order of how much they matter:

1. The gate's result is not reproducible — it depends on untracked local state.
2. It reads files that were deliberately kept out of version control.
3. Its failure mode is **inverted**: a local note saved with CRLF or containing
   a conflict marker fails `docs:validate` on the author's machine while CI
   passes, because CI never had the file. The gate fails the one person who
   cannot see why, and passes for everyone who can.

## Change

Enumerate with `git ls-files -z -- '*.md'`. `--root` support is kept for tests.

The local set and the clean-checkout set are now identical by construction,
rather than by the skip list happening to keep pace with the directory layout —
which it had already stopped doing.

## Acceptance

With `.local/` present on disk:

```
$ npm run docs:validate
docs:validate OK (8 Markdown files)

$ diff <(git ls-files '*.md' | sort) <(docs:validate --json | jq -r '.files[]' | sort)
  (identical)
```

## Note on the fixtures

They are now real git repositories. Writing a file to disk no longer makes it
visible to the gate — which is exactly the property being fixed, so it is
asserted directly rather than assumed: untracked Markdown is ignored, and
violations inside an untracked local note no longer fail the run. That last test
is the local-vs-CI inversion above, pinned so it cannot come back.

The drift this exposed, for the record: the audit measured 11 files, and it was
12 by the time the fix landed — a new untracked note had appeared in between.
The moving number is the argument.