### PR TITLE
docs: converge on one product name and link the table of contents

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -11,20 +11,20 @@ If you only need a quick local boot, start with `README.md` and come back here f
 
 ## Table of Contents
 
-- Quick Start (Dev)
-- Common Commands
-- GitHub Workflows
-- Repository Automation GitHub App
-- Postman/Newman Harness
-- Supported Models
-- Configuration and Profiles
-- Environment Variable Reference
-- Render Deployment Contract
-- Quality Gates
-- External Integration Validation Runbook
-- TLS and Outbound Trust Troubleshooting
-- Operational Notes
-- Keeping This Doc Correct
+- [Quick Start (Dev)](#quick-start-dev)
+- [Common Commands](#common-commands)
+- [GitHub Workflows](#github-workflows)
+- [Repository Automation GitHub App](#repository-automation-github-app)
+- [Postman/Newman Harness](#postmannewman-harness)
+- [Supported Models](#supported-models)
+- [Configuration and Profiles](#configuration-and-profiles)
+- [Environment Variable Reference](#environment-variable-reference)
+- [Render Deployment Contract](#render-deployment-contract)
+- [Quality Gates](#quality-gates)
+- [External Integration Validation Runbook](#external-integration-validation-runbook)
+- [TLS and Outbound Trust Troubleshooting](#tls-and-outbound-trust-troubleshooting)
+- [Operational Notes](#operational-notes)
+- [Keeping This Doc Correct](#keeping-this-doc-correct)
 
 ## Quick Start (Dev)
 

--- a/config/swagger-base.js
+++ b/config/swagger-base.js
@@ -21,10 +21,10 @@ const buildServers = () => {
 const createSwaggerDefinition = () => ({
   openapi: '3.0.0',
   info: {
-    title: 'AI-Powered Alternative Text Provider API',
+    title: 'Alt-Text 4 All',
     version: '1.0.0',
     description:
-      'This API provides descriptions to images, to contribute to the world-wide accessibility efforts.',
+      'Scrapes website images and generates AI-powered alt text to improve accessibility workflows.',
   },
   servers: buildServers(),
   components: {

--- a/docs/openapi.base.json
+++ b/docs/openapi.base.json
@@ -219,8 +219,8 @@
     }
   },
   "info": {
-    "description": "This API provides descriptions to images, to contribute to the world-wide accessibility efforts.",
-    "title": "AI-Powered Alternative Text Provider API",
+    "description": "Scrapes website images and generates AI-powered alt text to improve accessibility workflows.",
+    "title": "Alt-Text 4 All",
     "version": "1.0.0"
   },
   "openapi": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "alt-text-generator",
   "version": "1.0.0",
   "private": true,
-  "description": "A simple service that uses AI services to propose Alt Text descriptions for your website images.",
+  "description": "Alt-Text 4 All — scrapes website images and generates AI-powered alt text to improve accessibility workflows.",
   "keywords": [
     "alt",
     "text",

--- a/postman/collections/alt-text-generator.postman_collection.json
+++ b/postman/collections/alt-text-generator.postman_collection.json
@@ -1,8 +1,8 @@
 {
   "info": {
     "_postman_id": "e379638e-f74f-4aa6-813c-6073da2cfab1",
-    "name": "alt-text-generator API Contract Harness",
-    "description": "Deterministic Postman/Newman contract harness for the alt-text-generator API. Use the local fixture environment for CI/local runs, and keep live-provider validation separate.",
+    "name": "Alt-Text 4 All API Contract Harness",
+    "description": "Deterministic Postman/Newman contract harness for the Alt-Text 4 All API. Use the local fixture environment for CI/local runs, and keep live-provider validation separate.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "event": [


### PR DESCRIPTION
## Four names

| Surface | Was |
|---|---|
| `README.md:5,14` | Alt-Text 4 All |
| `package.json` / repo / Postman collection | alt-text-generator |
| `docs/openapi.base.json`, `config/swagger-base.js:24` | AI-Powered Alternative Text Provider API |
| Render `OPENROUTER_TITLE` (live) | Alt Text 4 All *(no hyphen)* |

Plus two competing descriptions. The OpenAPI title is the public-facing one —
`config/swagger.js` serves that artifact verbatim to swagger-ui and downstream
codegen — so which spelling won was not a cosmetic question.

## Now

**Alt-Text 4 All**, everywhere it is a product name:

```
README.md:5                 Alt-Text 4 All              (already correct)
package.json description    Alt-Text 4 All — ...
config/swagger-base.js      Alt-Text 4 All
docs/openapi.base.json      Alt-Text 4 All              (regenerated)
Postman collection          Alt-Text 4 All API Contract Harness
Render OPENROUTER_TITLE     Alt-Text 4 All              [live, done]
```

`package.json` `name` stays `alt-text-generator` — npm names cannot contain
spaces or capitals, and it is the package identifier, not the product name. The
repo, the Render service, and the collection *filename* keep it for the same
reason. That is a deliberate distinction, not an oversight.

The single description is lifted from the README's own overview line rather than
invented, so the package, the API, and the docs repeat wording a reader has
already seen instead of offering a third variant.

## `docs/openapi.base.json` is generated, not edited

Regenerated via `npm run openapi:generate` from `swagger-base.js`:

```
openapi:validate  OK  (8 paths, 8 operations)
openapi:check     OK  matches the generated contract
openapi:diff      OK  backward compatible with origin/main
```

`openapi:diff` matters here: title and description are metadata, so no path,
schema, or response moved. Nothing downstream breaks.

Worth noting this PR is the first to exercise #259 in anger — a change touching
`docs/openapi.base.json` now **runs** the `openapi` job instead of skipping it
as a "docs" path.

## Table of contents

All 14 entries already matched their `##` headings, so this is navigability
only, not a correctness fix. The anchors were generated with the same
`slugifyHeading` the docs gate uses to validate links — so the gate now checks
its own output, and a heading renamed without updating the TOC fails the `docs`
check rather than rotting silently.

## Verification

`docs:validate` 8/0 · `docs:lint` 0 · `openapi:validate` / `check` / `diff` ·
`postman:lint` (13 folders, 45 requests) · lint · typecheck · 863/863 unit.
The Postman diff is exactly two lines — name and description — with no
reformatting of the 45 requests.