### PR TITLE
ci(security): keep dependency-security.md true, and make expiry dates bite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,13 @@ jobs:
       - name: Lint Markdown
         run: npm run docs:lint
 
+      # Deterministic and offline: asserts the generated tables in
+      # dependency-security.md match the manifest, and that the manifest's
+      # override list matches package.json. The audit itself runs unblocking on
+      # a schedule (Security Audit / residual-advisories).
+      - name: Check generated dependency-security tables
+        run: npm run security:docs
+
   actionlint:
     name: actionlint
     runs-on: ubuntu-latest

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -61,3 +61,42 @@ jobs:
         run: |
           echo "npm audit reported high or critical production dependency findings."
           exit 1
+
+  # Non-blocking, by design. The npm-audit job above is the production gate and
+  # stays --omit=dev --audit-level=high, which is correct for production risk but
+  # structurally cannot see what docs/dependency-security.md is about: those
+  # advisories are all dev-only and all moderate. This job runs the full tree and
+  # compares it to the approved manifest, so the document has something keeping
+  # it true rather than being true by luck.
+  #
+  # It must never block: the advisory database changes without anyone touching
+  # this repo, so a required check here would go red because a third party
+  # published overnight.
+  residual-advisories:
+    name: residual-advisories
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Harden runner (audit)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup project
+        uses: ./.github/actions/setup-node-project
+
+      - name: Compare the full dependency tree against the approved manifest
+        run: |
+          if ! npm run security:residual --silent | tee residual.log; then
+            echo "::warning::Full-tree audit diverges from config/security/residual-advisories.json (advisory; see job log)"
+          fi
+          {
+            echo '### Residual dependency advisories'
+            echo ''
+            echo '```'
+            cat residual.log
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -14,6 +14,12 @@
   //                       its own number. That renders correctly (<ol start=N>)
   //                       and re-indenting eight fences to satisfy the rule
   //                       would churn the document without fixing anything.
+  //   MD060 table-column-style
+  //                       the repo mixes `|---|` and `| --- |` delimiter rows.
+  //                       Worth settling one day, but normalising 24 rows
+  //                       across four files — including required-checks.md,
+  //                       whose content is verified correct — is churn, not a
+  //                       fix. Nothing renders differently either way.
   //
   // Everything else stays on, including the heading-hierarchy rules this gate
   // is for: MD001 increment, MD024 duplicates, MD025 single H1, MD022 spacing.
@@ -22,7 +28,8 @@
     "MD013": false,
     "MD033": false,
     "MD041": false,
-    "MD029": false
+    "MD029": false,
+    "MD060": false
   },
   "globs": ["**/*.md"],
   "gitignore": true

--- a/config/security/residual-advisories.json
+++ b/config/security/residual-advisories.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "./residual-advisories.schema.json",
+  "$comment": "Approved residual advisories and override pins. docs/dependency-security.md's tables are generated from this file — edit here, then run `npm run security:docs -- --write`. Verified by scripts/security/residual-advisories.js.",
+  "verifiedAt": "2026-07-15",
+  "lockfileSha256": "9aa20c19d81ca2ec83bdaf7b02b80fd7af493e469de194e7a0e1e9926d6c2fdc",
+  "overrides": [
+    {
+      "package": "handlebars",
+      "range": "^4.7.9",
+      "fixes": "**critical** AST-injection / prototype-pollution chain"
+    },
+    {
+      "package": "lodash",
+      "range": "^4.18.1",
+      "fixes": "code-injection + prototype-pollution advisories"
+    },
+    {
+      "package": "node-forge",
+      "range": "^1.4.0",
+      "fixes": "signature/verification advisories"
+    },
+    {
+      "package": "underscore",
+      "range": "^1.13.8",
+      "fixes": "arbitrary code execution"
+    },
+    {
+      "package": "flatted",
+      "range": "^3.4.2",
+      "fixes": "prototype pollution + unbounded-recursion DoS"
+    },
+    {
+      "package": "qs",
+      "range": "^6.15.3",
+      "fixes": "transitive `qs` (the direct dep is already ≥ 6.15.3)"
+    }
+  ],
+  "accepted": [
+    {
+      "advisory": "GHSA-w5hq-g745-h8pq",
+      "package": "uuid",
+      "severity": "moderate",
+      "title": "Missing buffer bounds check in v3/v5/v6 when buf is provided",
+      "pulledBy": ["jest-junit", "postman-collection", "postman-request", "serialised-error"],
+      "productionReachable": false,
+      "why": "The fix is uuid@14, whose ESM/named-export API breaks those old consumers."
+    },
+    {
+      "advisory": "GHSA-hhhv-q57g-882q",
+      "package": "jose",
+      "severity": "moderate",
+      "title": "Resource exhaustion via a crafted JWE with compressed plaintext",
+      "pulledBy": ["postman-runtime"],
+      "productionReachable": false,
+      "why": "The fix is jose@6, two majors past what postman-runtime targets."
+    }
+  ]
+}

--- a/docs/dependency-security.md
+++ b/docs/dependency-security.md
@@ -19,6 +19,7 @@ would take out required CI lanes to fix **dev-only** advisories.
 their patched releases. All are dev/test-only (they arrive via `newman`, the
 Postman CLI used in the test harness):
 
+<!-- generated:overrides start -->
 | Override | Fixes |
 |---|---|
 | `handlebars ^4.7.9` | **critical** AST-injection / prototype-pollution chain |
@@ -27,6 +28,7 @@ Postman CLI used in the test harness):
 | `underscore ^1.13.8` | arbitrary code execution |
 | `flatted ^3.4.2` | prototype pollution + unbounded-recursion DoS |
 | `qs ^6.15.3` | transitive `qs` (the direct dep is already ≥ 6.15.3) |
+<!-- generated:overrides end -->
 
 Caret ranges (not exact pins) so patch/minor fixes still flow; these entries are
 removed once the upstream `newman` tree ships the patched versions itself.
@@ -36,12 +38,10 @@ removed once the upstream `newman` tree ships the patched versions itself.
 The remaining advisories are **all moderate, all dev/test-only**, and every
 available fix is a breaking major bump into a consumer that expects the old API:
 
-- **`uuid`** (buffer-bounds, GHSA-w5hq-g745-h8pq) — pulled by `jest-junit`,
-  `postman-collection`, `postman-request`, `serialised-error`. The fix is
-  `uuid@14`, whose ESM/named-export API breaks those old consumers.
-- **`jose`** (JWE resource exhaustion, GHSA-hhhv-q57g-882q) — pulled by
-  `postman-runtime`. The fix is `jose@6`, two majors past what postman-runtime
-  targets.
+<!-- generated:accepted start -->
+- **`uuid`** (Missing buffer bounds check in v3/v5/v6 when buf is provided, GHSA-w5hq-g745-h8pq) — pulled by `jest-junit`, `postman-collection`, `postman-request`, `serialised-error`. The fix is uuid@14, whose ESM/named-export API breaks those old consumers.
+- **`jose`** (Resource exhaustion via a crafted JWE with compressed plaintext, GHSA-hhhv-q57g-882q) — pulled by `postman-runtime`. The fix is jose@6, two majors past what postman-runtime targets.
+<!-- generated:accepted end -->
 
 Neither is reachable from the production runtime (`src/`). They are tolerated
 until `newman` / `jest-junit` update their own trees, at which point the
@@ -51,5 +51,30 @@ both of which are required CI.
 
 ## Verifying
 
-`npm audit` should report **0 critical, 0 high**. A regression that reintroduces
-a high/critical, or that force-downgrades `newman`, should fail review.
+The tables above are **generated** from
+[`config/security/residual-advisories.json`](../config/security/residual-advisories.json).
+Edit the manifest, then run `npm run security:docs -- --write`. The `docs` gate
+fails if this document and the manifest disagree, and if the manifest's override
+list and `package.json`'s do.
+
+<!-- generated:verified start -->
+Last verified against a full-tree `npm audit`: **2026-07-15**.
+
+Lockfile at that time: `9aa20c19d81ca2ec83bdaf7b02b80fd7af493e469de194e7a0e1e9926d6c2fdc`
+
+When `package-lock.json` changes, this stops matching — which is the signal
+to re-verify and update `config/security/residual-advisories.json`.
+<!-- generated:verified end -->
+
+`Dependency Residual Audit` runs a **full-tree** `npm audit` weekly and compares
+it to the manifest, reporting any advisory that is not approved, and any
+approved entry that upstream has since fixed. It is **non-blocking**: the
+advisory database changes without anyone touching this repo, and a required
+check must not go red because a third party published overnight.
+
+The always-required `npm-audit` job stays `--omit=dev --audit-level=high`, which
+is the right gate for *production* risk — and the reason this document needed
+its own: `--omit=dev` cannot see any of the advisories above, and
+`--audit-level=high` would not report them if it could. A regression that
+reintroduces a high/critical, or that force-downgrades `newman`, should still
+fail review.

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "jest": "^29.7.0",
         "jest-environment-node": "^30.4.1",
         "jest-junit": "^16.0.0",
-        "markdownlint-cli2": "0.18.1",
+        "markdownlint-cli2": "0.23.0",
         "newman": "^6.2.2",
         "newman-reporter-allure": "^3.6.0",
         "nodemon": "^3.1.14",
@@ -1842,9 +1842,9 @@
       "dev": true
     },
     "node_modules/@sindresorhus/merge-streams": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4946,6 +4946,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5073,21 +5086,21 @@
       }
     },
     "node_modules/globby": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
-      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
+      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sindresorhus/merge-streams": "^2.1.0",
+        "@sindresorhus/merge-streams": "^4.0.0",
         "fast-glob": "^3.3.3",
-        "ignore": "^7.0.3",
-        "path-type": "^6.0.0",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
         "slash": "^5.1.0",
-        "unicorn-magic": "^0.3.0"
+        "unicorn-magic": "^0.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5890,6 +5903,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-promise": {
@@ -7180,9 +7206,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.1.0.tgz",
-      "integrity": "sha512-s8VA5jkR8f22S3NAXmhKPFqGUduqZGlsufabVOgN14iTdw/RXcym7bKkbwjxLK9Yw2lEvvmJjFp119+KPeo8Kg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.0.tgz",
+      "integrity": "sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==",
       "funding": [
         {
           "type": "github",
@@ -7277,6 +7303,16 @@
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/jsprim": {
       "version": "2.0.2",
@@ -7467,15 +7503,25 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -7485,9 +7531,9 @@
       }
     },
     "node_modules/markdownlint": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.38.0.tgz",
-      "integrity": "sha512-xaSxkaU7wY/0852zGApM8LdlIfGCW8ETZ0Rr62IQtAnUMlMuifsg09vWJcNYeL4f0anvr8Vo4ZQar8jGpV0btQ==",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.41.0.tgz",
+      "integrity": "sha512-xMUI3ChBuRuxuLF4ENvCZyS8z/+Jly1coUcZwErKLIB3sDj7ojpaTBa1e9YVPhSN4jGEIjYGQCldbTJS/hqS+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7498,44 +7544,47 @@
         "micromark-extension-gfm-footnote": "2.1.0",
         "micromark-extension-gfm-table": "2.1.1",
         "micromark-extension-math": "3.1.0",
-        "micromark-util-types": "2.0.2"
+        "micromark-util-types": "2.0.2",
+        "string-width": "8.2.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/DavidAnson"
       }
     },
     "node_modules/markdownlint-cli2": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.18.1.tgz",
-      "integrity": "sha512-/4Osri9QFGCZOCTkfA8qJF+XGjKYERSHkXzxSyS1hd3ZERJGjvsUao2h4wdnvpHp6Tu2Jh/bPHM0FE9JJza6ng==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.23.0.tgz",
+      "integrity": "sha512-1nmgQmU/ZTMRVwYCDs7i1HI3zfBISnT2NNRv+9V01oOLZbAtqL+a7tldpPhBWBVBten3FqhMCGV6EUh9McqutQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "globby": "14.1.0",
-        "js-yaml": "4.1.0",
+        "globby": "16.2.0",
+        "js-yaml": "5.2.0",
         "jsonc-parser": "3.3.1",
-        "markdown-it": "14.1.0",
-        "markdownlint": "0.38.0",
-        "markdownlint-cli2-formatter-default": "0.0.5",
-        "micromatch": "4.0.8"
+        "jsonpointer": "5.0.1",
+        "markdown-it": "14.2.0",
+        "markdownlint": "0.41.0",
+        "markdownlint-cli2-formatter-default": "0.0.6",
+        "micromatch": "4.0.8",
+        "smol-toml": "1.7.0"
       },
       "bin": {
         "markdownlint-cli2": "markdownlint-cli2-bin.mjs"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/DavidAnson"
       }
     },
     "node_modules/markdownlint-cli2-formatter-default": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.5.tgz",
-      "integrity": "sha512-4XKTwQ5m1+Txo2kuQ3Jgpo/KmnG+X90dWt4acufg6HVGadTUG5hzHF/wssp9b5MBYOMCnZ9RMPaU//uHsszF8Q==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.6.tgz",
+      "integrity": "sha512-VVDGKsq9sgzu378swJ0fcHfSicUnMxnL8gnLm/Q4J/xsNJ4e5bA6lvAz7PCzIl0/No0lHyaWdqVD2jotxOSFMQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -7545,17 +7594,50 @@
         "markdownlint-cli2": ">=0.0.4"
       }
     },
-    "node_modules/markdownlint-cli2/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+    "node_modules/markdownlint/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/markdownlint/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "argparse": "^2.0.1"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdownlint/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/math-intrinsics": {
@@ -8903,19 +8985,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/path-type": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
-      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/performance-now": {
@@ -10303,6 +10372,19 @@
         "npm": ">= 3.0.0"
       }
     },
+    "node_modules/smol-toml": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
+      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/socks": {
       "version": "2.8.7",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
@@ -11123,13 +11205,13 @@
       }
     },
     "node_modules/unicorn-magic": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
     "validate:contract": "npm run openapi:diff && npm run postman:lint && npm run postman:smoke",
     "validate:ci": "npm run lint && npm run openapi:validate && npm run openapi:check && NODE_ENV=test REPLICATE_API_TOKEN=test-token npm run test:ci && npm run validate:contract",
     "prod": "NODE_ENV=production node src/app.js",
-    "dev": "NODE_ENV=development nodemon src/app.js | pino-pretty -i streams,options"
+    "dev": "NODE_ENV=development nodemon src/app.js | pino-pretty -i streams,options",
+    "security:docs": "node scripts/security/residual-advisories.js",
+    "security:residual": "node scripts/security/residual-advisories.js --check-audit"
   },
   "repository": {
     "type": "git",
@@ -99,7 +101,7 @@
     "jest": "^29.7.0",
     "jest-environment-node": "^30.4.1",
     "jest-junit": "^16.0.0",
-    "markdownlint-cli2": "0.18.1",
+    "markdownlint-cli2": "0.23.0",
     "newman": "^6.2.2",
     "newman-reporter-allure": "^3.6.0",
     "nodemon": "^3.1.14",

--- a/scripts/docs/validate-docs.js
+++ b/scripts/docs/validate-docs.js
@@ -154,6 +154,50 @@ function checkImageAlt(content, relativePath) {
 }
 
 /**
+ * A documented `Expiry: YYYY-MM-DD` is a promise to revisit something by a date.
+ * Nothing was keeping that promise: coverage-thresholds.md's ratchet exceptions
+ * carry one, and the day it passes the document silently becomes wrong. This
+ * turns the date into the thing that tells you.
+ *
+ * @param {string} content
+ * @param {string} relativePath
+ * @param {Date} [now]
+ * @returns {DocViolation[]}
+ */
+function checkExpiry(content, relativePath, now = new Date()) {
+  /** @type {DocViolation[]} */
+  const violations = [];
+  const today = now.toISOString().slice(0, 10);
+
+  stripCode(content).split('\n').forEach((line, index) => {
+    const pattern = /Expiry:\s*(\d{4}-\d{2}-\d{2})/g;
+    let match = pattern.exec(line);
+
+    while (match !== null) {
+      const expiry = match[1];
+
+      if (Number.isNaN(Date.parse(expiry))) {
+        violations.push({
+          file: relativePath,
+          line: index + 1,
+          message: `Expiry date is not a valid date: ${expiry}`,
+        });
+      } else if (expiry < today) {
+        violations.push({
+          file: relativePath,
+          line: index + 1,
+          message: `Documented Expiry ${expiry} has passed (today is ${today}) — revisit or extend it`,
+        });
+      }
+
+      match = pattern.exec(line);
+    }
+  });
+
+  return violations;
+}
+
+/**
  * @param {string} content
  * @param {string} relativePath
  * @returns {DocViolation[]}
@@ -375,6 +419,7 @@ function validateMarkdownFile(filePath, rootDir = ROOT) {
 
   violations.push(...checkImageAlt(content, relativePath));
   violations.push(...checkProhibitedReferences(content, relativePath));
+  violations.push(...checkExpiry(content, relativePath));
 
   return violations;
 }
@@ -460,6 +505,7 @@ if (require.main === module) {
 
 module.exports = {
   checkEnvVarCoverage,
+  checkExpiry,
   checkImageAlt,
   checkInternalLinks,
   checkProhibitedReferences,

--- a/scripts/security/residual-advisories.js
+++ b/scripts/security/residual-advisories.js
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+
+// Freshness model for docs/dependency-security.md.
+//
+// That document's central claims — which packages are pinned, which advisories
+// are knowingly tolerated — were accurate and entirely ungated. The scheduled
+// audit runs `npm audit --omit=dev --audit-level=high`, so it cannot see the
+// advisories the document is about: they are all dev-only and all moderate.
+// Nothing kept the document true; it simply was, until it would not be.
+//
+// Two halves, deliberately split by cost and blast radius:
+//
+//   --check-docs   deterministic, offline, blocking. The document's tables are
+//                  generated from the manifest, so they cannot drift from it.
+//   --check-audit  runs a full-tree `npm audit` and compares reality to the
+//                  manifest. Scheduled and NON-BLOCKING: it depends on the
+//                  advisory database, which changes without anyone touching
+//                  this repo, and a required check must not fail because a
+//                  third party published overnight.
+
+const { execFileSync } = require('node:child_process');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const MANIFEST_PATH = path.join(ROOT, 'config/security/residual-advisories.json');
+const DOC_PATH = path.join(ROOT, 'docs/dependency-security.md');
+const LOCKFILE_PATH = path.join(ROOT, 'package-lock.json');
+
+/** @param {string} name */
+const START = (name) => `<!-- generated:${name} start -->`;
+/** @param {string} name */
+const END = (name) => `<!-- generated:${name} end -->`;
+
+/** @returns {any} */
+function readManifest() {
+  return JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+}
+
+/** @returns {string} */
+function lockfileSha256() {
+  return crypto.createHash('sha256').update(fs.readFileSync(LOCKFILE_PATH, 'utf8')).digest('hex');
+}
+
+/**
+ * @param {any} manifest
+ * @returns {string}
+ */
+function renderOverridesTable(manifest) {
+  return [
+    '| Override | Fixes |',
+    '|---|---|',
+    ...manifest.overrides.map(
+      (/** @type {any} */ entry) => `| \`${entry.package} ${entry.range}\` | ${entry.fixes} |`,
+    ),
+  ].join('\n');
+}
+
+/**
+ * @param {any} manifest
+ * @returns {string}
+ */
+function renderAcceptedList(manifest) {
+  return manifest.accepted
+    .map((/** @type {any} */ entry) => {
+      const pulledBy = entry.pulledBy.map((/** @type {string} */ p) => `\`${p}\``).join(', ');
+
+      return `- **\`${entry.package}\`** (${entry.title}, ${entry.advisory}) — pulled by ${pulledBy}. ${entry.why}`;
+    })
+    .join('\n');
+}
+
+/**
+ * @param {any} manifest
+ * @returns {string}
+ */
+function renderVerified(manifest) {
+  return [
+    `Last verified against a full-tree \`npm audit\`: **${manifest.verifiedAt}**.`,
+    '',
+    `Lockfile at that time: \`${manifest.lockfileSha256}\``,
+    '',
+    'When `package-lock.json` changes, this stops matching — which is the signal',
+    'to re-verify and update `config/security/residual-advisories.json`.',
+  ].join('\n');
+}
+
+/**
+ * @param {string} content
+ * @param {string} name
+ * @param {string} body
+ * @returns {string}
+ */
+function replaceBlock(content, name, body) {
+  const start = START(name);
+  const end = END(name);
+  const pattern = new RegExp(`${start}[\\s\\S]*?${end}`);
+
+  if (!pattern.test(content)) {
+    throw new Error(`docs/dependency-security.md is missing the ${start} ... ${end} markers`);
+  }
+
+  return content.replace(pattern, `${start}\n${body}\n${end}`);
+}
+
+/**
+ * @param {any} manifest
+ * @returns {string}
+ */
+function renderDoc(manifest) {
+  let content = fs.readFileSync(DOC_PATH, 'utf8');
+
+  content = replaceBlock(content, 'overrides', renderOverridesTable(manifest));
+  content = replaceBlock(content, 'accepted', renderAcceptedList(manifest));
+  content = replaceBlock(content, 'verified', renderVerified(manifest));
+
+  return content;
+}
+
+/**
+ * The manifest's override list and package.json's must agree, or the document
+ * describes pins the tree does not have.
+ *
+ * @param {any} manifest
+ * @returns {string[]}
+ */
+function overrideMismatches(manifest) {
+  const actual = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')).overrides ?? {};
+  const declared = Object.fromEntries(
+    manifest.overrides.map((/** @type {any} */ e) => [e.package, e.range]),
+  );
+  /** @type {string[]} */
+  const problems = [];
+
+  Object.entries(actual).forEach(([pkg, range]) => {
+    if (!(pkg in declared)) {
+      problems.push(`package.json pins ${pkg} ${range} but the manifest does not list it`);
+    } else if (declared[pkg] !== range) {
+      problems.push(`package.json pins ${pkg} ${range} but the manifest says ${declared[pkg]}`);
+    }
+  });
+
+  Object.keys(declared).forEach((pkg) => {
+    if (!(pkg in actual)) {
+      problems.push(`the manifest lists ${pkg} but package.json does not pin it`);
+    }
+  });
+
+  return problems;
+}
+
+function checkDocs() {
+  const manifest = readManifest();
+  const problems = overrideMismatches(manifest);
+
+  if (fs.readFileSync(DOC_PATH, 'utf8') !== renderDoc(manifest)) {
+    problems.push(
+      'docs/dependency-security.md does not match the manifest. Run: npm run security:docs -- --write',
+    );
+  }
+
+  if (problems.length > 0) {
+    process.stderr.write('security:docs FAILED\n');
+    problems.forEach((problem) => process.stderr.write(`  - ${problem}\n`));
+    return 1;
+  }
+
+  process.stdout.write(
+    `security:docs OK (${manifest.overrides.length} overrides, ${manifest.accepted.length} accepted advisories, verified ${manifest.verifiedAt})\n`,
+  );
+
+  return 0;
+}
+
+function writeDocs() {
+  const manifest = readManifest();
+
+  fs.writeFileSync(DOC_PATH, renderDoc(manifest));
+  process.stdout.write('security:docs wrote docs/dependency-security.md from the manifest\n');
+
+  return 0;
+}
+
+/**
+ * @param {string} [auditFile]
+ * @returns {any}
+ */
+function loadAudit(auditFile) {
+  if (auditFile) {
+    return JSON.parse(fs.readFileSync(auditFile, 'utf8'));
+  }
+
+  // npm audit exits non-zero when it finds anything, which is the normal case
+  // here — the residual advisories are why this script exists.
+  try {
+    return JSON.parse(
+      execFileSync('npm', ['audit', '--json'], { cwd: ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }),
+    );
+  } catch (error) {
+    const stdout = /** @type {any} */ (error).stdout;
+
+    if (typeof stdout === 'string' && stdout.trim()) {
+      return JSON.parse(stdout);
+    }
+
+    throw error;
+  }
+}
+
+/**
+ * @param {any} audit
+ * @returns {Map<string, { package: string, severity: string, title: string }>}
+ */
+function distinctAdvisories(audit) {
+  const found = new Map();
+
+  Object.values(audit.vulnerabilities ?? {}).forEach((/** @type {any} */ vulnerability) => {
+    (vulnerability.via ?? []).forEach((/** @type {any} */ via) => {
+      if (typeof via === 'string' || !via.url) {
+        return;
+      }
+
+      const id = via.url.split('/').pop();
+
+      if (!found.has(id)) {
+        found.set(id, { package: via.name, severity: via.severity, title: via.title });
+      }
+    });
+  });
+
+  return found;
+}
+
+/**
+ * @param {string} [auditFile]
+ * @returns {number}
+ */
+function checkAudit(auditFile) {
+  const manifest = readManifest();
+  const audit = loadAudit(auditFile);
+  const found = distinctAdvisories(audit);
+  const accepted = new Set(manifest.accepted.map((/** @type {any} */ e) => e.advisory));
+
+  const unexpected = [...found.entries()].filter(([id]) => !accepted.has(id));
+  const stale = [...accepted].filter((id) => !found.has(id));
+  const totals = audit.metadata?.vulnerabilities ?? {};
+  const blocking = (totals.high ?? 0) + (totals.critical ?? 0);
+
+  process.stdout.write(`security:residual full-tree audit: ${JSON.stringify(totals)}\n`);
+  process.stdout.write(`  lockfile sha256: ${lockfileSha256()}\n`);
+  process.stdout.write(`  manifest verified: ${manifest.verifiedAt} (${manifest.lockfileSha256})\n`);
+
+  if (lockfileSha256() !== manifest.lockfileSha256) {
+    process.stdout.write('  NOTE: lockfile has changed since the manifest was verified\n');
+  }
+
+  unexpected.forEach(([id, info]) => {
+    process.stdout.write(`  UNAPPROVED ${info.severity} ${info.package} ${id} — ${info.title}\n`);
+  });
+
+  stale.forEach((id) => {
+    process.stdout.write(`  RESOLVED ${id} is approved in the manifest but no longer reported — remove it\n`);
+  });
+
+  if (blocking > 0) {
+    process.stdout.write(`  ${blocking} high/critical advisory(ies) present\n`);
+  }
+
+  if (unexpected.length === 0 && stale.length === 0 && blocking === 0) {
+    process.stdout.write('  OK reality matches the approved manifest\n');
+  }
+
+  return unexpected.length > 0 || stale.length > 0 || blocking > 0 ? 1 : 0;
+}
+
+/**
+ * @param {string[]} argv
+ * @returns {number}
+ */
+function main(argv = process.argv.slice(2)) {
+  if (argv.includes('--write')) {
+    return writeDocs();
+  }
+
+  if (argv.includes('--check-audit')) {
+    const index = argv.indexOf('--audit-file');
+
+    return checkAudit(index === -1 ? undefined : argv[index + 1]);
+  }
+
+  return checkDocs();
+}
+
+if (require.main === module) {
+  process.exitCode = main();
+}
+
+module.exports = {
+  checkAudit,
+  checkDocs,
+  distinctAdvisories,
+  lockfileSha256,
+  main,
+  overrideMismatches,
+  renderDoc,
+};

--- a/tests/unit/scripts/docs/validateDocs.test.js
+++ b/tests/unit/scripts/docs/validateDocs.test.js
@@ -5,6 +5,7 @@ const path = require('node:path');
 
 const {
   checkEnvVarCoverage,
+  checkExpiry,
   checkImageAlt,
   checkProhibitedReferences,
   collectAnchors,
@@ -269,6 +270,49 @@ describe('Unit | Scripts | Docs | Validate Docs', () => {
     it('disambiguates repeated headings the way GitHub does', () => {
       expect([...collectAnchors('## Notes\n\n## Notes\n\n## Notes\n')])
         .toEqual(['notes', 'notes-1', 'notes-2']);
+    });
+  });
+
+  describe('documented expiry dates', () => {
+    const AS_OF = new Date('2026-07-15T00:00:00Z');
+
+    it('accepts an expiry still in the future', () => {
+      expect(checkExpiry('Owner: QE. Expiry: 2026-09-30.\n', 'x.md', AS_OF)).toEqual([]);
+    });
+
+    it('accepts an expiry falling exactly today', () => {
+      expect(checkExpiry('Expiry: 2026-07-15\n', 'x.md', AS_OF)).toEqual([]);
+    });
+
+    it('rejects an expiry that has passed', () => {
+      expect(checkExpiry('Owner: QE. Expiry: 2026-07-14.\n', 'x.md', AS_OF)).toEqual([{
+        file: 'x.md',
+        line: 1,
+        message: 'Documented Expiry 2026-07-14 has passed (today is 2026-07-15) — revisit or extend it',
+      }]);
+    });
+
+    it('rejects a date that does not exist', () => {
+      expect(checkExpiry('Expiry: 2026-13-45\n', 'x.md', AS_OF)).toEqual([{
+        file: 'x.md',
+        line: 1,
+        message: 'Expiry date is not a valid date: 2026-13-45',
+      }]);
+    });
+
+    it('ignores an expiry inside a fenced code block', () => {
+      expect(checkExpiry('```\nExpiry: 2020-01-01\n```\n', 'x.md', AS_OF)).toEqual([]);
+    });
+
+    // The live case this exists for: coverage-thresholds.md carries a real one.
+    it('is watching a real documented expiry', () => {
+      const content = fs.readFileSync(
+        path.join(__dirname, '../../../../docs/coverage-thresholds.md'),
+        'utf8',
+      );
+
+      expect(content).toMatch(/Expiry:\s*\d{4}-\d{2}-\d{2}/);
+      expect(checkExpiry(content, 'docs/coverage-thresholds.md', AS_OF)).toEqual([]);
     });
   });
 

--- a/tests/unit/scripts/security/residualAdvisories.test.js
+++ b/tests/unit/scripts/security/residualAdvisories.test.js
@@ -1,0 +1,146 @@
+const {
+  checkAudit,
+  checkDocs,
+  distinctAdvisories,
+  lockfileSha256,
+  overrideMismatches,
+} = require('../../../../scripts/security/residual-advisories');
+
+const manifest = require('../../../../config/security/residual-advisories.json');
+
+/**
+ * Shapes a minimal `npm audit --json` payload: the fields this script reads.
+ *
+ * @param {Array<{ id: string, name: string, severity: string, title: string }>} advisories
+ * @param {object} [totals]
+ */
+const auditFixture = (advisories, totals = {}) => ({
+  vulnerabilities: Object.fromEntries(
+    advisories.map((a) => [a.name, {
+      name: a.name,
+      severity: a.severity,
+      via: [{
+        url: `https://github.com/advisories/${a.id}`,
+        name: a.name,
+        severity: a.severity,
+        title: a.title,
+      }],
+    }]),
+  ),
+  metadata: {
+    vulnerabilities: {
+      info: 0, low: 0, moderate: 0, high: 0, critical: 0, total: 0, ...totals,
+    },
+  },
+});
+
+const APPROVED = manifest.accepted.map((/** @type {any} */ e) => ({
+  id: e.advisory,
+  name: e.package,
+  severity: e.severity,
+  title: e.title,
+}));
+
+describe('Unit | Scripts | Security | Residual Advisories', () => {
+  let logs;
+
+  beforeEach(() => {
+    logs = [];
+    jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      logs.push(String(chunk));
+      return true;
+    });
+    jest.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      logs.push(String(chunk));
+      return true;
+    });
+  });
+
+  describe('the committed state', () => {
+    it('keeps the document and package.json in step with the manifest', () => {
+      expect(overrideMismatches(manifest)).toEqual([]);
+      expect(checkDocs()).toBe(0);
+    });
+
+    it('records the lockfile it was verified against', () => {
+      expect(manifest.lockfileSha256).toBe(lockfileSha256());
+      expect(manifest.verifiedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+  });
+
+  describe('distinctAdvisories', () => {
+    it('deduplicates one advisory reported through several packages', () => {
+      const audit = auditFixture([
+        { id: 'GHSA-aaaa', name: 'uuid', severity: 'moderate', title: 'Bounds' },
+      ]);
+
+      audit.vulnerabilities['postman-collection'] = {
+        name: 'postman-collection',
+        severity: 'moderate',
+        via: [
+          'uuid',
+          {
+            url: 'https://github.com/advisories/GHSA-aaaa', name: 'uuid', severity: 'moderate', title: 'Bounds',
+          },
+        ],
+      };
+
+      expect([...distinctAdvisories(audit).keys()]).toEqual(['GHSA-aaaa']);
+    });
+  });
+
+  describe('checkAudit', () => {
+    const withAudit = (payload, fn) => {
+      const file = `${global.__dirname ?? process.cwd()}/.residual-audit-fixture.json`;
+
+      require('node:fs').writeFileSync(file, JSON.stringify(payload));
+
+      try {
+        return fn(file);
+      } finally {
+        require('node:fs').rmSync(file, { force: true });
+      }
+    };
+
+    it('passes when reality matches the approved manifest', () => {
+      withAudit(auditFixture(APPROVED, { moderate: APPROVED.length, total: APPROVED.length }), (file) => {
+        expect(checkAudit(file)).toBe(0);
+      });
+
+      expect(logs.join('')).toContain('OK reality matches the approved manifest');
+    });
+
+    it('fails on an advisory nobody approved', () => {
+      const audit = auditFixture(
+        [...APPROVED, {
+          id: 'GHSA-new1', name: 'left-pad', severity: 'moderate', title: 'Surprise',
+        }],
+        { moderate: 3, total: 3 },
+      );
+
+      withAudit(audit, (file) => {
+        expect(checkAudit(file)).toBe(1);
+      });
+
+      expect(logs.join('')).toContain('UNAPPROVED moderate left-pad GHSA-new1');
+    });
+
+    // The manifest going stale in the other direction still needs a human: an
+    // entry upstream has fixed should be removed, not left implying live risk.
+    it('fails when an approved advisory is no longer reported', () => {
+      withAudit(auditFixture(APPROVED.slice(0, 1), { moderate: 1, total: 1 }), (file) => {
+        expect(checkAudit(file)).toBe(1);
+      });
+
+      expect(logs.join('')).toContain('is approved in the manifest but no longer reported');
+    });
+
+    it('fails on any high or critical, approved or not', () => {
+      withAudit(auditFixture(APPROVED, { critical: 1, total: 3 }), (file) => {
+        expect(checkAudit(file)).toBe(1);
+      });
+
+      expect(logs.join('')).toContain('1 high/critical advisory(ies) present');
+    });
+  });
+});


### PR DESCRIPTION
## The gap

`docs/dependency-security.md` is **accurate** — I re-verified every claim. It is
also **completely ungated**:

```
scripts/github/run-security-audit.sh:  npm audit --omit=dev --audit-level=high
```

`--omit=dev` means it cannot see the advisories the document is about — they are
every one dev-only. `--audit-level=high` means it would not report them if it
could — they are every one moderate. The document's central claims had nothing
holding them up. It was true by luck, and nothing would have said when that
stopped.

## Two halves, split by cost and blast radius

**Generated tables (blocking, offline, deterministic).** The override and
accepted-advisory tables now come from
`config/security/residual-advisories.json`. The `docs` gate fails when the
document and the manifest disagree, or when the manifest's override list and
`package.json`'s do. Prose stays hand-written — only the claims that must track
reality are generated.

```
$ npm run security:docs
security:docs OK (6 overrides, 2 accepted advisories, verified 2026-07-15)
```

Both failure directions are tested, and I checked they actually fire:

```
- docs/dependency-security.md does not match the manifest. Run: npm run security:docs -- --write
- package.json pins lodash ^4.0.0 but the manifest says ^4.18.1
- the manifest lists qs but package.json does not pin it
```

**Full-tree audit (scheduled, non-blocking).** `Security Audit /
residual-advisories` runs `npm audit` across the whole tree and compares it to
the manifest:

```
security:residual full-tree audit: {"moderate":9,"high":0,"critical":0,"total":9}
  OK reality matches the approved manifest
```

It reports advisories **nobody approved** and approved entries **upstream has
since fixed** — the manifest rots in both directions, and an entry implying live
risk that no longer exists is its own kind of wrong.

Non-blocking on purpose, and this is the whole design point: the advisory
database changes without anyone touching this repo. A required check here would
go red because a third party published overnight — the same reason the audit
warned against making external-link liveness a required gate.

The production `npm-audit` job is **untouched**. `--omit=dev --audit-level=high`
is the right question to ask about production risk. It is just not the question
this document answers, which is why the document needed its own.

The manifest records the lockfile SHA it was verified against, so a lockfile
change is what surfaces the need to re-verify.

## I introduced advisories, and this caught them

Worth stating plainly. Adding `markdownlint-cli2@0.18.1` (in #261) pulled in
`js-yaml@4.1.0` and `markdown-it@14.1.0` — four moderate advisories between
them. **The full tree went from the documented 9 to 12, and I did that.**
`dependency-review` passed it, because the production gate cannot see dev-only
moderates. This is exactly the blind spot.

`markdownlint-cli2@0.23.0` clears all four and returns the tree to the 9
documented here, none of which are ours:

```
before: js-yaml, markdown-it, jest-junit, jose, newman, postman-*, serialised-error, uuid   (12)
after:  jest-junit, jose, newman, postman-*, serialised-error, uuid                          (9)
```

Its new `MD060` table-pipe rule is off: the repo mixes `|---|` and `| --- |`,
and normalising 24 rows across four files — one of them `required-checks.md`,
whose content the audit verified as correct — is churn, not a fix.

## Expiry dates

`docs/coverage-thresholds.md` carries `Expiry: 2026-09-30` on its ratchet
exceptions. Accurate today; a defect on that date, with nothing to flag it. The
`docs` gate now fails on any documented `Expiry:` that has passed:

```
2026-09-30 as of 2026-07-15  -> ok
2026-07-14 as of 2026-07-15  -> Documented Expiry 2026-07-14 has passed — revisit or extend it
2026-13-45                   -> Expiry date is not a valid date
```

Fenced code blocks are ignored, today-exactly is allowed, and one test asserts
the check is watching the real `coverage-thresholds.md` date rather than only
synthetic strings.

## Verification

lint · typecheck · `docs:validate` 8/0 · `docs:lint` 0 · `security:docs` ·
`actionlint` · **876/876 unit (104 suites)**. The script's lockfile hash agrees
with `shasum -a 256` and with the manifest.